### PR TITLE
Fix installer detail page: redundant callout, code-block contrast, sidebar wording

### DIFF
--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -536,17 +536,12 @@ function buildAutomationBody(opts: {
 
 /**
  * Build the synthesized detail-page body for an automation installer. There is
- * no schedule/steps digest, so we prepend a short callout and render the
- * submitted `INSTALL.md` verbatim as the body.
+ * no schedule/steps digest, so the submitted `INSTALL.md` is rendered verbatim
+ * as the body. The "how to install" guidance lives next to the download button
+ * on the detail page, so we don't repeat it as a callout here.
  */
-function buildInstallerBody(install: string, slug: string): string {
-  const callout =
-    "> **Scout automation installer.** This is a Microsoft **Scout** automation " +
-    "delivered as an installer `.zip` (an `INSTALL.md` plus JSON config " +
-    "file(s)). Download the `.zip`, unzip it, and follow `INSTALL.md` — Scout " +
-    `creates the automation for you. This installer's files are ` +
-    `\`submissions/${slug}/\` in this repo.\n`;
-  return `${callout}\n${install.trim()}\n`;
+function buildInstallerBody(install: string, _slug: string): string {
+  return `${install.trim()}\n`;
 }
 
 /**

--- a/src/content/skills/vacation-urgent-forwarder.md
+++ b/src/content/skills/vacation-urgent-forwarder.md
@@ -10,8 +10,6 @@ createdAt: 2026-07-16
 updatedAt: 2026-07-16
 bundle: bundles/vacation-urgent-forwarder.zip
 ---
-> **Scout automation installer.** This is a Microsoft **Scout** automation delivered as an installer `.zip` (an `INSTALL.md` plus JSON config file(s)). Download the `.zip`, unzip it, and follow `INSTALL.md` — Scout creates the automation for you. This installer's files are `submissions/vacation-urgent-forwarder/` in this repo.
-
 # Vacation Urgent Forwarder
 
 This package installs one disabled recurring automation that monitors recent work email and Teams messages only during a configured vacation window. It forwards only clearly urgent signals to the user's personal email and keeps a local state file to prevent duplicate alerts.

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -266,7 +266,7 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
               isPlugin
                 ? "Download the plugin package and install it in Microsoft 365 Copilot Cowork."
                 : isInstaller
-                ? "Download the installer (.zip), unzip it, and follow INSTALL.md \u2014 Microsoft Scout creates the automation for you."
+                ? "Download the installer (.zip), unzip it, and ask Microsoft Scout to follow INSTALL.md \u2014 Scout creates the automation for you."
                 : isAutomation
                 ? "Download the automation and import it into Microsoft Scout (Automations \u203a Import)."
                 : `Download the ${

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -99,6 +99,14 @@
   overflow-wrap: break-word;
   word-break: break-word;
 }
+/* Code fences (shiki) carry their own foreground colors. Keep the inline-code
+   accent color (`prose-code:text-accent-text`) from bleeding into `<pre>`
+   blocks — otherwise plain-text blocks, which have no syntax tokens to color,
+   inherit the accent and render as low-contrast blue text on the dark code
+   background in both light and dark themes. */
+.prose :where(pre) code {
+  color: inherit;
+}
 
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
Cleanup on the Scout automation **installer** detail page (e.g. `vacation-urgent-forwarder`):

- **Remove redundant callout** — dropped the "Scout automation installer" blockquote that the installer body generator prepended. The same guidance already appears next to the download button, so the body just renders `INSTALL.md`.
- **Fix blue-on-black code blocks** — the inline-code accent color (`prose-code:text-accent-text`) was bleeding into `<pre>` code fences. Plain-text blocks have no syntax tokens to color, so the whole block inherited the accent and rendered as low-contrast blue on the dark shiki background. Added a `.prose :where(pre) code { color: inherit }` rule so fences use their own foreground in both light and dark themes.
- **Reword sidebar note** — now reads "…unzip it, and **ask Microsoft Scout to follow INSTALL.md** — Scout creates the automation for you," clarifying you hand it to Scout rather than doing it manually.

Verified against the dev server and `npm run build` passes.