### PR TITLE
Wire giscus ratings to the Announcements category

### DIFF
--- a/docs/ratings.md
+++ b/docs/ratings.md
@@ -7,7 +7,7 @@ where they naturally belong — on GitHub — and read at build time.
 ## How it works
 
 ```
-GitHub Discussions (category "Skill Ratings")
+GitHub Discussions (Announcements category)
     │   one discussion per skill; discussion title == skill slug
     │   the 👍 (THUMBS_UP) reaction count is the rating
     ▼
@@ -28,25 +28,42 @@ Gallery cards + detail pages + "Top rated" sort on the homepage
 - **Graceful by default:** with no `GITHUB_TOKEN`, no Discussions, or on a fork,
   `ratings.json` stays `{}` and every skill simply shows `0`. Nothing breaks.
 
-## One-time setup (maintainers)
+## Setup (already wired for this repo)
 
-The voting widget stays hidden until giscus is configured (`RATINGS_ENABLED` in
-[`src/lib/ratings-config.ts`](../src/lib/ratings-config.ts) is `false` until then).
+This repository is already configured: Discussions is enabled, giscus points at
+the **Announcements** category, and the repo/category IDs are committed in
+[`src/lib/ratings-config.ts`](../src/lib/ratings-config.ts) (they are public
+giscus client IDs, safe to commit). The only remaining manual step is installing
+the **giscus GitHub App** (below), after which voting is live.
 
-1. **Enable Discussions** on the repository (Settings → General → Features).
-2. **Create a Discussion category** named `Skill Ratings` (any format works;
-   "Announcements" keeps the list tidy since only maintainers open threads, but
-   giscus can also auto-create discussions on first vote).
-3. **Install the giscus GitHub App** on the repo: <https://github.com/apps/giscus>.
-4. On <https://giscus.app>, enter the repo and pick the `Skill Ratings` category.
-   Copy the generated **Repository ID** and **Category ID**.
-5. Paste them into [`src/lib/ratings-config.ts`](../src/lib/ratings-config.ts)
-   (`GISCUS_REPO_ID`, `GISCUS_CATEGORY_ID`) **or** provide them at build time as
-   the env vars `PUBLIC_GISCUS_REPO_ID` and `PUBLIC_GISCUS_CATEGORY_ID`. These are
-   public client IDs (giscus ships them in the browser bundle) — safe to commit.
+We reuse the **Announcements** category because it is the giscus-recommended
+type — only maintainers and the giscus app can open threads, so votes can
+auto-create one discussion per skill without opening the door to spam. Skill
+discussions are titled by slug; the welcome/announcement posts are ignored by
+`fetch-ratings.ts` because their titles aren't slug-shaped.
 
-That's it. On the next deploy the widget appears and `scripts/fetch-ratings.ts`
-starts populating counts.
+**To install the app (one time):** open
+<https://github.com/apps/giscus>, click **Install**, and select
+`microsoft/cat-agent-skills`.
+
+### Re-provisioning from scratch
+
+If you ever need to point ratings at a different repo or category:
+
+1. **Enable Discussions** (Settings → General → Features) and pick a category
+   (an **Announcement**-type category is recommended).
+2. **Install the giscus GitHub App**: <https://github.com/apps/giscus>.
+3. Fetch the IDs with the API (no need to visit giscus.app):
+
+   ```bash
+   gh api graphql -f query='{ repository(owner:"microsoft", name:"cat-agent-skills"){ id discussionCategories(first:20){ nodes{ id name } } } }'
+   ```
+
+4. Put the repo id + category id (and matching category name) into
+   [`src/lib/ratings-config.ts`](../src/lib/ratings-config.ts), or provide them
+   at build time via `PUBLIC_GISCUS_REPO_ID` / `PUBLIC_GISCUS_CATEGORY_ID` /
+   `PUBLIC_GISCUS_CATEGORY`. Keep the category name in sync with the
+   `GISCUS_CATEGORY` default in `scripts/fetch-ratings.ts`.
 
 ## Refreshing counts
 

--- a/scripts/fetch-ratings.ts
+++ b/scripts/fetch-ratings.ts
@@ -26,8 +26,11 @@ import { fileURLToPath } from "node:url";
 const OUT = resolve(dirname(fileURLToPath(import.meta.url)), "../src/data/ratings.json");
 
 const REPO = process.env.GISCUS_REPO ?? "microsoft/cat-agent-skills";
-const CATEGORY = process.env.GISCUS_CATEGORY ?? "Skill Ratings";
+const CATEGORY = process.env.GISCUS_CATEGORY ?? "Announcements";
 const TOKEN = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "";
+
+/** Skill slugs: 1-64 chars, lowercase alnum + single hyphens (agentskills spec). */
+const SLUG_RE = /^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$/;
 
 type Ratings = Record<string, number>;
 
@@ -128,7 +131,10 @@ async function main(): Promise<void> {
       for (const node of conn.nodes as any[]) {
         if (node.category?.name !== CATEGORY) continue;
         const slug = node.title.trim();
-        if (!slug) continue;
+        // Only slug-shaped titles are skill discussions. This keeps the welcome
+        // post and any real announcements (we share the Announcements category)
+        // out of the ratings snapshot.
+        if (!SLUG_RE.test(slug)) continue;
         ratings[slug] = (ratings[slug] ?? 0) + thumbsUp(node.reactionGroups);
       }
       after = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;

--- a/src/lib/ratings-config.ts
+++ b/src/lib/ratings-config.ts
@@ -22,13 +22,13 @@
 export const GISCUS_REPO = import.meta.env.PUBLIC_GISCUS_REPO ?? "microsoft/cat-agent-skills";
 
 /** giscus repository id (public client id, safe to commit). */
-export const GISCUS_REPO_ID = import.meta.env.PUBLIC_GISCUS_REPO_ID ?? "";
+export const GISCUS_REPO_ID = import.meta.env.PUBLIC_GISCUS_REPO_ID ?? "R_kgDOSwZGlA";
 
 /** Discussion category name that holds the rating discussions. */
-export const GISCUS_CATEGORY = import.meta.env.PUBLIC_GISCUS_CATEGORY ?? "Skill Ratings";
+export const GISCUS_CATEGORY = import.meta.env.PUBLIC_GISCUS_CATEGORY ?? "Announcements";
 
 /** giscus category id (public client id, safe to commit). */
-export const GISCUS_CATEGORY_ID = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID ?? "";
+export const GISCUS_CATEGORY_ID = import.meta.env.PUBLIC_GISCUS_CATEGORY_ID ?? "DIC_kwDOSwZGlM4DAxet";
 
 /**
  * The rating widget renders only when giscus has been fully configured. This


### PR DESCRIPTION
Follow-up to #19. Discussions is now enabled on the repo, so this activates ratings.

- **Points giscus at the Announcements category** (giscus-recommended type: only maintainers + the giscus app open threads → spam-safe, votes still auto-create per-skill discussions).
- Commits the **public giscus client IDs** (`R_kgDOSwZGlA` / `DIC_kwDOSwZGlM4DAxet`) so `RATINGS_ENABLED` is true and the widget renders. IDs are overridable via `PUBLIC_GISCUS_*` env.
- `fetch-ratings.ts` now only counts **slug-shaped titles**, so the welcome post and any real announcements in that category never pollute the snapshot.
- Docs updated to reflect the decision + an API-based re-provisioning recipe.

**Verified:** build emits the correct enabled giscus embed (`data-term=<slug>`, real IDs); live `ratings:fetch` against the repo returns 0 (no skill discussions yet, welcome post correctly ignored).

**Remaining manual step:** install the giscus GitHub App → https://github.com/apps/giscus → select `microsoft/cat-agent-skills`.