### PR TITLE
Integrate Microsoft Clarity analytics

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import { withBase } from "../lib/url";
+import { ANALYTICS_ENABLED, CLARITY_PROJECT_ID } from "../lib/analytics-config";
 
 interface Props {
   title?: string;
@@ -28,6 +29,15 @@ const fullTitle =
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />
     <link rel="icon" type="image/svg+xml" href={withBase("/favicon.svg")} />
+    {
+      ANALYTICS_ENABLED && (
+        <script
+          is:inline
+          type="text/javascript"
+          set:html={`(function(c,l,a,r,i,t,y){c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window,document,"clarity","script","${CLARITY_PROJECT_ID}");`}
+        />
+      )
+    }
   </head>
   <body class="min-h-screen flex flex-col antialiased">
     <header
@@ -88,5 +98,13 @@ const fullTitle =
         </p>
       </div>
     </footer>
+    {
+      ANALYTICS_ENABLED && (
+        <script
+          is:inline
+          set:html={`document.addEventListener("click",function(e){var el=e.target&&e.target.closest?e.target.closest("[data-clarity-event]"):null;if(!el)return;if(typeof window.clarity!=="function")return;var name=el.getAttribute("data-clarity-event");if(!name)return;for(var i=0;i<el.attributes.length;i++){var a=el.attributes[i];if(a.name.indexOf("data-clarity-")===0&&a.name!=="data-clarity-event"){var key=a.name.slice("data-clarity-".length).replace(/-([a-z])/g,function(m,c){return c.toUpperCase();});window.clarity("set",key,a.value);}}window.clarity("event",name);},true);`}
+        />
+      )
+    }
   </body>
 </html>

--- a/src/lib/analytics-config.ts
+++ b/src/lib/analytics-config.ts
@@ -1,0 +1,25 @@
+/**
+ * Configuration for Microsoft Clarity analytics.
+ *
+ * Clarity gives us session replay, heatmaps, and custom event tracking. We use
+ * it to understand how visitors browse the gallery and, in particular, to
+ * capture two important interactions:
+ *
+ *   - `skill_download` — a visitor downloads a skill/plugin package or `.md`.
+ *   - `skill_view`     — a visitor lands on a skill detail page.
+ *
+ * The project id below is NOT a secret — Clarity emits it into the public
+ * client bundle (like the giscus ids in `ratings-config.ts`). It is safe to
+ * commit. Set `PUBLIC_CLARITY_PROJECT_ID` at build time to point a deployment
+ * at a different Clarity project without touching code.
+ */
+
+/** Clarity project id (public client id, safe to commit). */
+export const CLARITY_PROJECT_ID =
+  import.meta.env.PUBLIC_CLARITY_PROJECT_ID ?? "xjxtbc1rra";
+
+/**
+ * Clarity only loads when a project id is configured. This keeps builds without
+ * an id (or with it explicitly cleared) from injecting a broken loader.
+ */
+export const ANALYTICS_ENABLED = Boolean(CLARITY_PROJECT_ID);

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -5,6 +5,7 @@ import { getCollection, render } from "astro:content";
 import { formatDate, PLATFORM_COLORS } from "../../lib/skills";
 import { withBase } from "../../lib/url";
 import { getRating } from "../../lib/ratings";
+import { ANALYTICS_ENABLED } from "../../lib/analytics-config";
 import {
   RATINGS_ENABLED,
   GISCUS_REPO,
@@ -191,6 +192,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                   <a
                     href={withBase(`/${d.bundle}`)}
                     download
+                    data-clarity-event="skill_download"
+                    data-clarity-skill={skill.id}
+                    data-clarity-download-type="plugin"
                     class="flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-500 transition-colors"
                   >
                     <svg
@@ -210,6 +214,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                     <a
                       href={withBase(`/${d.bundle}`)}
                       download
+                      data-clarity-event="skill_download"
+                      data-clarity-skill={skill.id}
+                      data-clarity-download-type="bundle"
                       class="flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-500 transition-colors"
                     >
                       <svg
@@ -226,6 +233,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                     <a
                       href={withBase(`/skills/${skill.id}.md`)}
                       download="SKILL.md"
+                      data-clarity-event="skill_download"
+                      data-clarity-skill={skill.id}
+                      data-clarity-download-type="markdown"
                       class="flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-brand-500 transition-colors"
                     >
                       <svg
@@ -340,4 +350,16 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
       }
     </section>
   </div>
+  {
+    ANALYTICS_ENABLED && (
+      <script
+        is:inline
+        set:html={`(function(){function fire(){if(typeof window.clarity!=="function"){return setTimeout(fire,300);}window.clarity("set","skill",${JSON.stringify(
+          skill.id
+        )});window.clarity("set","skillType",${JSON.stringify(
+          d.type
+        )});window.clarity("event","skill_view");}fire();})();`}
+      />
+    )
+  }
 </Layout>


### PR DESCRIPTION
Integrates Microsoft Clarity for session replay, heatmaps, and custom event tracking of the two key interactions.

## Events
- **skill_download** — fires on plugin/bundle/.md downloads (tagged with skill id and downloadType: plugin/bundle/markdown).
- **skill_view** — fires when landing on a skill detail page (tagged with skill id and skillType).

## How
- `src/lib/analytics-config.ts` (new) — `CLARITY_PROJECT_ID` (default `xjxtbc1rra`, overridable via `PUBLIC_CLARITY_PROJECT_ID`) and `ANALYTICS_ENABLED`. Mirrors `ratings-config.ts`.
- `src/layouts/Layout.astro` — loads the Clarity tag site-wide plus a reusable click-delegation script that turns any `[data-clarity-event]` element into a Clarity event, forwarding `data-clarity-*` attributes as tags. Gated on `ANALYTICS_ENABLED`.
- `src/pages/skills/[slug].astro` — annotates the three download links and fires `skill_view` on load.

## Notes
- The Clarity project id is a public client id (like the committed giscus ids), safe to commit; env override retargets deployments without code changes.
- Verified `npm run build` succeeds and the loader + event attributes appear in generated HTML.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>