### PR TITLE
Feature the Redlining Content skill

### DIFF
--- a/src/content/skills/redlining-content.md
+++ b/src/content/skills/redlining-content.md
@@ -9,6 +9,7 @@ authorUrl: "https://github.com/AndrewHessMSFT"
 version: 1.0.0
 createdAt: 2026-07-08
 updatedAt: 2026-07-08
+featured: true
 bundle: bundles/redlining-content.zip
 ---
 # Redlining Content Skill

--- a/submissions/redlining-content/metadata.json
+++ b/submissions/redlining-content/metadata.json
@@ -7,5 +7,6 @@
   "authorUrl": "https://github.com/AndrewHessMSFT",
   "version": "1.0.0",
   "createdAt": "2026-07-08",
-  "updatedAt": "2026-07-08"
+  "updatedAt": "2026-07-08",
+  "featured": true
 }


### PR DESCRIPTION
Marks the **Redlining Content** skill as featured.

- `submissions/redlining-content/metadata.json` → added `"featured": true`
- `src/content/skills/redlining-content.md` → added `featured: true` to frontmatter

Follows the same convention as the other featured skills (campaign-deck-builder, knowledge-source-router).