### PR TITLE
Onboard Scout automations as a third submission type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,20 @@ the [Cowork plugins section](submissions/README.md#cowork-plugins-advanced) of
 the submissions reference for the required package contents and validation
 rules.
 
+### Scout automations
+
+You can also submit a **Scout automation** — a scheduled/triggered `.json`
+(a schedule plus an ordered list of prompt steps) that runs **only** in Scout.
+An automation submission is a `submissions/<slug>/` folder with a `metadata.json`
+sidecar plus a single `.json` automation export; the fact that the one
+non-sidecar top-level file is a `.json` (instead of a `.zip` or a `SKILL.md`)
+marks it as an automation. The `.json` is published verbatim as the download and
+re-imports directly into Scout. Copy
+[`submissions/_template-automation/`](submissions/_template-automation) to start
+and see the
+[Scout automations section](submissions/README.md#scout-automations-advanced) of
+the submissions reference for the required shape and validation rules.
+
 ## Two descriptions
 
 A skill carries **two** descriptions, on purpose:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ deployed as a static site to GitHub Pages.
   See [`docs/ratings.md`](docs/ratings.md).
 - **Downloads**: the skill as a `SKILL.md` file, plus an optional `.zip` bundle
   when a skill ships files beyond its `SKILL.md`.
+- **More than skills**: also hosts **Cowork plugins** (M365 `.zip` packages) and
+  **Scout automations** (scheduled `.json` exports), each with its own badge,
+  filter, and verbatim download.
 
 ## 🚀 Local development
 
@@ -89,6 +92,11 @@ Write the agent instructions here as Markdown — this body becomes the
 > `name`, `description`, `platforms`, and `tags` are required (`platforms` must be
 > one or more of `Cowork`, `Copilot Studio`, `Scout`). PRs run a build check that
 > validates every skill against the schema.
+
+> Besides single skills, you can submit a **Cowork plugin** (a `.zip` M365 app
+> package, Cowork-only) or a **Scout automation** (a `.json` export, Scout-only).
+> Both drop into `submissions/<slug>/` the same way and are auto-detected by their
+> payload. See [`submissions/README.md`](submissions/README.md) for the details.
 
 ## 📁 Project structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tailwindcss/vite": "^4.1.4",
         "@types/adm-zip": "^0.5.8",
         "adm-zip": "^0.5.17",
+        "croner": "^9.1.0",
         "gray-matter": "^4.0.3",
         "tailwindcss": "^4.1.4",
         "tsx": "^4.22.4"
@@ -2866,6 +2867,16 @@
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
+    },
+    "node_modules/croner": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-9.1.0.tgz",
+      "integrity": "sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      }
     },
     "node_modules/crossws": {
       "version": "0.3.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tailwindcss/vite": "^4.1.4",
     "@types/adm-zip": "^0.5.8",
     "adm-zip": "^0.5.17",
+    "croner": "^9.1.0",
     "gray-matter": "^4.0.3",
     "tailwindcss": "^4.1.4",
     "tsx": "^4.22.4"

--- a/public/bundles/spend-more-time-with-friends-and-family.json
+++ b/public/bundles/spend-more-time-with-friends-and-family.json
@@ -1,0 +1,39 @@
+{
+  "description": "While the owner is OOF, watches a group chat for questions, answers them from local knowledge docs (with an AI-generated caveat), logs anything it can't answer for later review, and pings the owner on Teams relay if its config is incomplete.",
+  "schedule": {
+    "kind": "interval",
+    "naturalLanguage": "every 15 minutes",
+    "days": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "intervalMinutes": 15,
+    "anchor": {
+      "hour": 0,
+      "minute": 0
+    },
+    "hour": 0,
+    "minute": 0
+  },
+  "teamsNotify": "auto",
+  "id": "e4mxnk1pmrked1ny",
+  "name": "spend more time with friends and family",
+  "steps": [
+    {
+      "id": "1",
+      "label": "Main",
+      "prompt": "You are running the \"spend more time with friends and family\" automation. Work through these steps in order and stop early if instructed. All file paths are resolved at runtime relative to the Scout workspace so this automation is portable across machines and operating systems. Never hardcode an absolute path or a specific username.\n\nSTEP 0 — Resolve paths (portable, cross-OS).\n- Determine the workspace root (WS): this is the automation's current working directory. Get it portably: on macOS/Linux run the shell command `pwd`; on Windows run `cd` (cmd) or `$PWD.Path` (PowerShell). Trim whitespace/newlines from the result. Use whichever shell the OS provides.\n- Derive these paths by joining onto WS using the OS-native separator (the shell result for WS already uses the correct separator; just append subpaths with that same separator — forward slash `/` on macOS/Linux, backslash `\\` on Windows). Let SEP be that separator:\n  - BOT_DIR      = WS + SEP + \"friends-family-bot\"\n  - CONFIG_PATH  = BOT_DIR + SEP + \"config.json\"\n  - KNOWLEDGE_DIR = BOT_DIR + SEP + \"knowledge\"\n  - UNANSWERED   = BOT_DIR + SEP + \"unanswered.md\"\n- Use these resolved variables everywhere below. If you are ever unsure of the separator, prefer forward slashes — the filesystem tools accept them on all platforms.\n\nDEFAULT_CONFIG (the template to write when bootstrapping a missing config file). Note the path values are LEFT BLANK/relative on purpose — fill knowledgeDocs and unansweredLog with the runtime-resolved KNOWLEDGE_DIR and UNANSWERED values when you write the file, so nothing personal is hardcoded:\n{\n  \"chatId\": \"\",\n  \"knowledgeDocs\": [ \"<KNOWLEDGE_DIR>\" ],\n  \"unansweredLog\": \"<UNANSWERED>\",\n  \"lastProcessedMessageId\": \"\",\n  \"answerCaveat\": \"\\ud83e\\udd16 This is an AI-generated reply from Scout on behalf of the account owner (who is currently away). Please verify anything important.\",\n  \"ownerRelayEmail\": \"\"\n}\n\nSTEP 1 — Load or bootstrap config.\n- Try to read CONFIG_PATH as JSON.\n- If the file does NOT exist (or BOT_DIR is missing): create BOT_DIR and KNOWLEDGE_DIR if needed, then WRITE DEFAULT_CONFIG to CONFIG_PATH with <KNOWLEDGE_DIR> and <UNANSWERED> replaced by the actual runtime-resolved paths. This self-creates a config the user can fill in. Treat the freshly written config as loaded and continue to validation.\n- If the file exists but is unparseable/corrupt: do NOT overwrite it (avoid clobbering user edits). Treat as a fatal config error and go to STEP 1b, naming the parse problem.\n\nSTEP 1a — Validate.\n- Required fields: `chatId` (non-empty), and `knowledgeDocs` (a non-empty array whose folders/files actually exist and contain at least one readable knowledge file other than README.md).\n- Optional: `unansweredLog`, `lastProcessedMessageId`, `answerCaveat`, `ownerRelayEmail`.\n\nSTEP 1b — If any required field is missing/empty/invalid (including right after a fresh bootstrap, where they will be empty):\n- Do NOT touch the monitored chat. Instead, complain to the owner over the Teams relay so they can fix it.\n  - Check relay status with m_relay_status; if not connected, call m_relay_connect.\n  - Determine where to send: if `ownerRelayEmail` is set, call workiq_create_chat_by_email with it; otherwise send to the Teams self-chat (workiq_create_chat_by_email with the current user's own email from workiq_get_my_profile).\n  - Send a concise message naming exactly which fields are unset/invalid and the CONFIG_PATH to edit. If you just bootstrapped the file, say so, e.g.: \"⚠️ 'spend more time with friends and family' created a blank config at CONFIG_PATH but chatId and knowledge docs are still empty. Fill them in to activate.\"\n  - Then STOP the run. Register result \"blocked: incomplete config (<fields>)\". Do not proceed to later steps.\n\nSTEP 2 — Fetch new messages.\n- Call workiq_list_chat_messages for `chatId` (newest first, limit ~30).\n- Determine which messages are NEW: those posted after `lastProcessedMessageId`. If `lastProcessedMessageId` is empty, only consider messages from the last 60 minutes (do NOT backfill the whole history).\n- Ignore messages sent by the owner themselves (compare against workiq_get_my_profile) and ignore system/event messages.\n\nSTEP 3 — Identify questions.\n- From the NEW messages, pick those that are genuinely asking a question (ends with \"?\", or is clearly interrogative / a request for info). Skip greetings, reactions, and small talk.\n\nSTEP 4 — Answer from knowledge docs.\n- Read the contents of every knowledge file referenced by `knowledgeDocs` (recurse into folders; skip README.md). Treat this as the ONLY source of truth.\n- For each question, try to answer strictly from the knowledge docs. Do not invent facts not supported by the docs.\n- If you have a supported answer: post a reply in the chat using workiq_reply_to_chat_message (reply to that specific message). Prepend/append the caveat from `answerCaveat` (or a sensible default if unset) so it's clear the reply is AI-generated by Scout on the owner's behalf.\n- If the docs do NOT contain enough to answer: append a row to the `unansweredLog` markdown table with local timestamp, asker display name, the question text, and the message id / chat reference. Do NOT post a guess to the chat.\n\nSTEP 5 — Update state.\n- Set `lastProcessedMessageId` in CONFIG_PATH to the id of the newest message you processed, and write the file back (preserve all other fields).\n\nSTEP 6 — Register a short result summary: how many new questions were found, how many answered in-chat, how many logged as unanswered. Only surface to Teams if something needs the owner's attention (e.g. unanswered questions logged), otherwise keep it quiet."
+    }
+  ],
+  "enabled": false,
+  "oneShot": false,
+  "createdAt": "2026-07-14T08:36:20.014Z",
+  "updatedAt": "2026-07-14T09:23:04.158Z",
+  "triggerType": "schedule",
+  "lastExecutedAt": null
+}

--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -51,6 +51,7 @@ import { basename, join, posix, relative, sep } from "node:path";
 import AdmZip from "adm-zip";
 import matter from "gray-matter";
 import { validateSkillData } from "./validate-skill.ts";
+import { validateAutomationData, type AutomationDigest } from "./validate-automation.ts";
 import {
   isPluginPackage,
   validatePluginFiles,
@@ -102,11 +103,14 @@ type SubFile = { path: string; data: Buffer };
 type Submission = {
   slug: string;
   label: string;
-  /** "skill" (default) or a Cowork "plugin" (an M365 app package). */
-  kind: "skill" | "plugin";
+  /** "skill" (default), a Cowork "plugin", or a Scout "automation". */
+  kind: "skill" | "plugin" | "automation";
   skillMd?: string;
   metaName?: string;
   metaText?: string;
+  /** For an automation: the raw Scout automation `.json`, shipped verbatim. */
+  automationJson?: string;
+  automationJsonName?: string;
   /**
    * Every file that ships in the download bundle, at its authored path
    * (excluding the `metadata.*` sidecar and the root instruction file, which is
@@ -230,6 +234,7 @@ function processSubmission(sub: Submission): ImportProblem | null {
     return { source: label, problems: sub.loadProblems };
   }
   if (sub.kind === "plugin") return processPlugin(sub);
+  if (sub.kind === "automation") return processAutomation(sub);
   if (sub.skillMd === undefined) {
     return {
       source: label,
@@ -461,6 +466,163 @@ function processPlugin(sub: Submission): ImportProblem | null {
   return null;
 }
 
+// Day-of-week labels for rendering a schedule's `days` array (0 = Sunday).
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+/**
+ * Build the synthesized detail-page body for a Scout automation. There is no
+ * SKILL.md, so we render an overview, the trigger/schedule, the ordered prompt
+ * steps, and how to import the `.json` into Scout.
+ */
+function buildAutomationBody(opts: {
+  overview: string;
+  digest: AutomationDigest;
+  slug: string;
+}): string {
+  const { overview, digest, slug } = opts;
+  const lines: string[] = [overview.trim(), ""];
+  lines.push(
+    "> **Scout automation.** This is a Microsoft **Scout** automation (a `.json` " +
+      "of a schedule plus ordered prompt steps). It runs on Scout only.",
+    "",
+  );
+
+  lines.push("## Trigger", "");
+  if (digest.triggerType === "condition") {
+    lines.push(`Runs on a **condition** — ${digest.scheduleSummary}.`, "");
+  } else {
+    lines.push(`Runs on a **schedule** — ${digest.scheduleSummary}.`, "");
+  }
+
+  lines.push("## Steps", "");
+  digest.steps.forEach((step, i) => {
+    const label = step.label?.trim() || `Step ${i + 1}`;
+    lines.push(`### ${i + 1}. ${label}`, "");
+    // Fence the prompt verbatim so its own Markdown/paths render literally.
+    lines.push("```text", step.prompt.replace(/```/g, "``\u200b`"), "```", "");
+  });
+
+  lines.push(
+    "## Import into Scout",
+    "",
+    "1. Download the automation (the `.json` on this page).",
+    "2. In **Scout \u203a Automations**, choose **Import** and select the file " +
+      "(or paste its contents). Review the schedule and steps, then enable it.",
+    "",
+    "You can also point Scout's **Import from GitHub** at a repository directory " +
+      "of automation `.json` files (a `skills/` subfolder is installed " +
+      "automatically). This automation's file is " +
+      `\`submissions/${slug}/\` in this repo.`,
+    "",
+    "> Review the steps before enabling — automations act on your behalf on a " +
+      "schedule.",
+  );
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Validate + generate a Scout automation submission: a raw Scout automation
+ * `.json` plus a `metadata.*` sidecar. The `.json` ships verbatim as the
+ * download (re-importable into Scout); the detail page is synthesized.
+ */
+function processAutomation(sub: Submission): ImportProblem | null {
+  const { slug, label } = sub;
+  if (sub.automationJson === undefined) {
+    return { source: label, problems: ["no automation `.json` payload found"] };
+  }
+  if (sub.metaText === undefined) {
+    return {
+      source: label,
+      problems: [
+        `no metadata sidecar found next to the automation ` +
+          `(expected ${METADATA_NAMES.join(" / ")})`,
+      ],
+    };
+  }
+
+  // Validate the automation against Scout's import contract.
+  const av = validateAutomationData(
+    (() => {
+      try {
+        return JSON.parse(sub.automationJson!);
+      } catch {
+        return null;
+      }
+    })(),
+    label,
+  );
+  if (!av.ok || !av.digest) {
+    const problems = av.problems.length
+      ? av.problems
+      : [`${sub.automationJsonName ?? "automation.json"} is not valid JSON`];
+    return { source: label, problems };
+  }
+  const digest = av.digest;
+
+  let catalog: Record<string, unknown>;
+  try {
+    catalog = parseMetadataFile(sub.metaName!, sub.metaText);
+  } catch (err) {
+    return { source: label, problems: [`could not parse ${sub.metaName}: ${(err as Error).message}`] };
+  }
+
+  // Catalog name/description fall back to the automation's own fields.
+  const displayName = (catalog.name as string | undefined) ?? digest.name;
+  const catalogDescription =
+    (catalog.description as string | undefined) ?? digest.description;
+
+  const problems: string[] = [];
+  if (!displayName) {
+    problems.push("`name` is required in the metadata file (or the automation's `name`)");
+  }
+  if (!catalogDescription) {
+    problems.push(
+      "`description` is required in the metadata file (or the automation's `description`)",
+    );
+  }
+  if (problems.length) return { source: label, problems };
+
+  // An automation is Scout-only; drop any name/description/platforms/type from
+  // the sidecar so they can't override the derived values.
+  const {
+    name: _n,
+    description: _d,
+    platforms: _p,
+    type: _t,
+    ...catalogRest
+  } = catalog;
+  const meta: Record<string, unknown> = {
+    name: displayName,
+    description: catalogDescription,
+    platforms: ["Scout"],
+    type: "automation",
+    ...catalogRest,
+    bundle: `bundles/${slug}.json`,
+  };
+
+  const result = validateSkillData(meta, label);
+  if (!result.ok) return { source: label, problems: result.problems };
+
+  if (!checkOnly) {
+    const body = buildAutomationBody({
+      overview: catalogDescription!,
+      digest,
+      slug,
+    });
+    mkdirSync(CONTENT_DIR, { recursive: true });
+    writeIfChanged(join(CONTENT_DIR, `${slug}.md`), buildContent(meta, body));
+    mkdirSync(BUNDLES_DIR, { recursive: true });
+    // Ship the automation `.json` verbatim so the gallery download equals the
+    // exact file Scout imports.
+    writeIfChanged(join(BUNDLES_DIR, `${slug}.json`), sub.automationJson);
+    console.log(
+      `\u2713 ${label} \u2192 src/content/skills/${slug}.md ` +
+        `(automation, + public/bundles/${slug}.json)`,
+    );
+  }
+  return null;
+}
+
 /**
  * Load a `submissions/<slug>/` folder: a `metadata.json` sidecar plus exactly
  * one skill payload — either an unpacked canonical skill (root `SKILL.md` +
@@ -514,10 +676,29 @@ function loadSubmission(dir: string): Submission {
     // Unpacked: bundle the folder contents verbatim (minus the metadata sidecar).
     classifyPayload(sub, listFiles(dir));
   } else {
-    problems.push(
-      "submission has no payload \u2014 add a root `SKILL.md` (with optional " +
-        "`scripts/`, `references/`, `assets/`) or a single `<name>.zip`",
+    // A Scout automation payload: a single top-level `.json` that is NOT the
+    // metadata sidecar (all root `.json` files are automations by Scout's
+    // GitHub-import convention). The sidecar carries the catalog metadata.
+    const automationJsons = topFiles.filter(
+      (n) =>
+        n.toLowerCase().endsWith(".json") && !METADATA_NAMES.includes(n.toLowerCase()),
     );
+    if (automationJsons.length === 1) {
+      sub.kind = "automation";
+      sub.automationJsonName = automationJsons[0];
+      sub.automationJson = readFileSync(join(dir, automationJsons[0]), "utf8");
+    } else if (automationJsons.length > 1) {
+      problems.push(
+        `submission has ${automationJsons.length} automation .json files \u2014 ` +
+          "provide exactly one (plus the `metadata.*` sidecar)",
+      );
+    } else {
+      problems.push(
+        "submission has no payload \u2014 add a root `SKILL.md` (with optional " +
+          "`scripts/`, `references/`, `assets/`), a single `<name>.zip`, or a " +
+          "single Scout automation `<name>.json`",
+      );
+    }
   }
 
   if (problems.length) sub.loadProblems = problems;
@@ -562,8 +743,8 @@ function main() {
       "\nEach submission is a `submissions/<slug>/` folder with a `metadata.*` " +
         "sidecar (catalog `description`, `platforms`, `tags`) plus exactly one " +
         "payload: an unpacked `SKILL.md` (frontmatter `name` + agent-facing " +
-        "`description`, then instructions) or a single `<name>.zip`. Fix the " +
-        "items above and retry.",
+        "`description`, then instructions), a single `<name>.zip`, or a single " +
+        "Scout automation `<name>.json`. Fix the items above and retry.",
     );
     process.exit(1);
   }

--- a/scripts/validate-automation.ts
+++ b/scripts/validate-automation.ts
@@ -1,0 +1,298 @@
+/**
+ * Validate a Scout automation `.json` against Scout's own import contract.
+ *
+ * A Scout automation is a `.json` file describing a scheduled (or conditional)
+ * agent task: a `name`, a `schedule`, and an ordered list of prompt `steps`.
+ * Scout imports these directly (via its GitHub-directory import: every root
+ * `.json` in the pointed-at directory is treated as an automation), so this
+ * validator is a FAITHFUL, standalone port of Scout's `AutomationImportSchema`
+ * (electron/automations/schemas.ts in the Scout app repo). Anything that passes
+ * here is guaranteed to import cleanly into Scout.
+ *
+ * It also returns a digest (schedule summary + steps) the importer uses to
+ * synthesize the gallery detail page.
+ *
+ * Usage:
+ *   tsx scripts/validate-automation.ts <file.json> [more.json ...]
+ */
+import { readFileSync } from "node:fs";
+import { basename } from "node:path";
+import { Cron } from "croner";
+import { z } from "astro/zod";
+
+// --- Pure calendar math, ported verbatim from Scout's common/monthly-schedule.ts.
+//     Used by the `monthly` schedule superRefine to reject impossible combos
+//     (e.g. "the 31st" scoped to February only).
+
+/** Max day-of-month per 1-based month (Feb = 29 to admit leap-year Feb 29). */
+const MAX_DAY_OF_MONTH: readonly number[] = [
+  0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+];
+
+type MonthlyOn =
+  | { type: "dayOfMonth"; days: number[] }
+  | { type: "weekday"; ordinal: number; weekday: number }
+  | { type: "workday"; ordinal: number };
+
+/** Whether a monthly selector can ever fire given its month scope. Nth-weekday
+ *  and workday selectors always fire in some month, so they're always allowed. */
+function monthlyCanFire(on: MonthlyOn, months: readonly number[]): boolean {
+  if (on.type !== "dayOfMonth") return months.length > 0;
+  return on.days.some(
+    (d) => d === -1 || months.some((m) => m >= 1 && m <= 12 && d <= MAX_DAY_OF_MONTH[m]),
+  );
+}
+
+// --- Schema (ported from Scout's electron/automations/schemas.ts) -------------
+
+const AutomationStepSchema = z
+  .object({ id: z.string().optional(), label: z.string(), prompt: z.string() })
+  .strip();
+
+const TimeOfDaySchema = z.object({
+  hour: z.number().int().min(0).max(23),
+  minute: z.number().int().min(0).max(59),
+});
+
+const DaysSchema = z.array(z.number().int().min(0).max(6));
+
+const SingleScheduleSchema = z
+  .object({
+    kind: z.literal("single"),
+    naturalLanguage: z.string(),
+    days: DaysSchema,
+    time: TimeOfDaySchema,
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  })
+  .passthrough();
+
+const IntervalScheduleSchema = z
+  .object({
+    kind: z.literal("interval"),
+    naturalLanguage: z.string(),
+    days: DaysSchema,
+    intervalMinutes: z
+      .number()
+      .int()
+      .positive()
+      .refine((minutes) => minutes <= 1440 && 1440 % minutes === 0, {
+        message: "intervalMinutes must divide 1440 evenly",
+      }),
+    anchor: TimeOfDaySchema,
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  })
+  .passthrough();
+
+const MultiScheduleSchema = z
+  .object({
+    kind: z.literal("multi"),
+    naturalLanguage: z.string(),
+    days: DaysSchema,
+    times: z.array(TimeOfDaySchema).min(1),
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  })
+  .passthrough();
+
+/** Ordinal for Nth/last-of-month selectors: 1..5, or -1 meaning "last". */
+const OrdinalSchema = z.union([z.literal(-1), z.number().int().min(1).max(5)]);
+/** Day-of-month value: 1..31, or -1 meaning "last day of the month". */
+const DayOfMonthValueSchema = z.union([z.literal(-1), z.number().int().min(1).max(31)]);
+
+const MonthlyOnSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("dayOfMonth"), days: z.array(DayOfMonthValueSchema).min(1) }),
+  z.object({
+    type: z.literal("weekday"),
+    ordinal: OrdinalSchema,
+    weekday: z.number().int().min(0).max(6),
+  }),
+  z.object({ type: z.literal("workday"), ordinal: OrdinalSchema }),
+]);
+
+const MonthlyScheduleSchema = z
+  .object({
+    kind: z.literal("monthly"),
+    naturalLanguage: z.string(),
+    days: DaysSchema,
+    months: z.array(z.number().int().min(1).max(12)).min(1),
+    on: MonthlyOnSchema,
+    time: TimeOfDaySchema,
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  })
+  .passthrough();
+
+const CronScheduleSchema = z
+  .object({
+    kind: z.literal("cron"),
+    naturalLanguage: z.string(),
+    cronExpression: z.string().min(1),
+    days: DaysSchema,
+    hour: z.number().int().min(0).max(23),
+    minute: z.number().int().min(0).max(59),
+  })
+  .passthrough();
+
+const AutomationScheduleSchema = z
+  .discriminatedUnion("kind", [
+    SingleScheduleSchema,
+    IntervalScheduleSchema,
+    MultiScheduleSchema,
+    MonthlyScheduleSchema,
+    CronScheduleSchema,
+  ])
+  .superRefine((schedule, ctx) => {
+    if (schedule.kind === "monthly" && !monthlyCanFire(schedule.on as MonthlyOn, schedule.months)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "monthly selector can never fire in the given months",
+        path: ["on"],
+      });
+    }
+    if (schedule.kind === "cron") {
+      let fires = false;
+      try {
+        fires = new Cron(schedule.cronExpression).nextRun() !== null;
+      } catch {
+        fires = false;
+      }
+      if (!fires) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "cronExpression is not a valid, fireable cron expression",
+          path: ["cronExpression"],
+        });
+      }
+    }
+  });
+
+// Reasoning/context enums (Scout's electron/schemas/session-schema.ts).
+const ReasoningEffortSchema = z.string().min(1);
+const ContextWindowTokensSchema = z.number().int().positive();
+
+/**
+ * The partial shape Scout accepts at IMPORT time (id/enabled/timestamps may be
+ * absent). Mirrors Scout's `AutomationImportSchema`. `permissions` is kept loose
+ * (a passthrough object) rather than re-porting Scout's full PermissionsConfig.
+ */
+export const automationImportSchema = z
+  .object({
+    name: z.string().min(1),
+    steps: z.array(AutomationStepSchema),
+    schedule: AutomationScheduleSchema,
+    description: z.string().optional(),
+    condition: z.string().optional(),
+    conditionCheckInterval: z.number().optional(),
+    model: z.string().optional(),
+    reasoningEffort: ReasoningEffortSchema.optional(),
+    contextWindowTokens: ContextWindowTokensSchema.optional(),
+    permissions: z.object({}).passthrough().optional(),
+    browserHeadless: z.boolean().optional(),
+    teamsNotify: z.enum(["always", "auto", "never"]).optional(),
+    triggerType: z.enum(["schedule", "condition"]).optional(),
+  })
+  .strip();
+
+export type AutomationImport = z.infer<typeof automationImportSchema>;
+
+/** Digest of a validated automation, used to synthesize the gallery page. */
+export type AutomationDigest = {
+  name: string;
+  description?: string;
+  triggerType: "schedule" | "condition";
+  scheduleKind: string;
+  scheduleSummary: string;
+  steps: Array<{ label: string; prompt: string }>;
+};
+
+/** Result of validating a single automation source. */
+export type AutomationValidationResult = {
+  label: string;
+  ok: boolean;
+  problems: string[];
+  digest?: AutomationDigest;
+};
+
+/** Validate an already-parsed automation object against the import schema. */
+export function validateAutomationData(
+  data: unknown,
+  label: string,
+): AutomationValidationResult {
+  if (!data || typeof data !== "object") {
+    return { label, ok: false, problems: ["automation JSON must be an object"] };
+  }
+  const result = automationImportSchema.safeParse(data);
+  if (!result.success) {
+    const problems = result.error.issues.map((issue) => {
+      const field = issue.path.length ? issue.path.join(".") : "(root)";
+      return `${field}: ${issue.message}`;
+    });
+    return { label, ok: false, problems };
+  }
+  const d = result.data;
+  if (d.steps.length === 0) {
+    return { label, ok: false, problems: ["steps: must contain at least one step"] };
+  }
+  const digest: AutomationDigest = {
+    name: d.name,
+    description: d.description,
+    triggerType: d.triggerType ?? "schedule",
+    scheduleKind: d.schedule.kind,
+    scheduleSummary: d.schedule.naturalLanguage,
+    steps: d.steps.map((s) => ({ label: s.label, prompt: s.prompt })),
+  };
+  return { label, ok: true, problems: [], digest };
+}
+
+/** Validate a raw JSON string for one automation. */
+export function validateAutomationSource(
+  source: string,
+  label: string,
+): AutomationValidationResult {
+  let data: unknown;
+  try {
+    data = JSON.parse(source);
+  } catch (err) {
+    return { label, ok: false, problems: [`invalid JSON: ${(err as Error).message}`] };
+  }
+  return validateAutomationData(data, label);
+}
+
+/** Validate an automation `.json` file on disk. */
+export function validateAutomationFile(path: string): AutomationValidationResult {
+  return validateAutomationSource(readFileSync(path, "utf8"), path);
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  if (files.length === 0) {
+    console.error("usage: tsx scripts/validate-automation.ts <file.json> [more.json ...]");
+    process.exit(2);
+  }
+
+  let failures = 0;
+  for (const file of files) {
+    const result = validateAutomationFile(file);
+    if (result.ok) {
+      console.log(`\u2713 ${basename(file)} \u2014 automation OK`);
+    } else {
+      failures++;
+      console.error(`\u2717 ${file} \u2014 invalid automation:`);
+      for (const p of result.problems) console.error(`    \u2022 ${p}`);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(
+      `\n${failures} automation(s) failed validation. Fix the fields above and try again.`,
+    );
+    process.exit(1);
+  }
+  console.log(`\nAll ${files.length} automation(s) passed validation.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -33,6 +33,7 @@ const gradient = coverGradient(slug, coverColor);
 const mark = initials(name);
 const isSample = tags.includes("sample");
 const isPlugin = type === "plugin";
+const isAutomation = type === "automation";
 const shownTags = tags.filter((t) => t !== "sample").slice(0, 3);
 ---
 
@@ -64,6 +65,16 @@ const shownTags = tags.filter((t) => t !== "sample").slice(0, 3);
               title="A Cowork plugin (M365 app package)"
             >
               Plugin
+            </span>
+          )
+        }
+        {
+          isAutomation && (
+            <span
+              class="shrink-0 rounded bg-accent-soft px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-accent-text"
+              title="A Scout automation (scheduled .json)"
+            >
+              Automation
             </span>
           )
         }
@@ -116,7 +127,7 @@ const shownTags = tags.filter((t) => t !== "sample").slice(0, 3);
       {
         shownTags.length === 0 && (
           <span class="truncate text-xs text-subtle">
-            {author ? `by ${author}` : isPlugin ? "Cowork plugin" : "Community skill"}
+            {author ? `by ${author}` : isPlugin ? "Cowork plugin" : isAutomation ? "Scout automation" : "Community skill"}
           </span>
         )
       }
@@ -124,7 +135,7 @@ const shownTags = tags.filter((t) => t !== "sample").slice(0, 3);
     <span class="flex shrink-0 items-center gap-2.5 text-xs text-subtle">
       {
         hasBundle && (
-          <span class="flex items-center gap-1" title="Includes a downloadable bundle">
+          <span class="flex items-center gap-1" title={isAutomation ? "Includes a downloadable automation file" : "Includes a downloadable bundle"}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
@@ -133,7 +144,7 @@ const shownTags = tags.filter((t) => t !== "sample").slice(0, 3);
             >
               <path d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
             </svg>
-            .zip
+            {isAutomation ? ".json" : ".zip"}
           </span>
         )
       }

--- a/src/components/SkillCover.astro
+++ b/src/components/SkillCover.astro
@@ -100,6 +100,29 @@ const extraPlatforms = platforms.length - shownPlatforms.length;
           )
         }
         {
+          type === "automation" && (
+            <span
+              class="flex items-center gap-1 rounded-md bg-accent px-2 py-1 text-[10px] font-bold uppercase tracking-wide text-accent-fg backdrop-blur-sm"
+              title="A Scout automation (scheduled .json)"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="h-3 w-3"
+              >
+                <circle cx="12" cy="12" r="9" />
+                <path d="M12 7v5l3 2" />
+              </svg>
+              Automation
+            </span>
+          )
+        }
+        {
           shownPlatforms.map((platform) => (
             <span
               class="flex items-center gap-1.5 rounded-md bg-black/30 px-2 py-1 text-[10px] font-semibold text-white backdrop-blur-sm"
@@ -124,7 +147,11 @@ const extraPlatforms = platforms.length - shownPlatforms.length;
         hasBundle && (
           <span
             class="flex items-center gap-1 rounded-md bg-black/25 px-2 py-1 text-[10px] font-semibold text-white/90 backdrop-blur-sm"
-            title="Includes a downloadable script bundle"
+            title={
+              type === "automation"
+                ? "Includes a downloadable automation file"
+                : "Includes a downloadable script bundle"
+            }
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -134,7 +161,7 @@ const extraPlatforms = platforms.length - shownPlatforms.length;
             >
               <path d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
             </svg>
-            .zip
+            {type === "automation" ? ".json" : ".zip"}
           </span>
         )
       }

--- a/src/content/skills/spend-more-time-with-friends-and-family.md
+++ b/src/content/skills/spend-more-time-with-friends-and-family.md
@@ -1,0 +1,90 @@
+---
+name: Spend More Time With Friends & Family
+description: "While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete."
+platforms: [Scout]
+type: automation
+tags: [scout, automation, teams, out-of-office, knowledge]
+author: Adi Leibowitz
+version: 1.0.0
+createdAt: 2026-07-14
+updatedAt: 2026-07-14
+bundle: bundles/spend-more-time-with-friends-and-family.json
+---
+While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete.
+
+> **Scout automation.** This is a Microsoft **Scout** automation (a `.json` of a schedule plus ordered prompt steps). It runs on Scout only.
+
+## Trigger
+
+Runs on a **schedule** — every 15 minutes.
+
+## Steps
+
+### 1. Main
+
+```text
+You are running the "spend more time with friends and family" automation. Work through these steps in order and stop early if instructed. All file paths are resolved at runtime relative to the Scout workspace so this automation is portable across machines and operating systems. Never hardcode an absolute path or a specific username.
+
+STEP 0 — Resolve paths (portable, cross-OS).
+- Determine the workspace root (WS): this is the automation's current working directory. Get it portably: on macOS/Linux run the shell command `pwd`; on Windows run `cd` (cmd) or `$PWD.Path` (PowerShell). Trim whitespace/newlines from the result. Use whichever shell the OS provides.
+- Derive these paths by joining onto WS using the OS-native separator (the shell result for WS already uses the correct separator; just append subpaths with that same separator — forward slash `/` on macOS/Linux, backslash `\` on Windows). Let SEP be that separator:
+  - BOT_DIR      = WS + SEP + "friends-family-bot"
+  - CONFIG_PATH  = BOT_DIR + SEP + "config.json"
+  - KNOWLEDGE_DIR = BOT_DIR + SEP + "knowledge"
+  - UNANSWERED   = BOT_DIR + SEP + "unanswered.md"
+- Use these resolved variables everywhere below. If you are ever unsure of the separator, prefer forward slashes — the filesystem tools accept them on all platforms.
+
+DEFAULT_CONFIG (the template to write when bootstrapping a missing config file). Note the path values are LEFT BLANK/relative on purpose — fill knowledgeDocs and unansweredLog with the runtime-resolved KNOWLEDGE_DIR and UNANSWERED values when you write the file, so nothing personal is hardcoded:
+{
+  "chatId": "",
+  "knowledgeDocs": [ "<KNOWLEDGE_DIR>" ],
+  "unansweredLog": "<UNANSWERED>",
+  "lastProcessedMessageId": "",
+  "answerCaveat": "\ud83e\udd16 This is an AI-generated reply from Scout on behalf of the account owner (who is currently away). Please verify anything important.",
+  "ownerRelayEmail": ""
+}
+
+STEP 1 — Load or bootstrap config.
+- Try to read CONFIG_PATH as JSON.
+- If the file does NOT exist (or BOT_DIR is missing): create BOT_DIR and KNOWLEDGE_DIR if needed, then WRITE DEFAULT_CONFIG to CONFIG_PATH with <KNOWLEDGE_DIR> and <UNANSWERED> replaced by the actual runtime-resolved paths. This self-creates a config the user can fill in. Treat the freshly written config as loaded and continue to validation.
+- If the file exists but is unparseable/corrupt: do NOT overwrite it (avoid clobbering user edits). Treat as a fatal config error and go to STEP 1b, naming the parse problem.
+
+STEP 1a — Validate.
+- Required fields: `chatId` (non-empty), and `knowledgeDocs` (a non-empty array whose folders/files actually exist and contain at least one readable knowledge file other than README.md).
+- Optional: `unansweredLog`, `lastProcessedMessageId`, `answerCaveat`, `ownerRelayEmail`.
+
+STEP 1b — If any required field is missing/empty/invalid (including right after a fresh bootstrap, where they will be empty):
+- Do NOT touch the monitored chat. Instead, complain to the owner over the Teams relay so they can fix it.
+  - Check relay status with m_relay_status; if not connected, call m_relay_connect.
+  - Determine where to send: if `ownerRelayEmail` is set, call workiq_create_chat_by_email with it; otherwise send to the Teams self-chat (workiq_create_chat_by_email with the current user's own email from workiq_get_my_profile).
+  - Send a concise message naming exactly which fields are unset/invalid and the CONFIG_PATH to edit. If you just bootstrapped the file, say so, e.g.: "⚠️ 'spend more time with friends and family' created a blank config at CONFIG_PATH but chatId and knowledge docs are still empty. Fill them in to activate."
+  - Then STOP the run. Register result "blocked: incomplete config (<fields>)". Do not proceed to later steps.
+
+STEP 2 — Fetch new messages.
+- Call workiq_list_chat_messages for `chatId` (newest first, limit ~30).
+- Determine which messages are NEW: those posted after `lastProcessedMessageId`. If `lastProcessedMessageId` is empty, only consider messages from the last 60 minutes (do NOT backfill the whole history).
+- Ignore messages sent by the owner themselves (compare against workiq_get_my_profile) and ignore system/event messages.
+
+STEP 3 — Identify questions.
+- From the NEW messages, pick those that are genuinely asking a question (ends with "?", or is clearly interrogative / a request for info). Skip greetings, reactions, and small talk.
+
+STEP 4 — Answer from knowledge docs.
+- Read the contents of every knowledge file referenced by `knowledgeDocs` (recurse into folders; skip README.md). Treat this as the ONLY source of truth.
+- For each question, try to answer strictly from the knowledge docs. Do not invent facts not supported by the docs.
+- If you have a supported answer: post a reply in the chat using workiq_reply_to_chat_message (reply to that specific message). Prepend/append the caveat from `answerCaveat` (or a sensible default if unset) so it's clear the reply is AI-generated by Scout on the owner's behalf.
+- If the docs do NOT contain enough to answer: append a row to the `unansweredLog` markdown table with local timestamp, asker display name, the question text, and the message id / chat reference. Do NOT post a guess to the chat.
+
+STEP 5 — Update state.
+- Set `lastProcessedMessageId` in CONFIG_PATH to the id of the newest message you processed, and write the file back (preserve all other fields).
+
+STEP 6 — Register a short result summary: how many new questions were found, how many answered in-chat, how many logged as unanswered. Only surface to Teams if something needs the owner's attention (e.g. unanswered questions logged), otherwise keep it quiet.
+```
+
+## Import into Scout
+
+1. Download the automation (the `.json` on this page).
+2. In **Scout › Automations**, choose **Import** and select the file (or paste its contents). Review the schedule and steps, then enable it.
+
+You can also point Scout's **Import from GitHub** at a repository directory of automation `.json` files (a `skills/` subfolder is installed automatically). This automation's file is `submissions/spend-more-time-with-friends-and-family/` in this repo.
+
+> Review the steps before enabling — automations act on your behalf on a schedule.

--- a/src/lib/skill-schema.ts
+++ b/src/lib/skill-schema.ts
@@ -22,9 +22,10 @@ export const skillSchema = z.object({
   // Agent platform(s) the skill targets: Cowork, Copilot Studio, and/or Scout.
   platforms: z.array(z.enum(PLATFORMS)).nonempty(),
   // Distinguishes a single cross-platform Agent Skill from a Cowork plugin (an
-  // M365 app package bundling one or more skills + optional connectors). Derived
-  // by the importer, not authored; defaults keep existing skills unchanged.
-  type: z.enum(["skill", "plugin"]).default("skill"),
+  // M365 app package bundling one or more skills + optional connectors) or a
+  // Scout automation (a scheduled `.json` of ordered prompt steps). Derived by
+  // the importer, not authored; defaults keep existing skills unchanged.
+  type: z.enum(["skill", "plugin", "automation"]).default("skill"),
   tags: z.array(z.string()).nonempty(),
   author: z.string().optional(),
   // Optional URL to the author's website / profile, shown as a link on the

--- a/src/lib/skills.ts
+++ b/src/lib/skills.ts
@@ -8,10 +8,11 @@ export const PLATFORMS = ["Cowork", "Copilot Studio", "Scout"] as const;
 export type Platform = (typeof PLATFORMS)[number];
 
 /**
- * A submission is either a single cross-platform Agent Skill or a Cowork plugin
- * (an M365 app package bundling one or more skills + optional connectors).
+ * A submission is a single cross-platform Agent Skill, a Cowork plugin (an M365
+ * app package bundling one or more skills + optional connectors), or a Scout
+ * automation (a scheduled `.json` of ordered prompt steps, Scout-only).
  */
-export type SkillType = "skill" | "plugin";
+export type SkillType = "skill" | "plugin" | "automation";
 
 /** Brand accent color used for each platform's badge (CAT palette). */
 export const PLATFORM_COLORS: Record<Platform, string> = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -166,6 +166,12 @@ const allTags = [...tagCounts.entries()].sort(
             class="type-chip rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-muted transition hover:border-accent/40 hover:text-fg"
             aria-pressed="false">Plugins</button
           >
+          <button
+            type="button"
+            data-type="automation"
+            class="type-chip rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-muted transition hover:border-accent/40 hover:text-fg"
+            aria-pressed="false">Automations</button
+          >
         </div>
         <label class="flex items-center gap-2 text-sm text-muted">
           <span class="hidden sm:inline">Sort by</span>

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -2,6 +2,12 @@
 import Layout from "../../layouts/Layout.astro";
 import SkillCover from "../../components/SkillCover.astro";
 import { getCollection, render } from "astro:content";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  validateAutomationData,
+  type AutomationDigest,
+} from "../../../scripts/validate-automation";
 import { formatDate, PLATFORM_COLORS } from "../../lib/skills";
 import { withBase } from "../../lib/url";
 import { getRating } from "../../lib/ratings";
@@ -25,8 +31,22 @@ export async function getStaticPaths() {
 const { skill } = Astro.props;
 const d = skill.data;
 const isPlugin = d.type === "plugin";
-const noun = isPlugin ? "plugin" : "skill";
+const isAutomation = d.type === "automation";
+const noun = isPlugin ? "plugin" : isAutomation ? "automation" : "skill";
 const { Content } = await render(skill);
+
+// For automations, parse the published `.json` at build time so we can render
+// its trigger + prompt steps as structured UI instead of raw markdown.
+let automation: AutomationDigest | null = null;
+if (isAutomation && d.bundle) {
+  try {
+    const raw = readFileSync(join(process.cwd(), "public", d.bundle), "utf8");
+    const res = validateAutomationData(JSON.parse(raw), skill.id);
+    if (res.ok && res.digest) automation = res.digest;
+  } catch {
+    automation = null;
+  }
+}
 
 const updated = formatDate(d.updatedAt ?? d.createdAt);
 const created = formatDate(d.createdAt);
@@ -128,24 +148,86 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
         <hr class="my-7 border-border" />
 
         {
-          d.agentDescription && (
-            <div class="mb-6">
-              <h2 class="mb-2 text-sm font-semibold uppercase tracking-wider text-accent-text">
-                Description
-              </h2>
-              <p class="text-muted">{d.agentDescription}</p>
+          isAutomation && automation ? (
+            <div>
+              <div class="mb-6">
+                <h2 class="mb-2 text-sm font-semibold uppercase tracking-wider text-accent-text">
+                  Trigger
+                </h2>
+                <p class="flex items-center gap-2 text-muted">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    class="h-4 w-4 shrink-0 text-accent-text"
+                  >
+                    <circle cx="12" cy="12" r="9" />
+                    <path d="M12 7v5l3 2" />
+                  </svg>
+                  <span>
+                    <span class="font-medium text-fg">
+                      {automation.triggerType === "condition"
+                        ? "Runs on a condition"
+                        : "Runs on a schedule"}
+                    </span>
+                    {" — "}
+                    {automation.scheduleSummary}
+                  </span>
+                </p>
+              </div>
+
+              <div class="mb-3 flex items-baseline gap-2">
+                <h2 class="text-sm font-semibold uppercase tracking-wider text-accent-text">
+                  Steps
+                </h2>
+                <span class="text-xs text-subtle">
+                  {automation.steps.length}{" "}
+                  {automation.steps.length === 1 ? "step" : "steps"}
+                </span>
+              </div>
+              <ol class="space-y-6">
+                {automation.steps.map((step, i) => (
+                  <li>
+                    <div class="mb-2 flex items-center gap-2.5">
+                      <span class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent text-xs font-bold text-white">
+                        {i + 1}
+                      </span>
+                      <h3 class="font-semibold text-fg">
+                        {step.label || `Step ${i + 1}`}
+                      </h3>
+                    </div>
+                    <pre
+                      class="max-h-[28rem] overflow-auto whitespace-pre-wrap break-words rounded-lg border border-border bg-surface-2 px-4 py-3.5 font-mono text-[13px] leading-relaxed text-muted"
+                      set:text={step.prompt}
+                    />
+                  </li>
+                ))}
+              </ol>
             </div>
+          ) : (
+            <>
+              {d.agentDescription && (
+                <div class="mb-6">
+                  <h2 class="mb-2 text-sm font-semibold uppercase tracking-wider text-accent-text">
+                    Description
+                  </h2>
+                  <p class="text-muted">{d.agentDescription}</p>
+                </div>
+              )}
+
+              <h2 class="mb-3 text-sm font-semibold uppercase tracking-wider text-accent-text">
+                Instructions
+              </h2>
+              <article class="prose max-w-none dark:prose-invert prose-headings:text-fg prose-a:text-accent-text prose-strong:text-fg prose-code:text-accent-text prose-code:before:content-[''] prose-code:after:content-[''] prose-table:text-muted prose-th:text-fg">
+                <Content />
+              </article>
+            </>
           )
         }
-
-        <h2 class="mb-3 text-sm font-semibold uppercase tracking-wider text-accent-text">
-          Instructions
-        </h2>
-        <article
-          class="prose max-w-none dark:prose-invert prose-headings:text-fg prose-a:text-accent-text prose-strong:text-fg prose-code:text-accent-text prose-code:before:content-[''] prose-code:after:content-[''] prose-table:text-muted prose-th:text-fg"
-        >
-          <Content />
-        </article>
       </div>
 
       <!-- Sidebar -->
@@ -171,12 +253,14 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
           <hr class="my-5 border-border" />
 
           <h3 class="text-sm font-semibold text-fg">
-            {isPlugin ? "Add this plugin" : "Add this skill"}
+            {isPlugin ? "Add this plugin" : isAutomation ? "Add this automation" : "Add this skill"}
           </h3>
           <p class="mt-1 text-xs text-muted">
             {
               isPlugin
                 ? "Download the plugin package and install it in Microsoft 365 Copilot Cowork."
+                : isAutomation
+                ? "Download the automation and import it into Microsoft Scout (Automations \u203a Import)."
                 : `Download the ${
                     d.bundle ? "bundle" : "instructions"
                   } and add ${d.bundle ? "it" : "them"} to ${
@@ -206,6 +290,33 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                       <path d="M3 7a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />
                     </svg>
                     Download plugin package (.zip)
+                  </a>
+                )
+              ) : isAutomation ? (
+                d.bundle && (
+                  <a
+                    href={withBase(`/${d.bundle}`)}
+                    download={`${skill.id}.json`}
+                    data-clarity-event="skill_download"
+                    data-clarity-skill={skill.id}
+                    data-clarity-download-type="automation"
+                    class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      class="h-4 w-4"
+                    >
+                      <path
+                        d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    Download automation (.json)
                   </a>
                 )
               ) : (

--- a/src/pages/skills/[slug].md.ts
+++ b/src/pages/skills/[slug].md.ts
@@ -3,10 +3,10 @@ import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
   const skills = await getCollection("skills");
-  // Plugins are distributed as an M365 .zip package, not a single SKILL.md, so
-  // they don't expose a `.md` download route.
+  // Plugins ship as an M365 .zip package and automations ship as a Scout .json,
+  // not a single SKILL.md, so neither exposes a `.md` download route.
   return skills
-    .filter((skill) => skill.data.type !== "plugin")
+    .filter((skill) => skill.data.type !== "plugin" && skill.data.type !== "automation")
     .map((skill) => ({ params: { slug: skill.id }, props: { skill } }));
 }
 

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -142,6 +142,49 @@ exist with a `SKILL.md` whose frontmatter `name` is kebab-case and matches the
 folder. See [`legal-toolkit/`](./legal-toolkit) for a complete example, and copy
 [`_template-plugin/`](./_template-plugin) to start.
 
+## Scout automations (advanced)
+
+The gallery also hosts **Scout automations** — a scheduled/triggered `.json`
+(a schedule plus an ordered list of prompt steps) that runs **only** in Scout.
+
+An automation submission is a `submissions/<slug>/` folder with a `metadata.json`
+sidecar plus a **single `.json` automation export**. It's auto-detected as an
+automation because the one non-sidecar top-level file is a `.json` (not a `.zip`,
+not a `SKILL.md`):
+
+```
+submissions/<slug>/
+├── metadata.json          # catalog sidecar (name/description/tags optional —
+│                          #  they fall back to the automation's own fields)
+└── <name>.json            # the Scout automation export
+    ├── name               # non-empty string
+    ├── schedule           # required: single | interval | multi | monthly | cron
+    ├── steps[]            # { label, prompt } — the ordered prompt steps
+    └── …                  # optional: description, triggerType, model, etc.
+```
+
+The importer forces `platforms: ["Scout"]` and `type: "automation"`, publishes
+the `.json` **verbatim** as the download, and synthesizes the detail page
+(overview, the trigger/schedule, each step's prompt, and import steps).
+Automations show an **Automation** badge on their card and are filterable on the
+homepage. The exact `.json` you submit is what's offered for download and
+re-imported into Scout — so strip any personal paths or secrets first.
+
+This matches Scout's own GitHub-directory import convention: when Scout imports a
+bundle from a GitHub directory, **every root-level `.json` is an automation** and
+a `skills/` subdirectory holds skills. The file you submit here is the exact file
+Scout imports.
+
+Validation is a faithful port of Scout's import schema
+(`scripts/validate-automation.ts`) and will fail the PR with an itemized list if
+anything is off: `name` must be non-empty, every step needs a `label` and
+`prompt`, and `schedule` must be a valid discriminated union — including that an
+`interval`'s `intervalMinutes` divides 1440 evenly, a `monthly` selector can
+actually fire, and a `cron` expression is valid and fireable. Copy
+[`_template-automation/`](./_template-automation) to start, and see
+[`spend-more-time-with-friends-and-family/`](./spend-more-time-with-friends-and-family)
+for a complete example.
+
 ## Updating an existing skill
 
 Same path: edit the files in your `submissions/<slug>/` folder (or replace the

--- a/submissions/_template-automation/README.md
+++ b/submissions/_template-automation/README.md
@@ -1,0 +1,56 @@
+# Scout automation template
+
+Copy this folder to `submissions/<your-slug>/` to submit a **Scout automation** —
+a scheduled/triggered `.json` (a schedule plus an ordered list of prompt steps)
+that runs **only** in Scout.
+
+See [`../spend-more-time-with-friends-and-family/`](../spend-more-time-with-friends-and-family)
+for a complete working example.
+
+## What to put here
+
+```
+submissions/<your-slug>/
+├── metadata.json       # catalog sidecar (this file's sibling) — tweak or delete
+│                       #  name/description; they fall back to the automation
+└── <your-automation>.json   # the Scout automation export (add this yourself)
+```
+
+The submission is auto-detected as an **automation** because the single
+non-sidecar top-level file is a `.json` (not a `.zip`, not a `SKILL.md`). Do
+**not** set `platforms` in `metadata.json` — the importer forces `["Scout"]`.
+The exact `.json` you submit is the file offered for download and re-imported
+verbatim into Scout, so ship it as you want it distributed (strip any personal
+paths or secrets first).
+
+## Required `.json` shape
+
+The automation is validated against Scout's own import schema
+(`scripts/validate-automation.ts` is a faithful port). At minimum:
+
+- `name` — non-empty string.
+- `steps` — array of `{ "label": string, "prompt": string }` (an optional `id`
+  is allowed but Scout regenerates ids on import).
+- `schedule` — **required**, an object discriminated on `kind`:
+  - `single` — fires once per matching day at a time.
+  - `interval` — every N minutes (`intervalMinutes` must divide 1440 evenly).
+  - `multi` — several fixed times per day.
+  - `monthly` — a day/weekday/workday selector across chosen months (must be
+    able to actually fire — e.g. not Feb 31).
+  - `cron` — a `cronExpression` (must be a valid, fireable cron string).
+
+Optional: `description`, `triggerType` (`"schedule"` | `"condition"`),
+`condition`, `conditionCheckInterval`, `model`, `reasoningEffort`,
+`contextWindowTokens`, `permissions`, `browserHeadless`, `teamsNotify`
+(`always` | `auto` | `never`). Unknown top-level keys are stripped.
+
+The [`automation.json`](./automation.json) in this folder is a minimal valid
+example (a `single` daily schedule with one step).
+
+## Validate locally
+
+```bash
+npm run check:submissions    # thorough validation, writes nothing
+npm run import:submissions    # generate the automation page + published .json
+npm run build
+```

--- a/submissions/_template-automation/automation.json
+++ b/submissions/_template-automation/automation.json
@@ -1,0 +1,20 @@
+{
+  "name": "My Scout Automation",
+  "description": "One line describing what this automation does on each run.",
+  "triggerType": "schedule",
+  "schedule": {
+    "kind": "single",
+    "naturalLanguage": "every day at 9:00 AM",
+    "days": [],
+    "time": { "hour": 9, "minute": 0 },
+    "hour": 9,
+    "minute": 0
+  },
+  "steps": [
+    {
+      "label": "Main",
+      "prompt": "Describe, step by step, what the agent should do when this automation runs. Keep each step's prompt self-contained."
+    }
+  ],
+  "teamsNotify": "auto"
+}

--- a/submissions/_template-automation/metadata.json
+++ b/submissions/_template-automation/metadata.json
@@ -1,0 +1,10 @@
+{
+  "name": "My Scout Automation",
+  "description": "The CATALOG summary shown to people browsing the gallery. Optional for automations — if omitted it falls back to the automation's own description. (platforms is forced to Scout and must not be set here.)",
+  "tags": ["scout", "automation"],
+  "author": "Your Name",
+  "authorUrl": "https://example.com",
+  "version": "1.0.0",
+  "createdAt": "2026-01-01",
+  "updatedAt": "2026-01-01"
+}

--- a/submissions/spend-more-time-with-friends-and-family/metadata.json
+++ b/submissions/spend-more-time-with-friends-and-family/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "Spend More Time With Friends & Family",
+  "description": "While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete.",
+  "tags": ["scout", "automation", "teams", "out-of-office", "knowledge"],
+  "author": "Adi Leibowitz",
+  "version": "1.0.0",
+  "createdAt": "2026-07-14",
+  "updatedAt": "2026-07-14"
+}

--- a/submissions/spend-more-time-with-friends-and-family/spend-more-time-with-friends-and-family.json
+++ b/submissions/spend-more-time-with-friends-and-family/spend-more-time-with-friends-and-family.json
@@ -1,0 +1,39 @@
+{
+  "description": "While the owner is OOF, watches a group chat for questions, answers them from local knowledge docs (with an AI-generated caveat), logs anything it can't answer for later review, and pings the owner on Teams relay if its config is incomplete.",
+  "schedule": {
+    "kind": "interval",
+    "naturalLanguage": "every 15 minutes",
+    "days": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6
+    ],
+    "intervalMinutes": 15,
+    "anchor": {
+      "hour": 0,
+      "minute": 0
+    },
+    "hour": 0,
+    "minute": 0
+  },
+  "teamsNotify": "auto",
+  "id": "e4mxnk1pmrked1ny",
+  "name": "spend more time with friends and family",
+  "steps": [
+    {
+      "id": "1",
+      "label": "Main",
+      "prompt": "You are running the \"spend more time with friends and family\" automation. Work through these steps in order and stop early if instructed. All file paths are resolved at runtime relative to the Scout workspace so this automation is portable across machines and operating systems. Never hardcode an absolute path or a specific username.\n\nSTEP 0 — Resolve paths (portable, cross-OS).\n- Determine the workspace root (WS): this is the automation's current working directory. Get it portably: on macOS/Linux run the shell command `pwd`; on Windows run `cd` (cmd) or `$PWD.Path` (PowerShell). Trim whitespace/newlines from the result. Use whichever shell the OS provides.\n- Derive these paths by joining onto WS using the OS-native separator (the shell result for WS already uses the correct separator; just append subpaths with that same separator — forward slash `/` on macOS/Linux, backslash `\\` on Windows). Let SEP be that separator:\n  - BOT_DIR      = WS + SEP + \"friends-family-bot\"\n  - CONFIG_PATH  = BOT_DIR + SEP + \"config.json\"\n  - KNOWLEDGE_DIR = BOT_DIR + SEP + \"knowledge\"\n  - UNANSWERED   = BOT_DIR + SEP + \"unanswered.md\"\n- Use these resolved variables everywhere below. If you are ever unsure of the separator, prefer forward slashes — the filesystem tools accept them on all platforms.\n\nDEFAULT_CONFIG (the template to write when bootstrapping a missing config file). Note the path values are LEFT BLANK/relative on purpose — fill knowledgeDocs and unansweredLog with the runtime-resolved KNOWLEDGE_DIR and UNANSWERED values when you write the file, so nothing personal is hardcoded:\n{\n  \"chatId\": \"\",\n  \"knowledgeDocs\": [ \"<KNOWLEDGE_DIR>\" ],\n  \"unansweredLog\": \"<UNANSWERED>\",\n  \"lastProcessedMessageId\": \"\",\n  \"answerCaveat\": \"\\ud83e\\udd16 This is an AI-generated reply from Scout on behalf of the account owner (who is currently away). Please verify anything important.\",\n  \"ownerRelayEmail\": \"\"\n}\n\nSTEP 1 — Load or bootstrap config.\n- Try to read CONFIG_PATH as JSON.\n- If the file does NOT exist (or BOT_DIR is missing): create BOT_DIR and KNOWLEDGE_DIR if needed, then WRITE DEFAULT_CONFIG to CONFIG_PATH with <KNOWLEDGE_DIR> and <UNANSWERED> replaced by the actual runtime-resolved paths. This self-creates a config the user can fill in. Treat the freshly written config as loaded and continue to validation.\n- If the file exists but is unparseable/corrupt: do NOT overwrite it (avoid clobbering user edits). Treat as a fatal config error and go to STEP 1b, naming the parse problem.\n\nSTEP 1a — Validate.\n- Required fields: `chatId` (non-empty), and `knowledgeDocs` (a non-empty array whose folders/files actually exist and contain at least one readable knowledge file other than README.md).\n- Optional: `unansweredLog`, `lastProcessedMessageId`, `answerCaveat`, `ownerRelayEmail`.\n\nSTEP 1b — If any required field is missing/empty/invalid (including right after a fresh bootstrap, where they will be empty):\n- Do NOT touch the monitored chat. Instead, complain to the owner over the Teams relay so they can fix it.\n  - Check relay status with m_relay_status; if not connected, call m_relay_connect.\n  - Determine where to send: if `ownerRelayEmail` is set, call workiq_create_chat_by_email with it; otherwise send to the Teams self-chat (workiq_create_chat_by_email with the current user's own email from workiq_get_my_profile).\n  - Send a concise message naming exactly which fields are unset/invalid and the CONFIG_PATH to edit. If you just bootstrapped the file, say so, e.g.: \"⚠️ 'spend more time with friends and family' created a blank config at CONFIG_PATH but chatId and knowledge docs are still empty. Fill them in to activate.\"\n  - Then STOP the run. Register result \"blocked: incomplete config (<fields>)\". Do not proceed to later steps.\n\nSTEP 2 — Fetch new messages.\n- Call workiq_list_chat_messages for `chatId` (newest first, limit ~30).\n- Determine which messages are NEW: those posted after `lastProcessedMessageId`. If `lastProcessedMessageId` is empty, only consider messages from the last 60 minutes (do NOT backfill the whole history).\n- Ignore messages sent by the owner themselves (compare against workiq_get_my_profile) and ignore system/event messages.\n\nSTEP 3 — Identify questions.\n- From the NEW messages, pick those that are genuinely asking a question (ends with \"?\", or is clearly interrogative / a request for info). Skip greetings, reactions, and small talk.\n\nSTEP 4 — Answer from knowledge docs.\n- Read the contents of every knowledge file referenced by `knowledgeDocs` (recurse into folders; skip README.md). Treat this as the ONLY source of truth.\n- For each question, try to answer strictly from the knowledge docs. Do not invent facts not supported by the docs.\n- If you have a supported answer: post a reply in the chat using workiq_reply_to_chat_message (reply to that specific message). Prepend/append the caveat from `answerCaveat` (or a sensible default if unset) so it's clear the reply is AI-generated by Scout on the owner's behalf.\n- If the docs do NOT contain enough to answer: append a row to the `unansweredLog` markdown table with local timestamp, asker display name, the question text, and the message id / chat reference. Do NOT post a guess to the chat.\n\nSTEP 5 — Update state.\n- Set `lastProcessedMessageId` in CONFIG_PATH to the id of the newest message you processed, and write the file back (preserve all other fields).\n\nSTEP 6 — Register a short result summary: how many new questions were found, how many answered in-chat, how many logged as unanswered. Only surface to Teams if something needs the owner's attention (e.g. unanswered questions logged), otherwise keep it quiet."
+    }
+  ],
+  "enabled": false,
+  "oneShot": false,
+  "createdAt": "2026-07-14T08:36:20.014Z",
+  "updatedAt": "2026-07-14T09:23:04.158Z",
+  "triggerType": "schedule",
+  "lastExecutedAt": null
+}


### PR DESCRIPTION
## What

Extends the gallery to onboard **Scout automations** (scheduled/triggered `.json` files) alongside skills and Cowork plugins, using the same drop-in `submissions/<slug>/` + `metadata` sidecar model.

## How it works

A submission is auto-detected as an **automation** when its single non-sidecar top-level file is a `.json` (not a `.zip`, not a `SKILL.md`). The importer forces `platforms: ["Scout"]` + `type: "automation"`, validates against Scout's own import contract, and publishes the `.json` **verbatim** as the download so it re-imports directly into Scout.

## Changes

- **`scripts/validate-automation.ts`** — a faithful port of Scout's `AutomationImportSchema` (5 schedule kinds: single/interval/multi/monthly/cron + `superRefine`, via `astro/zod` + `croner`). Standalone CLI + programmatic API.
- **`scripts/import-submissions.ts`** — automation detection + `processAutomation` (forces platform/type, ships raw `.json`).
- **Type plumbing** — `type` enum, `SkillType` union, homepage filter chip, `SkillCard`/`SkillCover` **Automation** badge, and a `.json` (not `.zip`) download chip for automations.
- **Detail page** (`[slug].astro`) — a purpose-built **Trigger + Steps** layout that mirrors the skill page's eyebrow rhythm, parsing the published `.json` at build time. Excluded from the `.md` route.
- **Template + docs** — `submissions/_template-automation/`, plus README / CONTRIBUTING / submissions README.
- **First automation** — `spend-more-time-with-friends-and-family` (portable, no personal paths).

## Verification

- `check:submissions` → 17 pass; `import:submissions` generates the page + `.json` bundle; `build` → 63 pages.
- Negative tests (bad interval / missing fields / unfireable cron) hard-fail with itemized messages + exit 1.
- Validated the rendered page on a local dev server; regular skills/plugins unaffected.