### PR TITLE
Feature Scout automation via submission metadata

### DIFF
--- a/src/content/skills/spend-more-time-with-friends-and-family.md
+++ b/src/content/skills/spend-more-time-with-friends-and-family.md
@@ -8,6 +8,7 @@ author: Adi Leibowitz
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14
+featured: true
 bundle: bundles/spend-more-time-with-friends-and-family.json
 ---
 While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete.

--- a/src/content/skills/spend-more-time-with-friends-and-family.md
+++ b/src/content/skills/spend-more-time-with-friends-and-family.md
@@ -8,7 +8,6 @@ author: Adi Leibowitz
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14
-featured: true
 bundle: bundles/spend-more-time-with-friends-and-family.json
 ---
 While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete.

--- a/submissions/spend-more-time-with-friends-and-family/metadata.json
+++ b/submissions/spend-more-time-with-friends-and-family/metadata.json
@@ -5,5 +5,6 @@
   "author": "Adi Leibowitz",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
-  "updatedAt": "2026-07-14"
+  "updatedAt": "2026-07-14",
+  "featured": true
 }


### PR DESCRIPTION
## What

Makes the "Spend More Time With Friends & Family" Scout automation **featured** so it surfaces at the top of the gallery.

## Why this PR (follow-up to #48)

In #48 I set `featured: true` directly in the generated `src/content/skills/*.md`. But those files are **regenerated from `submissions/` by the CI "extract submissions" step**, which stripped the flag — so the change never reached production.

This PR sets `featured` in the **submission metadata** (`submissions/spend-more-time-with-friends-and-family/metadata.json`), the actual source of truth, and regenerates the content file so it survives extraction.

## Files

- `submissions/spend-more-time-with-friends-and-family/metadata.json` — `"featured": true`.
- `src/content/skills/spend-more-time-with-friends-and-family.md` — regenerated (via `npm run import:submissions`).

## Verification

- `npm run check:submissions` passes (generated content matches source).
- `npm run build` passes.