### PR TITLE
Remove Docs nav link, keep Contribute a skill

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,13 +53,6 @@ const fullTitle =
             class="hover:text-white transition-colors">Browse</a
           >
           <a
-            href="https://github.com/microsoft/cat-agent-skills/blob/main/docs/authoring-skills.md"
-            target="_blank"
-            rel="noopener"
-            class="hidden sm:inline hover:text-white transition-colors"
-            >Docs</a
-          >
-          <a
             href="https://github.com/microsoft/cat-agent-skills/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener"


### PR DESCRIPTION
Drops the redundant **Docs** link from the site header, leaving just **Contribute a skill**.