### PR TITLE
Add zip skill submission pipeline + metadata validation + support docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,16 @@ jobs:
   build:
     name: Build & validate skills
     runs-on: ubuntu-latest
+    # Allow the workflow to push extracted files back to PR branches from this
+    # repo. Forks can't receive a write token, so we fall back to validate-only.
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -22,6 +29,35 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+
+      # Same-repo PRs get a write token: extract submission zips into the site
+      # (writes src/content/skills/*.md + public/bundles/*.zip) and commit the
+      # result back to the PR branch. Hard-fails on missing/invalid metadata.
+      - name: Import skill submissions
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: npm run import:submissions
+
+      - name: Commit extracted skills
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          if [ -n "$(git status --porcelain src/content/skills public/bundles)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add src/content/skills public/bundles
+            git commit -m "chore: extract skill submissions [skip ci]"
+            git push
+          else
+            echo "No extracted changes to commit."
+          fi
+
+      # Fork PRs can't receive a write token, so only validate the submissions
+      # (still a hard fail on missing/invalid metadata). A maintainer can run
+      # `npm run import:submissions` after merge, or the contributor can run it
+      # locally and commit the generated files.
+      - name: Validate skill submissions (fork PRs)
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: npm run check:submissions
+
       # `astro build` runs `astro check`-style content validation: every skill in
       # src/content/skills is parsed against the Zod schema (required platforms,
       # tags, etc.), so a malformed or out-of-policy skill fails the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing a skill
+
+Thanks for helping grow the **CAT Agent Skills** gallery! A *skill* is a reusable
+instruction set for an AI agent — targeting one or more of **Cowork**,
+**Copilot Studio**, and **Scout** — published here as a Markdown page plus an
+optional `.zip` of helper scripts.
+
+There are **two ways** to contribute. Both open a pull request; both are
+validated automatically.
+
+## Option A — Submit a zip (recommended)
+
+Best when your skill ships scripts, or you'd rather not hand-edit the site.
+
+1. Assemble a folder containing:
+   - **`SKILL.md`** — the front page: YAML frontmatter (metadata) + your
+     instructions. Start from
+     [`submissions/SKILL.template.md`](submissions/SKILL.template.md).
+   - Any optional helper files (`scripts/`, schemas, a `README.md`).
+2. Zip it so `SKILL.md` is at the **root** of the archive.
+3. Name the zip after your slug, e.g. `meeting-summarizer.zip`, and place it in
+   [`submissions/`](submissions/).
+4. (Optional) Validate locally before pushing:
+   ```bash
+   npm run check:submissions   # metadata-only, writes nothing
+   ```
+5. Open a PR. CI extracts `SKILL.md` → `src/content/skills/<slug>.md`, bundles
+   the rest → `public/bundles/<slug>.zip`, and **commits the result back to your
+   PR**. If required metadata is missing, the check **fails** and tells you
+   exactly which fields to fix.
+
+See [`submissions/README.md`](submissions/README.md) for the exact zip layout.
+
+## Option B — Add a Markdown file directly
+
+Best for instruction-only skills with no scripts.
+
+1. Create `src/content/skills/<slug>.md` (the filename becomes the URL slug).
+2. Fill in the frontmatter and instructions — see
+   [`docs/authoring-skills.md`](docs/authoring-skills.md).
+3. (Optional) ship scripts by placing `public/bundles/<slug>.zip` and adding
+   `bundle: bundles/<slug>.zip` to the frontmatter.
+4. Open a PR.
+
+## Required metadata
+
+Every skill **must** include these frontmatter fields, or the build fails:
+
+| Field         | Type     | Notes                                               |
+| ------------- | -------- | --------------------------------------------------- |
+| `name`        | string   | Display name.                                       |
+| `description` | string   | One-line summary.                                   |
+| `platforms`   | string[] | One or more of `Cowork`, `Copilot Studio`, `Scout`. |
+| `tags`        | string[] | Lowercase tags for search/filtering.                |
+
+Optional: `author`, `version`, `createdAt`, `updatedAt`, `coverColor`,
+`featured`. (`bundle` is set automatically by the zip pipeline.)
+
+## Preview locally
+
+```bash
+npm install
+npm run dev      # http://localhost:4321/cat-agent-skills
+npm run build    # runs the same content validation as CI
+```
+
+## What CI checks
+
+- **PRs** run [`.github/workflows/ci.yml`](.github/workflows/ci.yml): it imports
+  any submission zips, validates all skill metadata (hard fail with an itemized
+  message), and builds the site.
+- Merges to `main` deploy the site to GitHub Pages.
+
+By contributing you agree your skill is shared under the repository's
+[MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -34,10 +34,16 @@ npm run preview  # preview the production build locally
 
 ## 🧩 Adding a skill
 
-Skills live in `src/content/skills/` as Markdown files. To add one, open a PR
-that adds `src/content/skills/<your-skill>.md`. See
-[`docs/authoring-skills.md`](docs/authoring-skills.md) for the full frontmatter
-spec and how to bundle scripts in a `.zip`.
+There are two ways to contribute — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+the full guide.
+
+- **Submit a zip** (recommended for skills with scripts): drop
+  `submissions/<slug>.zip` containing a front-page `SKILL.md`. CI extracts it
+  into the site, bundles any scripts, and validates the metadata.
+- **Add a Markdown file**: open a PR adding
+  `src/content/skills/<your-skill>.md`. See
+  [`docs/authoring-skills.md`](docs/authoring-skills.md) for the full frontmatter
+  spec and how to bundle scripts in a `.zip`.
 
 Minimal example:
 
@@ -74,6 +80,8 @@ src/
     skills.json.ts       metadata endpoint
 public/
   bundles/         downloadable .zip script bundles
+submissions/       drop-in <slug>.zip skill submissions (extracted by CI)
+scripts/           import-submissions + validate-skill (the zip pipeline)
 .github/workflows/ ci.yml (PR build check) + deploy.yml (Pages deploy)
 ```
 
@@ -84,6 +92,13 @@ validates every skill against the content schema). Pushing to `main` triggers
 `.github/workflows/deploy.yml`, which builds and publishes the site to GitHub
 Pages at `https://microsoft.github.io/cat-agent-skills/`. Enable Pages in the
 repo settings with the **GitHub Actions** source.
+
+## 🆘 Support
+
+CAT Agent Skills is an **example implementation**. The underlying Microsoft
+features (Power Apps, Power Automate, Dataverse, Copilot Studio, etc.) are fully
+supported, but the skills themselves are provided as-is. See
+[`SUPPORT.md`](SUPPORT.md) for how to file issues and get help.
 
 ## License
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+Although the underlying features and components used to build **CAT Agent
+Skills** are fully supported (such as Power Apps, Power Automate, Dataverse,
+Copilot Studio endpoints, etc.), the skills gallery itself represents an
+**example implementation** of these features. Our customers, partners, and
+community can use and customize these skills to implement capabilities in their
+organizations.
+
+## How to file issues and get help
+
+If you face issues with:
+
+- **Using CAT Agent Skills** (this gallery or any individual skill): Report your
+  issue at
+  [github.com/microsoft/cat-agent-skills/issues](https://github.com/microsoft/cat-agent-skills/issues).
+  Microsoft Support won't help you with issues related to this accelerator, but
+  they will help with related, underlying platform and feature issues.
+- **The core Microsoft features** (Power Apps, Power Automate, Dataverse,
+  Copilot Studio, etc.): Use your standard channel to contact Microsoft Support
+  via **Get Help + Support** in the
+  [Power Platform admin center](https://learn.microsoft.com/power-platform/admin/get-help-support).
+
+## Microsoft Support Policy
+
+Support for this project is limited to the resources listed above.

--- a/docs/authoring-skills.md
+++ b/docs/authoring-skills.md
@@ -4,6 +4,38 @@ A **skill** is a reusable instruction set for an AI agent — targeting one or m
 of **Cowork**, **Copilot Studio**, and **Scout** — published in this gallery as a
 single Markdown file (optionally accompanied by a `.zip` of helper scripts).
 
+You can contribute in **two ways**:
+
+- **Submit a zip** — drop `submissions/<slug>.zip` (containing a front-page
+  `SKILL.md`) and CI extracts it for you. See
+  [Zip submissions](#0-zip-submissions-recommended) below.
+- **Add a Markdown file directly** — hand-author `src/content/skills/<slug>.md`,
+  covered in the rest of this guide.
+
+## 0. Zip submissions (recommended)
+
+Place a single `<slug>.zip` in [`../submissions/`](../submissions/) with this
+layout:
+
+```
+meeting-summarizer.zip
+├── SKILL.md            # required: frontmatter metadata + instructions, at the zip root
+├── README.md           # optional: included in the downloadable bundle
+└── scripts/            # optional: helper scripts, bundled automatically
+    └── summarize.py
+```
+
+On every PR the import pipeline (`npm run import:submissions`):
+
+1. Reads the front-page `SKILL.md` and **validates its metadata** — a missing or
+   invalid required field **fails the PR** with an itemized message.
+2. Writes `src/content/skills/<slug>.md` (slug = the zip filename).
+3. Packages everything else into `public/bundles/<slug>.zip` and sets the
+   `bundle:` field automatically.
+
+Validate locally first with `npm run check:submissions`. The frontmatter fields
+are identical to those described below.
+
 ## 1. Create the Markdown file
 
 Add a file at `src/content/skills/<slug>.md`. The file name (without `.md`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "copilot-studio-skills-gallery",
+  "name": "cat-agent-skills",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "copilot-studio-skills-gallery",
+      "name": "cat-agent-skills",
       "version": "0.1.0",
       "dependencies": {
         "astro": "^5.6.1"
@@ -13,7 +13,11 @@
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.4",
-        "tailwindcss": "^4.1.4"
+        "@types/adm-zip": "^0.5.8",
+        "adm-zip": "^0.5.17",
+        "gray-matter": "^4.0.3",
+        "tailwindcss": "^4.1.4",
+        "tsx": "^4.22.4"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -2141,6 +2145,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2189,6 +2203,16 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -2211,6 +2235,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ansi-align": {
@@ -3535,6 +3569,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3555,6 +3603,19 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3641,6 +3702,46 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/h3": {
       "version": "1.15.11",
@@ -3892,6 +3993,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3976,6 +4087,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -5724,6 +5845,20 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
@@ -5834,6 +5969,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -5878,6 +6020,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/svgo": {
@@ -6004,6 +6156,509 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -6046,6 +6701,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "validate:skills": "tsx scripts/validate-skill.ts src/content/skills/*.md",
+    "import:submissions": "tsx scripts/import-submissions.ts",
+    "check:submissions": "tsx scripts/import-submissions.ts --check"
   },
   "dependencies": {
     "astro": "^5.6.1"
@@ -17,6 +20,10 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
-    "tailwindcss": "^4.1.4"
+    "@types/adm-zip": "^0.5.8",
+    "adm-zip": "^0.5.17",
+    "gray-matter": "^4.0.3",
+    "tailwindcss": "^4.1.4",
+    "tsx": "^4.22.4"
   }
 }

--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -1,0 +1,151 @@
+/**
+ * Import skill submission zips into the site content.
+ *
+ * For each `submissions/<slug>.zip` this script:
+ *   1. Unzips it in memory.
+ *   2. Locates the front-page `SKILL.md` (the skill instructions + metadata).
+ *   3. Validates the frontmatter against the shared schema (HARD FAIL on error).
+ *   4. Writes `src/content/skills/<slug>.md`.
+ *   5. Re-zips any remaining files (scripts) into `public/bundles/<slug>.zip`
+ *      and injects `bundle: bundles/<slug>.zip` into the frontmatter.
+ *
+ * Usage:
+ *   tsx scripts/import-submissions.ts            # import everything
+ *   tsx scripts/import-submissions.ts --check    # validate only, write nothing
+ *
+ * Slug = the zip filename without its extension (matches the existing rule
+ * where a content filename maps directly to the URL slug).
+ */
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import AdmZip from "adm-zip";
+import { validateSkillSource } from "./validate-skill.ts";
+
+const ROOT = join(import.meta.dirname, "..");
+const SUBMISSIONS_DIR = join(ROOT, "submissions");
+const CONTENT_DIR = join(ROOT, "src", "content", "skills");
+const BUNDLES_DIR = join(ROOT, "public", "bundles");
+const FRONT_PAGE = "skill.md";
+
+const checkOnly = process.argv.includes("--check");
+
+type ImportProblem = { zip: string; problems: string[] };
+
+/** Find the front-page SKILL.md entry, preferring the shallowest path. */
+function findFrontPage(zip: AdmZip): AdmZip.IZipEntry | undefined {
+  const candidates = zip
+    .getEntries()
+    .filter(
+      (e) => !e.isDirectory && basename(e.entryName).toLowerCase() === FRONT_PAGE,
+    )
+    .sort((a, b) => a.entryName.split("/").length - b.entryName.split("/").length);
+  return candidates[0];
+}
+
+/** Inject a `bundle:` line into a frontmatter block if not already present. */
+function injectBundle(source: string, bundlePath: string): string {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return source; // validation will have already failed
+  if (/^bundle\s*:/m.test(match[1])) return source; // author set it explicitly
+  const newBlock = `---\n${match[1]}\nbundle: ${bundlePath}\n---`;
+  return source.replace(match[0], newBlock);
+}
+
+function importZip(zipPath: string): ImportProblem | null {
+  const slug = basename(zipPath).replace(/\.zip$/i, "");
+  const label = `submissions/${basename(zipPath)}`;
+  const zip = new AdmZip(zipPath);
+
+  const frontEntry = findFrontPage(zip);
+  if (!frontEntry) {
+    return {
+      zip: label,
+      problems: [
+        `no front-page \`SKILL.md\` found at the zip root (required for every submission)`,
+      ],
+    };
+  }
+
+  let source = zip.readAsText(frontEntry);
+
+  // Validate metadata first — hard fail before writing anything.
+  const result = validateSkillSource(source, label);
+  if (!result.ok) {
+    return { zip: label, problems: result.problems };
+  }
+
+  // Everything that is not the front page becomes the downloadable bundle.
+  const scriptEntries = zip
+    .getEntries()
+    .filter((e) => !e.isDirectory && e.entryName !== frontEntry.entryName);
+
+  const hasBundle = scriptEntries.length > 0;
+  if (hasBundle) {
+    source = injectBundle(source, `bundles/${slug}.zip`);
+  }
+
+  if (checkOnly) return null;
+
+  // Write the content markdown.
+  mkdirSync(CONTENT_DIR, { recursive: true });
+  writeFileSync(join(CONTENT_DIR, `${slug}.md`), source, "utf8");
+
+  // Build the bundle zip from the leftover files.
+  if (hasBundle) {
+    mkdirSync(BUNDLES_DIR, { recursive: true });
+    const out = new AdmZip();
+    for (const entry of scriptEntries) {
+      out.addFile(entry.entryName, entry.getData());
+    }
+    out.writeZip(join(BUNDLES_DIR, `${slug}.zip`));
+  }
+
+  console.log(
+    `\u2713 ${label} \u2192 src/content/skills/${slug}.md` +
+      (hasBundle ? ` (+ public/bundles/${slug}.zip)` : ""),
+  );
+  return null;
+}
+
+function main() {
+  if (!existsSync(SUBMISSIONS_DIR)) {
+    console.log("No submissions/ directory \u2014 nothing to import.");
+    return;
+  }
+
+  const zips = readdirSync(SUBMISSIONS_DIR)
+    .filter((f) => f.toLowerCase().endsWith(".zip"))
+    .map((f) => join(SUBMISSIONS_DIR, f));
+
+  if (zips.length === 0) {
+    console.log("No submission zips found in submissions/.");
+    return;
+  }
+
+  const problems: ImportProblem[] = [];
+  for (const zip of zips) {
+    const problem = importZip(zip);
+    if (problem) problems.push(problem);
+  }
+
+  if (problems.length > 0) {
+    console.error(`\n\u2717 ${problems.length} submission(s) failed validation:\n`);
+    for (const p of problems) {
+      console.error(`  ${p.zip}:`);
+      for (const msg of p.problems) console.error(`    \u2022 ${msg}`);
+    }
+    console.error(
+      "\nEvery submission needs a front-page SKILL.md with valid metadata " +
+        "(name, description, platforms, tags). Fix the items above and retry.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    checkOnly
+      ? `\nAll ${zips.length} submission(s) passed validation (check-only, nothing written).`
+      : `\nImported ${zips.length} submission(s).`,
+  );
+}
+
+main();

--- a/scripts/validate-skill.ts
+++ b/scripts/validate-skill.ts
@@ -1,0 +1,99 @@
+/**
+ * Validate a skill's frontmatter against the shared Zod schema.
+ *
+ * Usage:
+ *   tsx scripts/validate-skill.ts <file.md> [more.md ...]
+ *
+ * Exits non-zero and prints an itemized list of problems if any file fails.
+ * Used both locally (`npm run validate:skills`) and by the import pipeline so
+ * the rules can never drift from the Astro build-time content schema.
+ */
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import matter from "gray-matter";
+import { skillSchema } from "../src/lib/skill-schema.ts";
+
+/** Result of validating a single markdown source. */
+export type ValidationResult = {
+  /** Human-readable label (file path) for messages. */
+  label: string;
+  ok: boolean;
+  /** Itemized, human-readable problems (empty when ok). */
+  problems: string[];
+};
+
+/**
+ * Validate a raw markdown string (frontmatter + body) for one skill.
+ * Returns ok=true or an itemized problem list on failure.
+ */
+export function validateSkillSource(
+  source: string,
+  label: string,
+): ValidationResult {
+  let data: Record<string, unknown>;
+  try {
+    data = matter(source).data;
+  } catch (err) {
+    return {
+      label,
+      ok: false,
+      problems: [`could not parse frontmatter: ${(err as Error).message}`],
+    };
+  }
+
+  if (!data || Object.keys(data).length === 0) {
+    return {
+      label,
+      ok: false,
+      problems: ["no YAML frontmatter found (expected a `---` block at the top)"],
+    };
+  }
+
+  const result = skillSchema.safeParse(data);
+  if (result.success) return { label, ok: true, problems: [] };
+
+  const problems = result.error.issues.map((issue) => {
+    const field = issue.path.length ? issue.path.join(".") : "(root)";
+    return `${field}: ${issue.message}`;
+  });
+  return { label, ok: false, problems };
+}
+
+/** Validate a markdown file on disk. */
+export function validateSkillFile(path: string): ValidationResult {
+  const source = readFileSync(path, "utf8");
+  return validateSkillSource(source, path);
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error("usage: tsx scripts/validate-skill.ts <file.md> [more.md ...]");
+    process.exit(2);
+  }
+
+  let failures = 0;
+  for (const file of files) {
+    const result = validateSkillFile(file);
+    if (result.ok) {
+      console.log(`\u2713 ${basename(file)} \u2014 metadata OK`);
+    } else {
+      failures++;
+      console.error(`\u2717 ${file} \u2014 invalid metadata:`);
+      for (const p of result.problems) console.error(`    \u2022 ${p}`);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(
+      `\n${failures} skill(s) failed metadata validation. ` +
+        `Fix the fields above and try again.`,
+    );
+    process.exit(1);
+  }
+  console.log(`\nAll ${files.length} skill(s) passed metadata validation.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,26 +1,10 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
-import { PLATFORMS } from "./lib/skills";
+import { skillSchema } from "./lib/skill-schema";
 
 const skills = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./src/content/skills" }),
-  schema: z.object({
-    name: z.string(),
-    description: z.string(),
-    // Agent platform(s) the skill targets: Cowork, Copilot Studio, and/or Scout.
-    platforms: z.array(z.enum(PLATFORMS)).nonempty(),
-    tags: z.array(z.string()).default([]),
-    author: z.string().optional(),
-    version: z.string().optional(),
-    createdAt: z.coerce.date().optional(),
-    updatedAt: z.coerce.date().optional(),
-    // Path (relative to /public) of a bundled .zip of scripts, when the skill
-    // ships executable scripts alongside its instructions.
-    bundle: z.string().optional(),
-    // Optional override for the auto-generated cover color (any CSS color).
-    coverColor: z.string().optional(),
-    featured: z.boolean().default(false),
-  }),
+  schema: skillSchema,
 });
 
 export const collections = { skills };

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,7 +60,7 @@ const fullTitle =
             >Docs</a
           >
           <a
-            href="https://github.com/microsoft/cat-agent-skills"
+            href="https://github.com/microsoft/cat-agent-skills/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener"
             class="rounded-lg border border-white/10 bg-white/5 px-3 py-1.5 hover:bg-white/10 hover:text-white transition-colors"

--- a/src/lib/skill-schema.ts
+++ b/src/lib/skill-schema.ts
@@ -1,0 +1,30 @@
+/**
+ * Single source of truth for the skill frontmatter schema.
+ *
+ * Imported by both the Astro content collection (`src/content.config.ts`) and
+ * the standalone CI validator (`scripts/validate-skill.mjs`) so that the rules
+ * enforced at build time and at submission time can never drift apart.
+ */
+import { z } from "astro/zod";
+import { PLATFORMS } from "./skills";
+
+/** Zod schema for a skill's frontmatter metadata. */
+export const skillSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  // Agent platform(s) the skill targets: Cowork, Copilot Studio, and/or Scout.
+  platforms: z.array(z.enum(PLATFORMS)).nonempty(),
+  tags: z.array(z.string()).nonempty(),
+  author: z.string().optional(),
+  version: z.string().optional(),
+  createdAt: z.coerce.date().optional(),
+  updatedAt: z.coerce.date().optional(),
+  // Path (relative to /public) of a bundled .zip of scripts, when the skill
+  // ships executable scripts alongside its instructions.
+  bundle: z.string().optional(),
+  // Optional override for the auto-generated cover color (any CSS color).
+  coverColor: z.string().optional(),
+  featured: z.boolean().default(false),
+});
+
+export type SkillFrontmatter = z.infer<typeof skillSchema>;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -36,11 +36,6 @@ const allTags = [...tagCounts.entries()].sort(
     >
     </div>
     <div class="relative mx-auto max-w-7xl px-4 py-14 sm:px-6 sm:py-20">
-      <p
-        class="mb-3 text-sm font-semibold uppercase tracking-widest text-brand-300"
-      >
-        Copilot Studio
-      </p>
       <h1
         class="max-w-3xl text-4xl font-extrabold leading-tight tracking-tight text-white sm:text-5xl"
       >

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -156,7 +156,7 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                   >
                     <path d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
                   </svg>
-                  Download scripts (.zip)
+                  Download bundle
                 </a>
               )
             }
@@ -174,6 +174,17 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
               </dl>
             )
           }
+
+          <p class="mt-5 border-t border-white/5 pt-4 text-xs text-slate-500">
+            This skill is an example implementation provided as-is. See{" "}
+            <a
+              href="https://github.com/microsoft/cat-agent-skills/blob/main/SUPPORT.md"
+              target="_blank"
+              rel="noopener"
+              class="underline hover:text-slate-300 transition-colors"
+              >Support</a
+            >{" "}for how to get help.
+          </p>
         </div>
       </aside>
     </div>

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -1,0 +1,55 @@
+# Skill submissions (zip)
+
+Drop a single self-contained **`<slug>.zip`** in this folder to contribute a
+skill without hand-editing the site. On every pull request, CI runs the import
+pipeline (`npm run import:submissions`), which:
+
+1. Finds each new/changed `submissions/*.zip`.
+2. Reads the front-page **`SKILL.md`** inside it (your instructions + metadata).
+3. **Validates the metadata** — a missing or invalid required field fails the PR
+   with a message listing exactly what's wrong.
+4. Writes `src/content/skills/<slug>.md`.
+5. Bundles any remaining files (scripts, schemas, README) into
+   `public/bundles/<slug>.zip` and links it from the skill page.
+
+The `<slug>` is the zip filename without `.zip` (e.g. `meeting-summarizer.zip`
+→ `/skills/meeting-summarizer`). Use lowercase, hyphenated names.
+
+## Required zip layout
+
+```
+meeting-summarizer.zip
+├── SKILL.md            # required: front page (frontmatter metadata + instructions)
+├── README.md           # optional: goes into the downloadable bundle
+└── scripts/            # optional: helper scripts, schemas, etc. (bundled)
+    └── summarize.py
+```
+
+- `SKILL.md` **must** sit at the root of the zip.
+- Everything other than `SKILL.md` is packaged into the downloadable bundle.
+- If the zip contains only `SKILL.md`, no bundle is produced.
+
+## Required metadata (frontmatter in `SKILL.md`)
+
+| Field         | Required | Notes                                                        |
+| ------------- | -------- | ------------------------------------------------------------ |
+| `name`        | ✅       | Display name.                                                |
+| `description` | ✅       | One-line summary.                                            |
+| `platforms`   | ✅       | One or more of `Cowork`, `Copilot Studio`, `Scout`.          |
+| `tags`        | ✅       | Lowercase tags for search/filtering.                         |
+| `author`      |          | Person or team.                                              |
+| `version`     |          | Semantic version, e.g. `1.0.0`.                              |
+| `createdAt`   |          | `YYYY-MM-DD`.                                                |
+| `updatedAt`   |          | `YYYY-MM-DD`.                                                |
+| `bundle`      |          | Set automatically by the pipeline — do not add it yourself.  |
+
+See [`SKILL.template.md`](./SKILL.template.md) for a starting point and
+[`../docs/authoring-skills.md`](../docs/authoring-skills.md) for full guidance.
+
+## Try it locally before opening a PR
+
+```bash
+npm run check:submissions   # validate metadata only, write nothing
+npm run import:submissions   # actually extract into the site
+npm run build                # confirm the site builds with your skill
+```

--- a/submissions/SKILL.template.md
+++ b/submissions/SKILL.template.md
@@ -1,0 +1,26 @@
+---
+name: My Great Skill
+description: One-line summary shown on the card and detail page.
+platforms: [Cowork, Copilot Studio, Scout]
+tags: [productivity, automation]
+author: Your Name
+version: 1.0.0
+createdAt: 2026-01-01
+updatedAt: 2026-01-01
+---
+
+You are the **My Great Skill** skill. Write the agent-facing instructions here
+as Markdown — this body becomes the "Instructions" section on the detail page.
+
+## When to use this skill
+Describe what triggers this skill.
+
+## Instructions
+1. Concrete, numbered steps the agent should follow.
+2. ...
+
+## Guardrails
+- What the agent must not do.
+
+## Tone
+The voice the agent should adopt.


### PR DESCRIPTION
## Summary

Implements zip-based skill submissions, strict metadata validation, and support docs.

### Zip submissions
- Drop `submissions/<slug>.zip` containing a root `SKILL.md`; CI extracts it to `src/content/skills/<slug>.md`, bundles any other files into `public/bundles/<slug>.zip`, and injects `bundle:`.
- Standalone `.md` submissions still work.
- `scripts/import-submissions.ts` + `scripts/validate-skill.ts`; npm scripts `import:submissions`, `check:submissions`, `validate:skills`.

### Metadata validation
- Shared Zod schema (`src/lib/skill-schema.ts`) used by both Astro content validation and the CI validator.
- `tags` now required/non-empty.
- PRs **hard-fail** with an itemized message when required metadata is missing.

### CI
- `ci.yml`: same-repo PRs auto-extract + commit back; fork PRs validate-only; then `astro build`.

### UI / docs
- Removed homepage eyebrow; renamed download button to **Download bundle** (shown only when a bundle exists).
- New `CONTRIBUTING.md` (nav links to it) and `SUPPORT.md`; subtle support link on each skill page.

Verified locally: bad zip → hard fail; good zip → extracted md + bundle; `npm run build` passes.