### PR TITLE
Count only positive reactions toward skill ratings

### DIFF
--- a/docs/ratings.md
+++ b/docs/ratings.md
@@ -9,7 +9,7 @@ where they naturally belong — on GitHub — and read at build time.
 ```
 GitHub Discussions (Announcements category)
     │   one discussion per skill; discussion title == skill slug
-    │   the 👍 (THUMBS_UP) reaction count is the rating
+    │   positive reactions (👍 ❤️ 🎉 🚀 😄) are summed as the rating; 👎/😕/👀 ignored
     ▼
 scripts/fetch-ratings.ts   (GraphQL, runs in CI with GITHUB_TOKEN)
     ▼

--- a/scripts/fetch-ratings.ts
+++ b/scripts/fetch-ratings.ts
@@ -3,9 +3,10 @@
  * build-time snapshot to `src/data/ratings.json`.
  *
  * Each skill maps to one Discussion whose title is the skill slug (giscus
- * `mapping="specific"`, `term=slug`). The rating is the number of THUMBS_UP
- * reactions on that Discussion. The homepage uses this snapshot to sort skills
- * by rating; the live vote is reflected on the next build/scheduled rebuild.
+ * `mapping="specific"`, `term=slug`). The rating is the number of *positive*
+ * reactions on that Discussion (👍 ❤️ 🎉 🚀 😄); negative reactions (👎 😕) and
+ * neutral (👀) are ignored. The homepage uses this snapshot to sort skills by
+ * rating; the live vote is reflected on the next build/scheduled rebuild.
  *
  * Usage:
  *   GITHUB_TOKEN=... npm run ratings:fetch
@@ -103,9 +104,23 @@ const QUERY = `
 
 type ReactionGroup = { content: string; reactors: { totalCount: number } };
 
-function thumbsUp(groups: ReactionGroup[] | undefined): number {
-  const group = (groups ?? []).find((g) => g.content === "THUMBS_UP");
-  return group?.reactors?.totalCount ?? 0;
+// GitHub reaction contents split into sentiment buckets. The rating counts only
+// positive reactions; negatives (👎/😕) and neutral (👀) never contribute, so a
+// thumbs-down can't drag a skill's score down or turn into a "rating".
+const POSITIVE_REACTIONS = new Set([
+  "THUMBS_UP", // 👍
+  "HEART", // ❤️
+  "HOORAY", // 🎉
+  "ROCKET", // 🚀
+  "LAUGH", // 😄
+]);
+
+function positiveScore(groups: ReactionGroup[] | undefined): number {
+  let total = 0;
+  for (const g of groups ?? []) {
+    if (POSITIVE_REACTIONS.has(g.content)) total += g.reactors?.totalCount ?? 0;
+  }
+  return total;
 }
 
 async function main(): Promise<void> {
@@ -135,7 +150,7 @@ async function main(): Promise<void> {
         // post and any real announcements (we share the Announcements category)
         // out of the ratings snapshot.
         if (!SLUG_RE.test(slug)) continue;
-        ratings[slug] = (ratings[slug] ?? 0) + thumbsUp(node.reactionGroups);
+        ratings[slug] = (ratings[slug] ?? 0) + positiveScore(node.reactionGroups);
       }
       after = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
     } while (after);


### PR DESCRIPTION
The giscus widget exposes all 8 GitHub reactions, including 👎 and 😕.

This restricts the build-time rating to **positive-sentiment reactions** and explicitly ignores negatives and neutral:

| Counts (positive) | Ignored |
|---|---|
| 👍 THUMBS_UP · ❤️ HEART · 🎉 HOORAY · 🚀 ROCKET · 😄 LAUGH | 👎 THUMBS_DOWN · 😕 CONFUSED · 👀 EYES |

So a thumbs-down can never lower a skill's score or register as a rating.

**Verified:** unit-checked the scoring (negatives/neutral excluded), live `ratings:fetch` + build green.