### PR TITLE
Add header "Report an issue" button with issue/feedback form

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contribute a skill
+    url: https://github.com/microsoft/cat-agent-skills/blob/main/CONTRIBUTING.md
+    about: Want to add a skill, plugin, or automation to the gallery? Start here.
+  - name: Get support
+    url: https://github.com/microsoft/cat-agent-skills/blob/main/SUPPORT.md
+    about: Looking for help using a skill? See our support guidance.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,35 @@
+name: Issue or feedback
+description: Report a problem with the gallery, or share feedback and suggestions.
+title: "[Feedback]: "
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. Use this form to report a problem with the
+        gallery site or to share feedback and ideas.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What would you like to do?
+      options:
+        - Report an issue
+        - Share feedback / a suggestion
+    validations:
+      required: true
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: Link to the page this relates to (if applicable).
+      placeholder: https://microsoft.github.io/cat-agent-skills/...
+    validations:
+      required: false
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Describe the issue or share your feedback. For a bug, what did you expect and what happened?
+      placeholder: Tell us more...
+    validations:
+      required: true

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/global.css";
 import { withBase } from "../lib/url";
+import { FEEDBACK_URL } from "../lib/issues";
 import { ANALYTICS_ENABLED, CLARITY_PROJECT_ID } from "../lib/analytics-config";
 
 interface Props {
@@ -68,9 +69,32 @@ const fullTitle =
           class="flex shrink-0 items-center gap-2.5 text-sm text-muted sm:gap-5"
         >
           <a
-            href={withBase("/")}
-            class="hidden hover:text-fg transition-colors sm:inline">Browse</a
+            href={FEEDBACK_URL}
+            target="_blank"
+            rel="noopener"
+            data-clarity-event="report_issue"
+            data-clarity-report-scope="site"
+            title="Report an issue or share feedback"
+            class="inline-flex items-center gap-1.5 hover:text-fg transition-colors"
           >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="h-4 w-4 shrink-0"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="9"></circle>
+              <path d="M12 8v5"></path>
+              <path d="M12 16h.01"></path>
+            </svg>
+            <span class="hidden sm:inline">Report an issue</span>
+            <span class="sr-only sm:hidden">Report an issue</span>
+          </a>
           <a
             href="https://github.com/microsoft/cat-agent-skills/blob/main/CONTRIBUTING.md"
             target="_blank"

--- a/src/lib/issues.ts
+++ b/src/lib/issues.ts
@@ -1,0 +1,5 @@
+/** GitHub repository that backs this gallery. */
+export const GITHUB_REPO = "microsoft/cat-agent-skills";
+
+/** URL to the "Issue or feedback" GitHub issue form. */
+export const FEEDBACK_URL = `https://github.com/${GITHUB_REPO}/issues/new?template=feedback.yml`;


### PR DESCRIPTION
## What

Adds a gentle "Report an issue" link to the site header, next to "Contribute a skill". It opens a single GitHub issue form that lets the reporter choose between **filing an issue** or **sharing feedback**.

## Why

There was no easy way for visitors to report a problem or share feedback. Since individual skills aren't formally supported, we intentionally keep this site-level (not per-skill).

## Changes

- **`.github/ISSUE_TEMPLATE/feedback.yml`** — new "Issue or feedback" form: a dropdown (Report an issue / Share feedback), an optional page URL, and a details box. Applies the `feedback` label.
- **`.github/ISSUE_TEMPLATE/config.yml`** — contact links to Contributing and Support.
- **`src/lib/issues.ts`** — `GITHUB_REPO` constant + `FEEDBACK_URL`.
- **`src/layouts/Layout.astro`** — muted icon+text "Report an issue" link in the header. This replaces the old "Browse" link, which just duplicated the logo's link to home.

## Verification

- `npm run check:submissions` passes (20 skills)
- `npm run build` succeeds (70 pages)
- Built HTML: header link points to `issues/new?template=feedback.yml` on every page