### PR TITLE
Add trust acknowledgement gate before skill downloads

### DIFF
--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -269,7 +269,44 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
             }
           </p>
 
-          <div class="mt-4 flex flex-col gap-2">
+          <div class="mt-4 rounded-lg border border-border bg-surface-2 p-3.5">
+            <div class="flex items-start gap-2.5">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+                aria-hidden="true"
+              >
+                <path d="M12 3 4 6v5c0 4.5 3.2 7.9 8 9 4.8-1.1 8-4.5 8-9V6l-8-3z" />
+                <path d="M12 8v4" />
+                <path d="M12 16h.01" />
+              </svg>
+              <div>
+                <p class="text-xs font-semibold text-fg">Add only what you trust</p>
+                <label
+                  for="trust-ack"
+                  class="mt-2 flex cursor-pointer items-start gap-2 text-xs leading-relaxed text-muted"
+                >
+                  <input
+                    type="checkbox"
+                    id="trust-ack"
+                    class="mt-0.5 h-3.5 w-3.5 shrink-0 cursor-pointer rounded border-border accent-accent"
+                  />
+                  <span>
+                    I understand I should only add {noun}s from sources I trust.
+                    This {noun} runs with my agent's permissions.
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div id="download-actions" class="mt-3 flex flex-col gap-2">
             {
               isPlugin ? (
                 d.bundle && (
@@ -279,7 +316,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                     data-clarity-event="skill_download"
                     data-clarity-skill={skill.id}
                     data-clarity-download-type="plugin"
-                    class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity"
+                    data-download-gated
+                    aria-disabled="true"
+                    class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity pointer-events-none opacity-50 cursor-not-allowed"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -300,7 +339,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                     data-clarity-event="skill_download"
                     data-clarity-skill={skill.id}
                     data-clarity-download-type="automation"
-                    class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity"
+                    data-download-gated
+                    aria-disabled="true"
+                    class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity pointer-events-none opacity-50 cursor-not-allowed"
                   >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -328,7 +369,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                       data-clarity-event="skill_download"
                       data-clarity-skill={skill.id}
                       data-clarity-download-type="bundle"
-                      class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity"
+                      data-download-gated
+                      aria-disabled="true"
+                      class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity pointer-events-none opacity-50 cursor-not-allowed"
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -347,7 +390,9 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
                       data-clarity-event="skill_download"
                       data-clarity-skill={skill.id}
                       data-clarity-download-type="markdown"
-                      class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity"
+                      data-download-gated
+                      aria-disabled="true"
+                      class="flex items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-semibold text-accent-fg hover:opacity-90 transition-opacity pointer-events-none opacity-50 cursor-not-allowed"
                     >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -465,6 +510,11 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
   <script
     is:inline
     set:html={`(function(){function frame(){return document.querySelector('iframe.giscus-frame');}function themeFor(){return document.documentElement.getAttribute('data-theme')==='dark'?'dark':'light';}function apply(){var f=frame();if(!f||!f.contentWindow)return;f.contentWindow.postMessage({giscus:{setConfig:{theme:themeFor()}}},'https://giscus.app');}document.addEventListener('themechange',apply);window.addEventListener('message',function(e){if(e.origin==='https://giscus.app'&&e.data&&e.data.giscus&&'discussion'in e.data.giscus){apply();}});})();`}
+  />
+  {/* Gate downloads behind the trust acknowledgement checkbox. */}
+  <script
+    is:inline
+    set:html={`(function(){var ack=document.getElementById('trust-ack');var actions=document.getElementById('download-actions');if(!ack||!actions)return;var links=actions.querySelectorAll('[data-download-gated]');var locked=['pointer-events-none','opacity-50','cursor-not-allowed'];function sync(){var on=ack.checked;links.forEach(function(l){if(on){locked.forEach(function(c){l.classList.remove(c);});l.removeAttribute('aria-disabled');}else{locked.forEach(function(c){l.classList.add(c);});l.setAttribute('aria-disabled','true');}});}actions.addEventListener('click',function(e){if(!ack.checked){var l=e.target.closest('[data-download-gated]');if(l){e.preventDefault();ack.focus();}}});ack.addEventListener('change',sync);sync();})();`}
   />
   {
     ANALYTICS_ENABLED && (


### PR DESCRIPTION
## What & why

Skills, plugins, and automations from this gallery run with the agent's permissions. Today anyone can download and install one without pausing to consider whether they trust the source. This adds a clear-but-elegant trust gate on the skill detail page.

## Changes

On `src/pages/skills/[slug].astro` (the single place all downloads happen — cards just link here):

- A subtle amber-tinted notice with a shield icon, headed **"Add only what you trust"**, plus an acknowledgement checkbox: *"I understand I should only add {skills/plugins/automations} from sources I trust. This … runs with my agent's permissions."*
- The download button starts **locked** (dimmed, `cursor-not-allowed`, `aria-disabled`) and only unlocks when the box is ticked. Covers all three variants: plugin `.zip`, automation `.json`, and skill bundle `.zip` / `SKILL.md`.
- A small `is:inline` script toggles the lock and blocks clicks while unchecked (keyboard-accessible — clicking a locked link focuses the checkbox).

Uses existing theme tokens, so it reads well in light and dark mode. Existing `data-clarity-*` analytics attributes are preserved. No new dependencies.

## Testing

- `npm run build` passes (64 pages).
- Verified live via `npm run dev` across skill, plugin, and automation pages: button is inert until the checkbox is checked, then downloads normally.