### PR TITLE
Add Power Automate Desktop assessment skill

### DIFF
--- a/submissions/power-automate-desktop-assessment/README.md
+++ b/submissions/power-automate-desktop-assessment/README.md
@@ -14,7 +14,7 @@ The skill inventories solution artifacts, generates static metrics, and produces
 
 ## Portable workflow
 
-The bundled scripts run with Python 3.10+ and the standard library in the Linux-style execution environments used by Cowork, Copilot Studio, and Scout. The default outputs are a Markdown assessment and a JSON metrics file. Richer formats are optional and used only when the host provides a supported document-generation capability.
+The bundled scripts run with Python 3.10+ and the standard library in the Linux-style execution environments used by Cowork and Copilot Studio. The default outputs are a Markdown assessment and a JSON metrics file. Richer formats are optional and used only when the host provides a supported document-generation capability.
 
 The extraction workflow validates ZIP members before writing and rejects path traversal, excessive archive expansion, and unsafe output reuse. It does not print secret values or modify the supplied automation.
 

--- a/submissions/power-automate-desktop-assessment/README.md
+++ b/submissions/power-automate-desktop-assessment/README.md
@@ -1,0 +1,29 @@
+# Power Automate Desktop Assessment
+
+Review exported Power Automate solutions and hybrid cloud/desktop automation projects using an evidence-based assessment workflow grounded in current Microsoft guidance.
+
+## What it covers
+
+- Maintainability, architecture, and reuse
+- Reliability, error handling, and troubleshooting readiness
+- Security, credentials, DLP, and access control
+- Performance, concurrency, machine strategy, and scaling
+- Testing, ALM, governance, and operational support
+
+The skill inventories solution artifacts, generates static metrics, and produces prioritized findings with evidence, impact, remediation, effort, and suggested ownership. It treats package analysis as one source of evidence and clearly identifies where run history, logs, selectors, machine configuration, or governance records are still required.
+
+## Portable workflow
+
+The bundled scripts run with Python 3.10+ and the standard library in the Linux-style execution environments used by Cowork, Copilot Studio, and Scout. The default outputs are a Markdown assessment and a JSON metrics file. Richer formats are optional and used only when the host provides a supported document-generation capability.
+
+The extraction workflow validates ZIP members before writing and rejects path traversal, excessive archive expansion, and unsafe output reuse. It does not print secret values or modify the supplied automation.
+
+## Typical inputs
+
+- Exported Power Platform solution ZIP
+- Desktop-flow and cloud-flow definitions
+- Run history and action logs
+- Selector, machine, connection, DLP, and work queue configuration
+- Test evidence and operational documentation
+
+The resulting report includes an executive summary, strengths, prioritized risks, detailed recommendations, a remediation roadmap, open questions, and an inventory of reviewed artifacts and references.

--- a/submissions/power-automate-desktop-assessment/SKILL.md
+++ b/submissions/power-automate-desktop-assessment/SKILL.md
@@ -153,7 +153,7 @@ Use these signals to drive findings:
 - desktop flow binaries with UI/Web automation modules that require selector robustness and runtime diagnostics review;
 - generic names, misspellings, or artifacts named `OLD`, `TEST`, `Unknown`, or similar that indicate maintainability or ALM hygiene issues.
 
-## Runtime contract for Cowork, Copilot Studio, and Scout
+## Runtime contract for Cowork and Copilot Studio
 
 The required workflow targets the common execution model of all declared platforms:
 

--- a/submissions/power-automate-desktop-assessment/SKILL.md
+++ b/submissions/power-automate-desktop-assessment/SKILL.md
@@ -153,55 +153,100 @@ Use these signals to drive findings:
 - desktop flow binaries with UI/Web automation modules that require selector robustness and runtime diagnostics review;
 - generic names, misspellings, or artifacts named `OLD`, `TEST`, `Unknown`, or similar that indicate maintainability or ALM hygiene issues.
 
+## Runtime contract for Cowork, Copilot Studio, and Scout
+
+The required workflow targets the common execution model of all declared platforms:
+
+- Python 3.10+ in an isolated Linux-style runtime with a writable `/tmp` directory.
+- Python standard library only for extraction, metrics, and the canonical report.
+- Input and output through host-provided file or attachment capabilities, not a desktop filesystem or sync client.
+- No PowerShell, Windows paths, desktop Office automation, process termination, Node.js, or host-specific skill-loader paths.
+
+The skill includes four companion scripts under `scripts/`:
+
+- `extract_solution.py` safely extracts a solution ZIP and rejects path traversal and oversized archives.
+- `analyze_solution.py` generates static metrics without emitting configuration or secret values.
+- `render_report.py` produces the canonical Markdown report.
+- `run_assessment.py` runs the complete extraction, analysis, and report pipeline.
+
+If a host exposes Python through an action or tool rather than directly to the agent, configure that action to use the same command-line contract and pass host-managed input/output files to it.
+
 ## Recommended assessment automation workflow
 
-Use this workflow for solution ZIP assessments. Adapt paths to the user's workspace and requested output file.
+### 1. Stage the input
 
-### 1. Extract the solution ZIP
+Use the host's file or attachment capability to materialize the supplied solution ZIP as a read-only temporary file, for example:
 
-```powershell
-$zip = 'C:\path\to\solution.zip'
-$out = 'C:\path\to\workspace\solution_extract'
-if (Test-Path -LiteralPath $out) { Remove-Item -LiteralPath $out -Recurse -Force }
-New-Item -ItemType Directory -Path $out -Force | Out-Null
-Expand-Archive -LiteralPath $zip -DestinationPath $out -Force
-Get-ChildItem -LiteralPath $out -Recurse -File | Select-Object FullName, Length
+`/tmp/input/solution.zip`
+
+Do not assume that a user-provided local path is visible inside the execution runtime.
+
+### 2. Run the bundled Python workflow
+
+From the skill package root, run:
+
+```bash
+python3 scripts/run_assessment.py \
+  --zip /tmp/input/solution.zip \
+  --work-dir /tmp/pad-assessment
 ```
 
-### 2. Generate assessment metrics
+The command creates a unique run directory and prints the exact paths. It produces:
 
-Create or reuse an analysis script that:
+- `/tmp/pad-assessment/run-<id>/output/assessment_metrics.json`
+- `/tmp/pad-assessment/run-<id>/output/assessment_report.md`
 
+The workflow:
+
+- preserves the original ZIP;
+- validates archive members before writing, extracts into a new staging directory, and rejects path traversal, excessive member counts, oversized files, and excessive total expansion;
 - parses `solution.xml`;
 - reads `environmentvariabledefinitions/*/environmentvariabledefinition.xml`;
 - inspects `desktopflowbinaries/*/data/*.json`;
 - walks all `Workflows/*.json` recursively;
-- counts triggers, actions, action types, connectors, scopes, `Foreach`, maximum nested `Foreach` depth, `runAfter` non-success paths, retry policies, `Terminate`, HTTP actions, wait/delay actions, desktop/child-flow references, and sensitive keyword classes;
-- writes `assessment_metrics.json`.
+- counts triggers, actions, action types, connectors, scopes, `Foreach`, maximum nested `Foreach` depth, non-success `runAfter` paths, retry policies, `Terminate`, HTTP-like actions, wait/delay actions, and desktop/child-flow references;
+- records only sensitive keyword classes or presence indicators, never secret values;
+- keeps source filenames for traceability and uses friendly names in the report.
 
-Key parser behaviors:
+Individual scripts can also be invoked directly:
 
-- tolerate mixed JSON structures where `inputs`, `cases`, `else`, or `default` might be strings or objects;
-- never print secret values, only keyword classes or presence indicators;
-- keep file names for traceability but map them to friendly workflow names in the report.
+```bash
+python3 scripts/extract_solution.py \
+  /tmp/input/solution.zip \
+  /tmp/pad-assessment/solution_extract
 
-### 3. Create visual executive dashboard
+python3 scripts/analyze_solution.py \
+  --root /tmp/pad-assessment/solution_extract \
+  --output /tmp/pad-assessment/output/assessment_metrics.json
 
-Generate a PNG dashboard when the report format supports images. The dashboard should include:
+python3 scripts/render_report.py \
+  --metrics /tmp/pad-assessment/output/assessment_metrics.json \
+  --output /tmp/pad-assessment/output/assessment_report.md
+```
 
-- KPI cards: cloud flows, total actions, desktop artifacts, high-priority recommendations, nested-loop flows, ALM hygiene signals;
-- bar chart: top workflows by action count;
-- bar chart: recommendation hotspots by topic;
-- priority split: High / Medium / Low;
-- short interpretation bullets.
+### 3. Complete the evidence-based review
 
-Use an available charting or document-generation tool. If image generation is unavailable, use a compact table-based dashboard.
+Treat the generated report as a static-analysis draft. Verify its threshold-based findings against the extracted artifacts and add evidence from any supplied run history, action logs, selectors, machine configuration, DLP policies, test results, and operational documentation.
 
-### 4. Generate the assessment report
+Do not infer runtime behavior from package structure alone. Lower confidence and list missing evidence when runtime artifacts are unavailable.
 
-Create the report in the user's requested format. If no format is requested, use Markdown. The report should be in English by default and organized as:
+### 4. Create the executive dashboard
 
-1. Visual executive dashboard with KPI image and summary metrics.
+The portable default is a compact Markdown table using the metrics JSON. If the host provides a supported chart or image-generation capability, a PNG dashboard can also include:
+
+- KPI cards: cloud flows, total actions, desktop artifacts, high-priority recommendations, nested-loop flows, and ALM hygiene signals;
+- top workflows by action count;
+- recommendation hotspots by topic;
+- priority split;
+- short interpretation notes.
+
+Image generation is optional and must not block delivery of the Markdown report.
+
+### 5. Generate the assessment report
+
+Markdown is the canonical cross-platform output. The report should be in English by default and organized as:
+
+1. Executive dashboard or summary metrics table.
 2. Executive summary.
 3. Priority recommendations grouped by artifact type:
    - Cloud Flows
@@ -214,12 +259,10 @@ Create the report in the user's requested format. If no format is requested, use
 Report structure requirements:
 
 - The assessment body must be written in English unless the user explicitly requests another report language.
-- Section 2 must be organized by artifact type, not by raw file order.
-- Use friendly artifact names in headings, followed by the artifact type in brackets, for example `LA - Email Forwarder - Performer Main [Cloud Flow]`.
-- Do not use raw JSON filenames as recommendation titles. Keep raw names only in the **Technical source** row for traceability.
-- Include a visual executive dashboard near the beginning of the report. Prefer a generated PNG image with KPI cards and charts. If image generation is unavailable, use visually formatted Word tables as a fallback.
-- The dashboard should show at least: cloud flow count, total cloud actions, desktop artifacts, high-priority recommendations, nested-loop workflows, ALM hygiene signals, top workflows by action count, recommendation hotspots by topic, and priority split.
-- The detailed recommendation sections should be actionable and not purely inventory-based. Each recommendation must state what was observed, the expected target state, the remediation approach, and the expected impact.
+- Organize recommendations by artifact type, not raw file order.
+- Use friendly artifact names in headings, followed by the artifact type, for example `Invoice Dispatcher [Cloud Flow]`.
+- Do not use raw JSON filenames as recommendation titles. Keep raw names only in the **Technical source** field for traceability.
+- Each recommendation must state what was observed, the target state, the remediation approach, the expected impact, and the priority.
 
 For each recommendation, use professional headings:
 
@@ -231,37 +274,41 @@ For each recommendation, use professional headings:
 - **Expected business/operational impact**
 - **Priority**
 
-Avoid using raw JSON filenames as section titles. Use a friendly workflow name plus artifact type, and keep the raw filename only as **Technical source**.
+### 6. Optional richer document formats
 
-### 5. Validate the report
+Only create DOCX, PDF, or another rich format when the user requests it and the current host exposes a supported document-generation capability.
 
-Validate the generated file with an appropriate format-specific validator when one is available. Confirm that headings, tables, images, links, and page layout render correctly before delivery.
+- Use the host-native capability; do not require `docx-js`, Node.js, Microsoft Word, LibreOffice, a mounted OneDrive/SharePoint folder, or another platform's skill loader.
+- Treat the Markdown report and metrics JSON as the source of truth.
+- If the requested format is unavailable, deliver Markdown and state the limitation explicitly.
+- Validate an optional rich document with the host's supported validator or preview capability before delivery. Never claim validation that did not run.
 
-### 6. Output naming
+### 7. Publish outputs safely
 
-Use explicit report names:
+Use explicit names:
 
-- `*_Assessment_BestPractices.docx` for the concise best-practices version.
-- `*_Assessment_DetailedRecommendations_EN.docx` for the full English detailed version with visual dashboard and workflow-level recommendations.
+- `*_Assessment.md`
+- `*_Assessment_Metrics.json`
+- an equivalent extension only when an optional richer format was requested and generated.
 
-If the target file is locked by Word or OneDrive, create a new versioned filename rather than overwriting.
+Return or persist outputs with the host's file/attachment API. Do not assume a mounted cloud-drive path. Avoid in-place overwrite; when a destination already exists, use a new versioned name. Never terminate user applications or sync processes.
 
 ## Common myths and verified facts
 
 These are factually wrong claims that show up repeatedly in PAD assessments (and in partner-authored documents being reviewed). Always fact-check against current Microsoft Learn before accepting them as evidence — and call them out when they appear in the artifact under review.
 
-| Myth (frequently asserted) | Verified fact | Authoritative reference |
-|---|---|---|
-| "Automation Center captures error screenshots automatically" | False. AC stores run history, status, recommendations, and queue health, but does **not** capture screenshots on error. The supported pattern is an explicit `Take screenshot` action wrapped by `On block error` or by exception-handling subflows. | Learn: *Troubleshoot failed unattended runs using screenshots* |
-| "Use the Azure Application Insights connector ('Send to App Insights') for telemetry" | The Azure Application Insights connector is **deprecated and read-only** (it only ran Analytics queries; it never wrote telemetry). For Power Automate: enable App Insights integration at the **environment level** in Power Platform admin centre to capture cloud flows automatically; for desktop flow custom traces, use an HTTP action against the Application Insights ingestion endpoint. | Learn: *Set up Application Insights for an environment*; Connectors reference (deprecated marker) |
-| "PAD has a 'Get files in folder' action under the System group" | The action lives under **Folder** group, not System. | Learn: *Folder actions reference* |
-| "PAD has a 'Generate random text or number' action" | The native action is **`Create random text`** under the **Text** group. | Learn: *Text actions reference* |
-| "PAD has a 'Convert custom object to datatable' action" | Does **not exist**. Variables actions provide `Convert JSON to custom object`, `Convert custom object to JSON`, and `Convert data table to text`. To produce a datatable from JSON, iterate the parsed custom object and use `Insert row into data table`, or perform the conversion in cloud-flow expressions. | Learn: *Variables actions* |
-| "Unattended fails because Entra tokens expire" | Most reports of this symptom are actually the **`Connect with sign-in` option being interactive-only** — it cannot reconnect a machine after sign-out without a logged-in session. Move to a self-hosted Machine Group with a service principal as connection identity. The `Entra token expiry` framing leads to wrong remediation (forced re-login scripts) instead of the correct one (service principal). | Learn: *Set up machines for desktop flows*; *Run desktop flows from a cloud flow* |
-| "Logs V1 with custom retention is fine" | Logs V2 (Elastic Tables) supersedes V1. V2 provides **automatic data retention**, **near real-time updates**, and scales to GB of action logs per run. New environments default to V2; assessments should recommend V2 unless there is a hard incompatibility. | Learn: *Desktop flow action logs configuration* |
-| "Work Queues can be parallelised aggressively" | Learn-documented limit: keep dequeueing concurrency moderate — **up to five parallel dequeue operations per work queue is recommended**. For sub-second processing, Work Queues are not suitable; Learn explicitly recommends **Azure Service Bus Queues** as alternative. | Learn: *Work queues — Known limitations* |
-| "Cloud flow timeout caps desktop flow at 24 h / 4 h / pick a number" | The `Run a flow built with Power Automate Desktop` action accepts an ISO 8601 timeout (e.g., `PT10M`, `PT1H`); Learn does **not** publish a maximum value for the action timeout. The only documented hard envelope is the cloud flow run duration limit (**30 days**). | Learn: *Limits of automated, scheduled, and instant flows* |
-| "Custom assembly call counts and native action counts can be conflated" | Distinguish carefully when counting Work Queue usage: **native** calls use the `WORKQUEUES` module, while **custom assembly** calls use a project-specific namespace and method. A mix is common; report them in two separate columns ("native hits" vs "assembly hits"), never a single total. | Robin script convention; assembly source/manifest |
+| Myth (frequently asserted)                                                            | Verified fact                                                                                                                                                                                                                                                                                                                                                                                                 | Authoritative reference                                                                           |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| "Automation Center captures error screenshots automatically"                          | False. AC stores run history, status, recommendations, and queue health, but does **not** capture screenshots on error. The supported pattern is an explicit `Take screenshot` action wrapped by `On block error` or by exception-handling subflows.                                                                                                                                                          | Learn: _Troubleshoot failed unattended runs using screenshots_                                    |
+| "Use the Azure Application Insights connector ('Send to App Insights') for telemetry" | The Azure Application Insights connector is **deprecated and read-only** (it only ran Analytics queries; it never wrote telemetry). For Power Automate: enable App Insights integration at the **environment level** in Power Platform admin centre to capture cloud flows automatically; for desktop flow custom traces, use an HTTP action against the Application Insights ingestion endpoint.             | Learn: _Set up Application Insights for an environment_; Connectors reference (deprecated marker) |
+| "PAD has a 'Get files in folder' action under the System group"                       | The action lives under **Folder** group, not System.                                                                                                                                                                                                                                                                                                                                                          | Learn: _Folder actions reference_                                                                 |
+| "PAD has a 'Generate random text or number' action"                                   | The native action is **`Create random text`** under the **Text** group.                                                                                                                                                                                                                                                                                                                                       | Learn: _Text actions reference_                                                                   |
+| "PAD has a 'Convert custom object to datatable' action"                               | Does **not exist**. Variables actions provide `Convert JSON to custom object`, `Convert custom object to JSON`, and `Convert data table to text`. To produce a datatable from JSON, iterate the parsed custom object and use `Insert row into data table`, or perform the conversion in cloud-flow expressions.                                                                                               | Learn: _Variables actions_                                                                        |
+| "Unattended fails because Entra tokens expire"                                        | Most reports of this symptom are actually the **`Connect with sign-in` option being interactive-only** — it cannot reconnect a machine after sign-out without a logged-in session. Move to a self-hosted Machine Group with a service principal as connection identity. The `Entra token expiry` framing leads to wrong remediation (forced re-login scripts) instead of the correct one (service principal). | Learn: _Set up machines for desktop flows_; _Run desktop flows from a cloud flow_                 |
+| "Logs V1 with custom retention is fine"                                               | Logs V2 (Elastic Tables) supersedes V1. V2 provides **automatic data retention**, **near real-time updates**, and scales to GB of action logs per run. New environments default to V2; assessments should recommend V2 unless there is a hard incompatibility.                                                                                                                                                | Learn: _Desktop flow action logs configuration_                                                   |
+| "Work Queues can be parallelised aggressively"                                        | Learn-documented limit: keep dequeueing concurrency moderate — **up to five parallel dequeue operations per work queue is recommended**. For sub-second processing, Work Queues are not suitable; Learn explicitly recommends **Azure Service Bus Queues** as alternative.                                                                                                                                    | Learn: _Work queues — Known limitations_                                                          |
+| "Cloud flow timeout caps desktop flow at 24 h / 4 h / pick a number"                  | The `Run a flow built with Power Automate Desktop` action accepts an ISO 8601 timeout (e.g., `PT10M`, `PT1H`); Learn does **not** publish a maximum value for the action timeout. The only documented hard envelope is the cloud flow run duration limit (**30 days**).                                                                                                                                       | Learn: _Limits of automated, scheduled, and instant flows_                                        |
+| "Custom assembly call counts and native action counts can be conflated"               | Distinguish carefully when counting Work Queue usage: **native** calls use the `WORKQUEUES` module, while **custom assembly** calls use a project-specific namespace and method. A mix is common; report them in two separate columns ("native hits" vs "assembly hits"), never a single total.                                                                                                               | Robin script convention; assembly source/manifest                                                 |
 
 When the artifact under review claims any of the left-column statements, treat it as a finding (Medium severity by default) and cite the corrected fact in the report.
 
@@ -520,9 +567,9 @@ Severity guidance:
 
 ## Top risks
 
-| Priority | Severity | Area | Finding | Recommended action |
-|---|---|---|---|---|
-| 1 | High | Reliability | ... | ... |
+| Priority | Severity | Area        | Finding | Recommended action |
+| -------- | -------- | ----------- | ------- | ------------------ |
+| 1        | High     | Reliability | ...     | ...                |
 
 ## Detailed findings
 
@@ -531,12 +578,15 @@ Severity guidance:
 ## Remediation roadmap
 
 ### Quick wins (0-2 weeks)
+
 - ...
 
 ### Stabilization (2-6 weeks)
+
 - ...
 
 ### Structural improvements (6+ weeks)
+
 - ...
 
 ## Open questions and missing evidence
@@ -577,7 +627,7 @@ Use this checklist internally and include it when useful:
 ## Output style
 
 - Write formal assessment reports in English by default, even when the conversation is in another language, unless the user explicitly requests a different report language. Short chat explanations can still match the user's language.
-- Be concise but specific. Avoid generic best-practice filler.
+- Be detailed yet specific. Avoid generic best-practice filler.
 - When evidence is missing, say so clearly and lower confidence rather than guessing.
 - When using non-official/community sources, identify them as supplementary rather than authoritative.
 - If the user asks for an assessment report file, create the requested format only after confirming the intended deliverable type unless it is obvious from the request.

--- a/submissions/power-automate-desktop-assessment/SKILL.md
+++ b/submissions/power-automate-desktop-assessment/SKILL.md
@@ -1,0 +1,583 @@
+---
+name: power-automate-desktop-assessment
+description: Assess Power Automate Desktop and hybrid cloud/desktop automation projects for maintainability, reliability, security, performance, troubleshooting readiness, scaling, and governance using current Microsoft guidance and evidence-based review practices.
+---
+
+# Power Automate Desktop Assessment
+
+Use this skill when assessing, reviewing, or preparing recommendations for a Microsoft Power Automate Desktop (PAD) project, desktop flow, exported solution/package, cloud-flow orchestration around desktop flows, or related Power Platform automation artifacts. The goal is to produce an evidence-based assessment with findings, risks, severity, and actionable remediation.
+
+## Source references
+
+Use these references as the baseline for assessment criteria:
+
+### Microsoft Learn: Power Automate and enterprise guidance
+
+- Power Automate documentation hub: https://learn.microsoft.com/en-us/power-automate/
+- Power Automate guidance documentation: https://learn.microsoft.com/en-us/power-automate/guidance/
+- Power Automate planning guidance: https://learn.microsoft.com/en-us/power-automate/guidance/planning/introduction
+- Automation CoE guidance: https://learn.microsoft.com/en-us/power-automate/guidance/automation-coe/overview
+- Automation Kit guidance: https://learn.microsoft.com/en-us/power-automate/guidance/automation-kit/overview/introduction
+- Application lifecycle management for automation projects: https://learn.microsoft.com/en-us/power-automate/guidance/planning/application-lifecycle-management
+
+### Microsoft Learn: cloud flow coding guidelines
+
+- Cloud flow coding guidelines overview: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/
+- Naming conventions: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/use-consistent-naming-conventions
+- Solution-aware flows: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/understand-benefits-solution-aware-flows
+- Scopes: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/create-scopes
+- Child flows/reuse: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/create-reusable-code
+- Parallel execution and concurrency: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/implement-parallel-execution
+- Data operations: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/use-data-operations
+- Trigger optimization: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/optimize-power-automate-triggers
+- Work only with relevant data: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/work-with-relevant-data
+- Avoid anti-patterns: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/avoid-anti-patterns
+- Environment variables: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/use-environment-variables
+- Robust error handling: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/error-handling
+- Flow Checker: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/manage-flows-flow-checker
+- Test cloud flows: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/test-cloud-flows
+- Troubleshoot cloud flows: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/troubleshoot-cloud-flows
+- Platform limits and throttling: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/understand-limits
+- Secure inputs/outputs/triggers: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/use-secure-inputs-outputs-triggers
+- Generic configuration: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/keep-flow-configuration-generic
+- Flow ownership/access: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/understand-access-to-flows
+- Dataverse/Purview auditing: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/use-auditing-dataverse
+- Prevent data exfiltration: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/prevent-data-exfiltration
+- Monitoring and alerting: https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/monitoring-and-alerting
+
+### Microsoft Learn: desktop flow coding guidelines
+
+- Desktop flow coding guidelines overview: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/
+- Build readable and maintainable flow scripts: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/build-readable-flow-scripts
+- Optimize flow performance: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/optimize-flow-performance
+- Secure your data: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/secure-your-data
+- Optimize end-to-end process performance: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/optimize-end-to-end-performance
+- Monitor and troubleshoot automation processes: https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/monitor-automation
+
+### Microsoft Learn: desktop execution, diagnostics, and troubleshooting
+
+- Troubleshooter executable/app: https://learn.microsoft.com/en-us/power-automate/desktop-flows/troubleshooter
+- Troubleshoot desktop flows runtime: https://learn.microsoft.com/en-us/power-automate/desktop-flows/troubleshoot
+- Run desktop flows best practices: https://learn.microsoft.com/en-us/power-automate/desktop-flows/run-desktop-flows-best-practices
+- Run desktop flows concurrently: https://learn.microsoft.com/en-us/power-automate/desktop-flows/run-desktop-flows-concurrently
+- Run unattended desktop flows: https://learn.microsoft.com/en-us/power-automate/desktop-flows/run-unattended-desktop-flows
+- Machine groups: https://learn.microsoft.com/en-us/power-automate/desktop-flows/manage-machine-groups
+- Hosted RPA overview: https://learn.microsoft.com/en-us/power-automate/desktop-flows/hosted-rpa-overview
+- Work queues: https://learn.microsoft.com/en-us/power-automate/desktop-flows/work-queues
+- Desktop flow action logs configuration: https://learn.microsoft.com/en-us/power-automate/desktop-flows/configure-desktop-flow-logs
+- Static analysis for desktop flows: https://learn.microsoft.com/en-us/power-automate/desktop-flows/static-analysis
+- Cloud flow error troubleshooting: https://learn.microsoft.com/en-us/power-automate/troubleshoot-flow-errors
+- Cloud flow error code reference: https://learn.microsoft.com/en-us/power-automate/error-reference
+- Fix connection failures in cloud flows: https://learn.microsoft.com/en-us/power-automate/fix-connection-failures
+
+If live documentation is available, check current Microsoft guidance before finalizing recommendations. Prioritize Microsoft Learn over community sources. If documentation cannot be fetched, proceed with the criteria below and state that the assessment is based on the embedded baseline.
+
+## Microsoft Learn discovery workflow
+
+When this skill is used, start by searching current Microsoft guidance with the documentation or web retrieval tools available to the agent before relying on the embedded baseline.
+
+1. Start with the official Microsoft Learn URLs listed in **Source references**.
+2. Search Microsoft Learn to find:
+   - the current version of each referenced article;
+   - child/sub articles under the cloud flow coding guidelines and desktop flow coding guidelines sections;
+   - related troubleshooting, limits, security, ALM, monitoring, and governance articles;
+   - newer pages that supersede or redirect from the listed URLs.
+3. Retrieve the relevant article content and extract assessment criteria, not generic documentation summaries.
+4. Prefer official Microsoft Learn results over community content.
+5. Record which Microsoft Learn articles were actually consulted in the assessment report appendix.
+6. If documentation retrieval is unavailable, use the embedded baseline and explicitly mark the documentation confidence as limited.
+7. Do not skip Microsoft Learn discovery because the baseline is already present. The baseline is a fallback and checklist, not a replacement for current Microsoft Learn research.
+
+Suggested discovery queries:
+
+- `Power Automate desktop flow coding guidelines build readable maintainable flow scripts`
+- `Power Automate desktop flow optimize flow performance wait timeout loops unused components`
+- `Power Automate secure desktop flows credentials sensitive variables DLP audit logs`
+- `Power Automate optimize end-to-end process performance machine groups hosted machine groups work queues`
+- `Power Automate monitor troubleshoot desktop automation action logs V2 Automation center`
+- `Power Automate run desktop flows best practices timeout distribute load machine groups`
+- `Power Automate cloud flow coding guidelines naming conventions concurrency trigger conditions anti-patterns limits`
+- `Power Automate troubleshoot cloud flow errors 401 403 404 429 500`
+
+## Assessment principles
+
+- Be evidence-based: cite the file, flow, action, variable, selector, screenshot, exported artifact, run history, action log, or configuration record that supports each finding.
+- Do not rubber-stamp. Flag real maintainability, reliability, security, correctness, performance, scaling, and governance issues directly.
+- Separate required fixes from optional improvements.
+- Prefer pragmatic remediation that fits low-code/RPA delivery, not over-engineered software patterns.
+- Do not alter the user's automation unless explicitly asked. Assessment mode is read-only by default.
+- Treat exported flows, credentials, environment variables, logs, selectors, screenshots, run history, connection references, and machine details as potentially sensitive.
+- Clearly distinguish official Microsoft guidance from community or experience-based observations.
+
+## Inputs to inspect
+
+Depending on what the user provides, inspect as many of these as are available:
+
+- PAD desktop flow exports, solution ZIPs, extracted folders, scripts, UI selector definitions, images, dependencies, connection references, environment variables, machine/runtime configuration notes, run history, action logs, error logs, documentation, test evidence, cloud flows that trigger desktop flows, DLP policies, machine group/hosted machine group configuration, work queue configuration, and operational dashboards.
+- If a ZIP is provided, inspect its structure first, then extracted relevant metadata and flow definitions.
+- If only screenshots or notes are available, perform a partial assessment and clearly mark missing evidence.
+
+## Solution ZIP analysis patterns
+
+When assessing an exported Power Platform solution ZIP, extract and summarize these artifacts before writing findings:
+
+- `solution.xml`: solution unique name, version, managed/unmanaged status, publisher, and package metadata.
+- `customizations.xml`: solution components, component counts, entity/process metadata, and signs of unmanaged/customized artifacts.
+- `Workflows/*.json`: cloud flow definitions, triggers, actions, connection references, child-flow calls, desktop-flow calls, error handling, loops, scopes, variables, HTTP calls, waits, retry policies, and termination paths.
+- `environmentvariabledefinitions/*/environmentvariabledefinition.xml`: schema name, display name, type, required flag, default value presence, and secret store flag.
+- `desktopflowbinaries/*/data/*.json`: desktop flow manifest, engine version, module references, connector references, UI control repository, image repository, dependency file, screen/control counts, and use of UI/Web/File/System modules.
+
+For workflow metrics, capture:
+
+- number of workflows and total actions;
+- top action types;
+- connectors and connection references used;
+- largest workflows by action count;
+- `Foreach` count and maximum nested `Foreach` depth;
+- scope count and `runAfter` non-success paths;
+- retry policy count;
+- `Terminate` actions;
+- HTTP actions;
+- wait/delay actions;
+- child workflow / desktop flow references;
+- potential sensitive keyword classes in definitions, without printing secret values.
+
+Use these signals to drive findings:
+
+- very large workflows or duplicated `OLD` / `TEST` workflows retained in the solution;
+- nested loops or high loop counts that may create request, runtime, or throttling risk;
+- workflows with little or no structured error handling (`Scope`, non-success `runAfter`, `Terminate`, retry policy);
+- unmanaged solution packages intended for controlled environments;
+- environment variables with no defaults and no required flag where deployment validation depends on external configuration;
+- connection references for Outlook, OneDrive, Dataverse, filesystem, web content, or UI flows that need DLP/access review;
+- desktop flow binaries with UI/Web automation modules that require selector robustness and runtime diagnostics review;
+- generic names, misspellings, or artifacts named `OLD`, `TEST`, `Unknown`, or similar that indicate maintainability or ALM hygiene issues.
+
+## Recommended assessment automation workflow
+
+Use this workflow for solution ZIP assessments. Adapt paths to the user's workspace and requested output file.
+
+### 1. Extract the solution ZIP
+
+```powershell
+$zip = 'C:\path\to\solution.zip'
+$out = 'C:\path\to\workspace\solution_extract'
+if (Test-Path -LiteralPath $out) { Remove-Item -LiteralPath $out -Recurse -Force }
+New-Item -ItemType Directory -Path $out -Force | Out-Null
+Expand-Archive -LiteralPath $zip -DestinationPath $out -Force
+Get-ChildItem -LiteralPath $out -Recurse -File | Select-Object FullName, Length
+```
+
+### 2. Generate assessment metrics
+
+Create or reuse an analysis script that:
+
+- parses `solution.xml`;
+- reads `environmentvariabledefinitions/*/environmentvariabledefinition.xml`;
+- inspects `desktopflowbinaries/*/data/*.json`;
+- walks all `Workflows/*.json` recursively;
+- counts triggers, actions, action types, connectors, scopes, `Foreach`, maximum nested `Foreach` depth, `runAfter` non-success paths, retry policies, `Terminate`, HTTP actions, wait/delay actions, desktop/child-flow references, and sensitive keyword classes;
+- writes `assessment_metrics.json`.
+
+Key parser behaviors:
+
+- tolerate mixed JSON structures where `inputs`, `cases`, `else`, or `default` might be strings or objects;
+- never print secret values, only keyword classes or presence indicators;
+- keep file names for traceability but map them to friendly workflow names in the report.
+
+### 3. Create visual executive dashboard
+
+Generate a PNG dashboard when the report format supports images. The dashboard should include:
+
+- KPI cards: cloud flows, total actions, desktop artifacts, high-priority recommendations, nested-loop flows, ALM hygiene signals;
+- bar chart: top workflows by action count;
+- bar chart: recommendation hotspots by topic;
+- priority split: High / Medium / Low;
+- short interpretation bullets.
+
+Use an available charting or document-generation tool. If image generation is unavailable, use a compact table-based dashboard.
+
+### 4. Generate the assessment report
+
+Create the report in the user's requested format. If no format is requested, use Markdown. The report should be in English by default and organized as:
+
+1. Visual executive dashboard with KPI image and summary metrics.
+2. Executive summary.
+3. Priority recommendations grouped by artifact type:
+   - Cloud Flows
+   - Desktop Flow / PAD
+   - Environment Variables
+   - Solution-level artifacts
+4. Complete recommendations grouped by artifact type.
+5. Recommended next steps.
+
+Report structure requirements:
+
+- The assessment body must be written in English unless the user explicitly requests another report language.
+- Section 2 must be organized by artifact type, not by raw file order.
+- Use friendly artifact names in headings, followed by the artifact type in brackets, for example `LA - Email Forwarder - Performer Main [Cloud Flow]`.
+- Do not use raw JSON filenames as recommendation titles. Keep raw names only in the **Technical source** row for traceability.
+- Include a visual executive dashboard near the beginning of the report. Prefer a generated PNG image with KPI cards and charts. If image generation is unavailable, use visually formatted Word tables as a fallback.
+- The dashboard should show at least: cloud flow count, total cloud actions, desktop artifacts, high-priority recommendations, nested-loop workflows, ALM hygiene signals, top workflows by action count, recommendation hotspots by topic, and priority split.
+- The detailed recommendation sections should be actionable and not purely inventory-based. Each recommendation must state what was observed, the expected target state, the remediation approach, and the expected impact.
+
+For each recommendation, use professional headings:
+
+- **Technical source**
+- **Assessment area**
+- **Observed condition**
+- **Target state / best practice**
+- **Recommended remediation**
+- **Expected business/operational impact**
+- **Priority**
+
+Avoid using raw JSON filenames as section titles. Use a friendly workflow name plus artifact type, and keep the raw filename only as **Technical source**.
+
+### 5. Validate the report
+
+Validate the generated file with an appropriate format-specific validator when one is available. Confirm that headings, tables, images, links, and page layout render correctly before delivery.
+
+### 6. Output naming
+
+Use explicit report names:
+
+- `*_Assessment_BestPractices.docx` for the concise best-practices version.
+- `*_Assessment_DetailedRecommendations_EN.docx` for the full English detailed version with visual dashboard and workflow-level recommendations.
+
+If the target file is locked by Word or OneDrive, create a new versioned filename rather than overwriting.
+
+## Common myths and verified facts
+
+These are factually wrong claims that show up repeatedly in PAD assessments (and in partner-authored documents being reviewed). Always fact-check against current Microsoft Learn before accepting them as evidence — and call them out when they appear in the artifact under review.
+
+| Myth (frequently asserted) | Verified fact | Authoritative reference |
+|---|---|---|
+| "Automation Center captures error screenshots automatically" | False. AC stores run history, status, recommendations, and queue health, but does **not** capture screenshots on error. The supported pattern is an explicit `Take screenshot` action wrapped by `On block error` or by exception-handling subflows. | Learn: *Troubleshoot failed unattended runs using screenshots* |
+| "Use the Azure Application Insights connector ('Send to App Insights') for telemetry" | The Azure Application Insights connector is **deprecated and read-only** (it only ran Analytics queries; it never wrote telemetry). For Power Automate: enable App Insights integration at the **environment level** in Power Platform admin centre to capture cloud flows automatically; for desktop flow custom traces, use an HTTP action against the Application Insights ingestion endpoint. | Learn: *Set up Application Insights for an environment*; Connectors reference (deprecated marker) |
+| "PAD has a 'Get files in folder' action under the System group" | The action lives under **Folder** group, not System. | Learn: *Folder actions reference* |
+| "PAD has a 'Generate random text or number' action" | The native action is **`Create random text`** under the **Text** group. | Learn: *Text actions reference* |
+| "PAD has a 'Convert custom object to datatable' action" | Does **not exist**. Variables actions provide `Convert JSON to custom object`, `Convert custom object to JSON`, and `Convert data table to text`. To produce a datatable from JSON, iterate the parsed custom object and use `Insert row into data table`, or perform the conversion in cloud-flow expressions. | Learn: *Variables actions* |
+| "Unattended fails because Entra tokens expire" | Most reports of this symptom are actually the **`Connect with sign-in` option being interactive-only** — it cannot reconnect a machine after sign-out without a logged-in session. Move to a self-hosted Machine Group with a service principal as connection identity. The `Entra token expiry` framing leads to wrong remediation (forced re-login scripts) instead of the correct one (service principal). | Learn: *Set up machines for desktop flows*; *Run desktop flows from a cloud flow* |
+| "Logs V1 with custom retention is fine" | Logs V2 (Elastic Tables) supersedes V1. V2 provides **automatic data retention**, **near real-time updates**, and scales to GB of action logs per run. New environments default to V2; assessments should recommend V2 unless there is a hard incompatibility. | Learn: *Desktop flow action logs configuration* |
+| "Work Queues can be parallelised aggressively" | Learn-documented limit: keep dequeueing concurrency moderate — **up to five parallel dequeue operations per work queue is recommended**. For sub-second processing, Work Queues are not suitable; Learn explicitly recommends **Azure Service Bus Queues** as alternative. | Learn: *Work queues — Known limitations* |
+| "Cloud flow timeout caps desktop flow at 24 h / 4 h / pick a number" | The `Run a flow built with Power Automate Desktop` action accepts an ISO 8601 timeout (e.g., `PT10M`, `PT1H`); Learn does **not** publish a maximum value for the action timeout. The only documented hard envelope is the cloud flow run duration limit (**30 days**). | Learn: *Limits of automated, scheduled, and instant flows* |
+| "Custom assembly call counts and native action counts can be conflated" | Distinguish carefully when counting Work Queue usage: **native** calls use the `WORKQUEUES` module, while **custom assembly** calls use a project-specific namespace and method. A mix is common; report them in two separate columns ("native hits" vs "assembly hits"), never a single total. | Robin script convention; assembly source/manifest |
+
+When the artifact under review claims any of the left-column statements, treat it as a finding (Medium severity by default) and cite the corrected fact in the report.
+
+## Assessment workflow
+
+1. Understand context
+   - Identify business process, trigger/orchestration model, attended vs unattended execution, target applications, expected volume, SLA, users, environments, failure impact, regulatory constraints, and support ownership.
+   - Identify the project structure and main desktop flows/subflows/cloud flows.
+
+2. Inventory the automation
+   - List desktop flows, subflows, cloud orchestration flows, key actions, external systems, files/folders, applications automated, credentials/secrets touchpoints, connectors, connection references, environment variables, machine groups, work queues, and environment-specific assumptions.
+
+3. Review using the assessment dimensions below
+   - For every significant finding, capture evidence, impact, severity, and recommendation.
+   - Use severity labels: Critical, High, Medium, Low, Observation.
+
+4. Produce a report
+   - Start with executive summary and overall health rating.
+   - Include strengths, key risks, prioritized findings, remediation roadmap, and open questions.
+   - Include quick wins separately from structural remediation.
+
+5. Fact-check pass before finalize
+   - Treat the report as a draft until an explicit fact-check pass is done. Do **not** ship v1 without it; bugs in numerical claims and action-name mismatches damage credibility with technical reviewers far more than a missing recommendation.
+   - Audit chapter-by-chapter (or section-by-section). For each chapter, classify every assertable claim as verified / ambiguous / wrong, with a one-line reason and a Microsoft Learn citation for the non-trivial ones.
+   - Categories of claims to check exhaustively:
+     - **Native PAD action names** — exact group + action name as published in Learn (groups change: Folder != System; Text != Variables). Do not rely on memory.
+     - **Connector names and status** — many connectors are deprecated, renamed, or read-only. Always verify status flags on the connector reference page.
+     - **Numerical metrics** — counts, line numbers, callsite distributions must reconcile against the raw scripts and against the metrics JSON. Re-run greps if a number was edited.
+     - **Throughput math** — verify it is internally consistent (items/day x seconds/item x machines should reconcile).
+     - **Platform limits** — five parallel dequeue ops per queue, sub-second -> Service Bus, 30-day cloud flow envelope, etc. Cite Learn verbatim.
+     - **Internal cross-references** — section X says "see section Y"; section Y must still exist and still say what X claims.
+     - **Carry-over consistency** — when a fix is applied in one chapter, search the whole document for the obsolete wording; the same myth often appears in 3-5 places (executive summary, scorecard rationale, top-N priorities, glossary, roadmap card).
+   - Present fact-check findings clearly and correct unsupported claims before finalizing the report.
+   - Apply each correction consistently across all language and audience variants, then rebuild and revalidate every output.
+
+## Assessment dimensions
+
+### 1. Correctness and functional fit
+
+Check whether the automation appears to implement the intended process correctly.
+
+- Are business rules explicit and traceable?
+- Are edge cases handled: empty inputs, missing files, duplicate records, invalid formats, application timeouts, unexpected UI states, locked records, partial completion, stale reads, polling-trigger backlogs, and target resource changes?
+- Are there clear start/end states and idempotency considerations for reruns?
+- Are manual handoffs and exception paths defined?
+- Are assumptions about screen resolution, language, data formats, dates, paths, user profile, browser version, and machine state documented?
+- If cloud flows orchestrate desktop flows, do trigger behavior and trigger conditions match the intended processing window and avoid unintended reruns?
+
+### 2. Maintainability and readability
+
+Assess whether another maker/developer can understand and safely change the flow.
+
+- Flow, subflow, action, variable, UI element, image, and parameter names should be descriptive and consistent.
+- For desktop variables, check whether camelCase, PascalCase, or underscores are used consistently, whether data type prefixes are used, and whether input/output variables have prefixes in both variable name and external name.
+- For cloud flow components, check descriptive names, consistent camelCase/underscore style, and optional prefixes/tags such as `Trg_`, `Act_`, or `Var_` when this matches team standards.
+- Avoid generic names such as `var`, `temp`, `data`, `result`, `NewVar`, `Button`, `Trigger1`, or unexplained abbreviations.
+- Check whether naming conventions are documented in a style guide/wiki for the maker community.
+- Related actions should be grouped logically. For desktop flows, look for `Region` / `End region` actions to group actions inside a subflow where useful.
+- Long flows should be decomposed into meaningful subflows or reusable child desktop flows.
+- Use comments at the beginning of `Main`, each subflow, and bug-fix sections to describe purpose, intended audience, related flows, and non-obvious design decisions.
+- Avoid excessive nesting, duplicated action blocks, many skipped actions inside large switch branches, and hidden dependencies between distant actions.
+- Dead, disabled, unused UI elements, and unused images should be justified or removed.
+
+### 3. Architecture, design, and reuse
+
+Assess whether the solution is structured for scale and supportability.
+
+- Clear separation between orchestration, business rules, UI automation, data access, logging, exception handling, and notification.
+- Reusable subflows for repeated behavior within a desktop flow.
+- Reusable child desktop flows for shared components across desktop flows, invoked via `Run desktop flow` where appropriate.
+- Shared UI element collections should be used when the same application UI elements are reused across flows, so UI changes can be fixed centrally.
+- Custom actions may be appropriate when repeated behavior needs a packaged reusable action.
+- Avoid tight coupling to a single machine, user profile, screen layout, locale, hard-coded path, or unmanaged machine state.
+- Use environment variables/configuration for environment-specific values where applicable.
+- Prefer supported APIs, cloud connectors, or application/file-specific PAD actions over UI automation when reliable interfaces exist.
+- For desktop action choice, prefer in this order: cloud connector actions, application/file-specific desktop actions, UI/browser automation, then image recognition/OCR/mouse/keyboard/clipboard. Consider scripting or HTTP actions for advanced cases when maintainable and governed.
+- Consider ALM: solution packaging, source control/export process, version control, dev/test/prod separation, deployment notes, ownership, and rollback plan.
+
+### 4. Error handling and resilience
+
+Use Microsoft guidance patterns where applicable.
+
+- Desktop flows should use action-level `On error` parameters, `On block error` for groups of actions, `Get last error` to capture diagnostic context, and `Stop flow` for graceful terminal failures.
+- Cloud flows should use `Run after` settings and scopes to implement try/catch-style error paths, and `Terminate` where failure state must be explicit.
+- Errors should be classified as recoverable vs terminal.
+- Retry policies should be used for transient failures, with bounded retries and backoff where possible.
+- Failures should surface meaningful messages and preserve diagnostic context.
+- Logging should capture run ID/correlation ID, step, input reference, error details, last error, retry status, and outcome without leaking secrets.
+- Termination paths should make failure state explicit and prevent unsafe continuation after critical errors.
+- Avoid excessive custom logging/actions that materially degrade performance or increase action/request consumption.
+- If run history shows errors, distinguish save errors, trigger issues, action errors, logic issues, runtime connectivity issues, queue errors, and environment/machine issues.
+
+### 5. Security, privacy, and access control
+
+Assess data protection, credentials, access, and exposure risk.
+
+- No passwords, tokens, keys, secrets, or personal data hard-coded in flows, scripts, comments, logs, paths, screenshots, sample files, connection strings, or notifications.
+- Prefer Power Automate credentials backed by Azure Key Vault or CyberArk for desktop-flow credentials.
+- In desktop flows, prefer `Get credential` for sensitive values instead of passing secrets as input variables.
+- Mark all sensitive input, output, and flow variables as sensitive. Do not copy sensitive values into non-sensitive variables, because sensitivity does not automatically propagate except for credential variable types.
+- For desktop flow connections, use dedicated credentials and machine mapping where machines require separate accounts.
+- Check whether MFA/certificate-based authentication requirements are met where relevant.
+- Review access to desktop flows and related components: child desktop flows, work queues, credentials, UI element collections, custom actions, connection references, and connector actions.
+- Apply least privilege to owner/co-owner/user roles and Dataverse security roles; verify whether broad Process table read access grants unintended co-owner visibility.
+- Sensitive input/output files should be stored in approved locations with appropriate access controls and retention.
+- Logs and notifications should not expose confidential records unnecessarily.
+- Validate external data before using it in decisions, file paths, commands, scripts, browser input, UI automation, HTTP calls, or generated messages.
+- Review use of scripts, command execution, clipboard, email sending, file deletion, and external network calls.
+- Check DLP policies for desktop flow action groups, connector classification as Business/Non-business/Blocked, and individual connector action controls.
+- Check whether Dataverse auditing and/or Microsoft Purview auditing is enabled for automation-related tables where needed.
+
+### 6. Performance and runtime efficiency
+
+Assess runtime efficiency and operational scalability.
+
+- Avoid unnecessary UI interactions, repeated application launches, fixed sleeps, row-by-row processing, nested loops, and expensive selectors when batching or data actions are possible.
+- Prefer explicit `Wait for...` actions with timeouts over generic `Wait` actions.
+- Configure desktop flow timeout appropriately for expected duration.
+- Check loops for upper bounds, exit conditions, and large dataset risks.
+- For Excel/data-heavy flows, prefer Data table actions, Database actions, Power Fx functions, or maintainable scripting rather than looping through thousands of records in UI actions.
+- Remove unused components, disabled actions, unused UI elements, and unused images to reduce size and save/load time.
+- Identify high-volume paths, repeated file/network I/O, unbounded reads, action overages, and connector/API throttling risks.
+- Capture expected and observed runtime where available.
+
+### 7. Cloud-flow orchestration, concurrency, and API optimization
+
+Use this dimension when cloud flows trigger or coordinate desktop flows, or when the assessment includes cloud flows.
+
+- Use trigger conditions and OData filters so flows run only when necessary.
+- Understand polling vs webhook trigger behavior, especially backlog processing when a disabled polling-trigger flow is re-enabled.
+- Use trigger concurrency control carefully; default is often safest, and concurrency control is irreversible on an existing flow.
+- Use parallel branches only for independent tasks, especially tasks taking more than five seconds, and avoid overwhelming endpoints.
+- Use `Apply to each` concurrency for independent items only; tune degree of parallelism instead of assuming 50 is best.
+- Remember concurrency in nested `Apply to each` loops applies only at the highest level; inner loops remain sequential.
+- Avoid large switch branches with many skipped actions; call child flows from branches when this improves maintainability.
+- Process only relevant data: use trigger-level filters, Dataverse OData filters/select columns/row count, SharePoint filter query/top count/limit columns by view.
+- Avoid nested `For each` loops. Use OData expansion, Select, filtering, batching, bulk operations, or dataflows where appropriate.
+- Avoid using cloud flows as heavy ETL engines for large-scale transformations; consider Power Platform dataflows for ETL and cloud flows for orchestration.
+- Estimate API request usage: triggers/actions, loops, retries, pagination, and failed actions count toward limits. Watch for 429 throttling.
+- Review platform limits: API request limits, connector throttling, Dataverse service protection limits, flow concurrency limits, action burst limits, and flow design limits.
+
+### 8. Execution scaling, workload distribution, and machine strategy
+
+Assess whether the automation can run at the required volume and SLA.
+
+- Desktop flows can queue for up to 12 hours while waiting for a machine; assess whether scheduling and capacity avoid timeout/failure risk.
+- Spread load over time where possible if machine capacity is limited.
+- Use machine groups for identical machine configurations and dynamic workload distribution.
+- Use hosted machine groups when automatic scaling, Microsoft-managed maintenance, high availability, and reduced infrastructure overhead are appropriate.
+- In cloud flows, consider parallel branches of `Run a flow built with Power Automate for desktop` only when desktop flow instances can safely run concurrently across machines/machine groups.
+- Anticipate unattended parallel run volume and confirm licensing/capacity is adequate.
+- For long-running desktop flows, verify the cloud action timeout is configured to cover expected run duration.
+- Track CPU, memory, network, and app resource usage on machines that run flows.
+- Consider Windows session reuse only when compliance and machine state requirements allow it.
+- For attended scenarios, consider picture-in-picture when the user must keep working while automation runs.
+- Use work queues to decouple complex processes, store work items, control prioritization/expiration/status, and support asynchronous scaling.
+
+### 9. UI automation robustness
+
+PAD-specific review focus.
+
+- Selectors should be stable and resilient; avoid brittle coordinates, image-only matching, text that changes frequently, or unvalidated mouse/keyboard automation when better selectors or actions exist.
+- UI element names should be clear and organized, preferably via shared UI element collections for reused assets.
+- The flow should handle application startup, login/session state, pop-ups, loading states, focus issues, unexpected dialogs, browser extension state, virtual desktop quirks, and reconnects.
+- Clipboard use should be minimized or guarded because it is shared mutable state.
+- Keyboard/mouse actions should be deterministic and validated with post-action checks.
+- Screenshots/image recognition and OCR should have documented thresholds, fallback behavior, and justification when used instead of more reliable actions.
+
+### 10. Observability, diagnostics, and supportability
+
+Assess whether operations teams can support the automation.
+
+- Run history and business transaction status should be traceable.
+- Configure desktop flow action logs to V2 where appropriate. Logs V2 use Elastic Tables, provide retention, can scale to high-volume logs, and support near real-time/progressive action logging.
+- Use `Log message` with Info/Warning/Error severity to record progress and important details.
+- Use `Display message` for attended user interaction/debugging where appropriate, knowing it is also logged.
+- Use custom logging to Dataverse, SharePoint, or files only when justified and governed.
+- Alerts should be actionable and routed to the right owner.
+- Include enough context for triage: process instance, record/file identifier, failed step, error type, last error, retry status, machine/machine group, and run URL where available.
+- Review Automation center reports: cloud flow activity, desktop flow activity, desktop flow runs, capacity utilization, recommendations, process map, execution logs, and performance metrics.
+- Review tenant-level Power Platform admin center Monitor page where enterprise-wide health is relevant.
+- For advanced reporting, consider Microsoft Fabric / OneLake integration for automation-centric analytics.
+- There should be clear support documentation: prerequisites, recovery steps, restart/rerun process, known issues, escalation contacts, and ownership.
+
+### 11. Troubleshooting readiness
+
+Check whether the project and operating model can diagnose failures quickly.
+
+- Know whether the local Power Automate for desktop Troubleshooter can be run via Help > Troubleshooter or `PAD.Troubleshooter.exe`.
+- Troubleshooter diagnostic categories include connectivity, sign-in, Dataverse, UI/Web automation, picture-in-picture, installation issues, and connectivity for cloud runtime.
+- Check whether generated troubleshooter CSV reports and exported logs are captured for incident analysis when needed.
+- For desktop runtime connectivity, confirm `UIFlowService` can reach required services such as `*.dynamics.com`, `*.servicebus.windows.net`, `*.gateway.prod.island.powerapps.com`, and `*.api.powerplatform.com`.
+- If connectivity works in an interactive user session but fails via service, review `NT SERVICE\UIFlowService` privileges, proxy rules, and service account configuration.
+- For virtual desktop/RDP/Citrix issues, verify correct PAD version, agent for virtual desktops, reconnect steps, and plugin registration if applicable.
+- Use verbose logging only to reproduce and capture issues, then turn it off because it can reduce performance and consume disk capacity.
+- For cloud failures, classify using save errors, trigger issues, action errors, logic issues, and common error codes: 401 auth, 403 permission/DLP, 404 missing resource, 429 rate limit, 500 service/server issue.
+- For expression errors, check missing branches, wrong data types, nulls, syntax, references to steps that did not execute, and use `coalesce()` or explicit empty checks where appropriate.
+
+### 12. Testing and verification
+
+Assess test quality and release readiness.
+
+- Evidence of unit-like subflow testing, end-to-end testing, negative/error-path testing, regression testing, and operational smoke tests.
+- Test data should cover happy path, empty inputs, invalid inputs, boundary cases, duplicate records, unavailable apps, permission failures, throttling/rate limits, machine unavailable, application update/UI change, and rerun/idempotency scenarios.
+- Tests should verify business outcomes, not just that the flow ran.
+- Include deployment validation and smoke tests for each environment.
+- Review whether Flow Checker, Power CAT Toolkit, static analysis for desktop flows, or equivalent tooling was used where applicable.
+
+### 13. Governance, CoE, and compliance
+
+Assess alignment with Power Platform governance.
+
+- Ownership, service account model, environment strategy, DLP policy alignment, connector usage, licensing, machine group usage, and monitoring responsibilities should be clear.
+- Confirm solution packaging and ALM practices for enterprise maintainability.
+- Assess whether the automation fits the organization's CoE operating model, environment strategy, maker support model, monitoring/reporting model, and adoption maturity.
+- Consider Automation Kit / Automation Center for enterprise-scale monitoring, exception rules, DLP impact analysis, desktop flow audit logs, scheduler, and historical voluminous data monitoring.
+- Check whether the business impact, ROI, risk, and process mining insights are captured for continuous improvement.
+
+## Finding format
+
+Use this format for each finding:
+
+```markdown
+### [Severity] Short finding title
+
+**Evidence:** File/flow/action/subflow/log/run/configuration reference and what was observed.
+**Impact:** Why it matters for correctness, maintenance, reliability, security, performance, scaling, or governance.
+**Recommendation:** Specific remediation steps.
+**Effort:** Low/Medium/High.
+**Owner:** Maker/Developer/Admin/Business owner/Operations/CoE, if inferable.
+```
+
+Severity guidance:
+
+- Critical: likely data loss, security exposure, unsafe execution, material compliance breach, or automation cannot reliably run.
+- High: significant production reliability, maintainability, supportability, scalability, or compliance risk.
+- Medium: meaningful issue that should be fixed in the next planned iteration.
+- Low: minor improvement or localized maintainability issue.
+- Observation: informational context, good practice, positive finding, or future consideration.
+
+## Report template
+
+```markdown
+# Power Automate Desktop Assessment
+
+## Executive summary
+
+**Overall health:** Red/Amber/Green
+**Assessment confidence:** High/Medium/Low
+**Scope reviewed:** ...
+**Key conclusion:** ...
+
+## Strengths
+
+- ...
+
+## Top risks
+
+| Priority | Severity | Area | Finding | Recommended action |
+|---|---|---|---|---|
+| 1 | High | Reliability | ... | ... |
+
+## Detailed findings
+
+[Use finding format]
+
+## Remediation roadmap
+
+### Quick wins (0-2 weeks)
+- ...
+
+### Stabilization (2-6 weeks)
+- ...
+
+### Structural improvements (6+ weeks)
+- ...
+
+## Open questions and missing evidence
+
+- ...
+
+## Appendix: Inventory
+
+- Desktop flows/subflows/cloud flows reviewed
+- External systems and dependencies
+- Machine/machine group/hosted machine group/work queue configuration reviewed
+- Sensitive-data touchpoints
+- Test/log/run history evidence reviewed
+- Relevant Microsoft Learn references used
+```
+
+## Assessment checklist
+
+Use this checklist internally and include it when useful:
+
+- [ ] Project inventory completed
+- [ ] Business process and run model understood
+- [ ] Cloud orchestration reviewed, if present
+- [ ] Naming and readability reviewed
+- [ ] Comments, regions, subflows, and reusable components reviewed
+- [ ] UI selector robustness reviewed
+- [ ] Error handling and retry behavior reviewed
+- [ ] Logging/monitoring/action logs reviewed
+- [ ] Troubleshooter/diagnostics readiness reviewed
+- [ ] Security, sensitive variables, credentials, access, and DLP reviewed
+- [ ] Performance/scalability/concurrency reviewed
+- [ ] Machine groups/hosted machines/work queues reviewed, if applicable
+- [ ] Platform limits/throttling/API request usage reviewed
+- [ ] ALM/governance/CoE reviewed
+- [ ] Testing evidence reviewed
+- [ ] Findings prioritized with severity and effort
+
+## Output style
+
+- Write formal assessment reports in English by default, even when the conversation is in another language, unless the user explicitly requests a different report language. Short chat explanations can still match the user's language.
+- Be concise but specific. Avoid generic best-practice filler.
+- When evidence is missing, say so clearly and lower confidence rather than guessing.
+- When using non-official/community sources, identify them as supplementary rather than authoritative.
+- If the user asks for an assessment report file, create the requested format only after confirming the intended deliverable type unless it is obvious from the request.

--- a/submissions/power-automate-desktop-assessment/metadata.json
+++ b/submissions/power-automate-desktop-assessment/metadata.json
@@ -3,7 +3,7 @@
   "description": "Assess Power Automate Desktop and hybrid automation projects with evidence-based findings and prioritized remediation guidance.",
   "platforms": ["Cowork", "Copilot Studio", "Scout"],
   "tags": ["power-automate", "desktop-flows", "automation", "assessment", "governance"],
-  "version": "1.0.0",
+  "version": "1.1.0",
   "createdAt": "2026-07-17",
-  "updatedAt": "2026-07-17"
+  "updatedAt": "2026-07-18"
 }

--- a/submissions/power-automate-desktop-assessment/metadata.json
+++ b/submissions/power-automate-desktop-assessment/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "Power Automate Desktop Assessment",
+  "description": "Assess Power Automate Desktop and hybrid automation projects with evidence-based findings and prioritized remediation guidance.",
+  "platforms": ["Cowork", "Copilot Studio", "Scout"],
+  "tags": ["power-automate", "desktop-flows", "automation", "assessment", "governance"],
+  "version": "1.0.0",
+  "createdAt": "2026-07-17",
+  "updatedAt": "2026-07-17"
+}

--- a/submissions/power-automate-desktop-assessment/metadata.json
+++ b/submissions/power-automate-desktop-assessment/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Power Automate Desktop Assessment",
   "description": "Assess Power Automate Desktop and hybrid automation projects with evidence-based findings and prioritized remediation guidance.",
-  "platforms": ["Cowork", "Copilot Studio", "Scout"],
+  "platforms": ["Cowork", "Copilot Studio"],
   "tags": ["power-automate", "desktop-flows", "automation", "assessment", "governance"],
   "version": "1.1.0",
   "createdAt": "2026-07-17",

--- a/submissions/power-automate-desktop-assessment/scripts/analyze_solution.py
+++ b/submissions/power-automate-desktop-assessment/scripts/analyze_solution.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import re
+from typing import Iterator
+import xml.etree.ElementTree as ET
+
+
+GUID_SUFFIX = re.compile(
+    r"-[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+API_ID_PATTERN = re.compile(
+    r"/providers/Microsoft\.PowerApps/apis/([^/\"\\]+)",
+    re.IGNORECASE,
+)
+SENSITIVE_KEY_PATTERNS = {
+    "password": re.compile(r"password", re.IGNORECASE),
+    "secret": re.compile(r"secret", re.IGNORECASE),
+    "token": re.compile(r"token", re.IGNORECASE),
+    "credential": re.compile(r"credential", re.IGNORECASE),
+    "authorization": re.compile(r"authorization|bearer", re.IGNORECASE),
+    "key": re.compile(
+        r"(^|[-_])(api|access|private|client)?[-_]?key($|[-_])",
+        re.IGNORECASE,
+    ),
+}
+
+
+def load_json(path: Path) -> object:
+    with path.open("r", encoding="utf-8-sig") as stream:
+        return json.load(stream)
+
+
+def write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        json.dump(data, stream, ensure_ascii=False, indent=2)
+        stream.write("\n")
+
+
+def get_definition(data: object) -> dict[str, object]:
+    if not isinstance(data, dict):
+        return {}
+    properties = data.get("properties")
+    if not isinstance(properties, dict):
+        properties = {}
+    definition = properties.get("definition") or data.get("definition") or {}
+    return definition if isinstance(definition, dict) else {}
+
+
+def friendly_name(filename: str) -> str:
+    stem = Path(filename).stem
+    stem = GUID_SUFFIX.sub("", stem)
+    return re.sub(r"[-_]+", " ", stem).strip()
+
+
+def walk_actions(
+    actions: object,
+    *,
+    prefix: str = "",
+    foreach_depth: int = 0,
+) -> Iterator[dict[str, object]]:
+    if not isinstance(actions, dict):
+        return
+
+    for name, raw_action in actions.items():
+        if not isinstance(raw_action, dict):
+            continue
+
+        action_type = str(raw_action.get("type") or "Unknown")
+        current_path = f"{prefix}/{name}" if prefix else str(name)
+        current_depth = foreach_depth + int(action_type.lower() == "foreach")
+        yield {
+            "path": current_path,
+            "name": str(name),
+            "type": action_type,
+            "foreachDepth": current_depth,
+            "runAfter": raw_action.get("runAfter")
+            if isinstance(raw_action.get("runAfter"), dict)
+            else {},
+            "inputs": raw_action.get("inputs"),
+            "raw": raw_action,
+        }
+
+        yield from walk_actions(
+            raw_action.get("actions"),
+            prefix=current_path,
+            foreach_depth=current_depth,
+        )
+
+        else_block = raw_action.get("else")
+        if isinstance(else_block, dict):
+            yield from walk_actions(
+                else_block.get("actions"),
+                prefix=f"{current_path}/else",
+                foreach_depth=current_depth,
+            )
+
+        cases = raw_action.get("cases")
+        if isinstance(cases, dict):
+            for case_name, case_value in cases.items():
+                if isinstance(case_value, dict):
+                    yield from walk_actions(
+                        case_value.get("actions"),
+                        prefix=f"{current_path}/case:{case_name}",
+                        foreach_depth=current_depth,
+                    )
+
+        default_block = raw_action.get("default")
+        if isinstance(default_block, dict):
+            yield from walk_actions(
+                default_block.get("actions"),
+                prefix=f"{current_path}/default",
+                foreach_depth=current_depth,
+            )
+
+
+def sensitive_keyword_classes(node: object) -> list[str]:
+    matches: set[str] = set()
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                key_text = str(key)
+                for keyword_class, pattern in SENSITIVE_KEY_PATTERNS.items():
+                    if pattern.search(key_text):
+                        matches.add(keyword_class)
+                visit(child)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child)
+
+    visit(node)
+    return sorted(matches)
+
+
+def connector_names(data: object, definition: dict[str, object]) -> list[str]:
+    connectors: set[str] = set()
+
+    if isinstance(data, dict):
+        properties = data.get("properties")
+        if isinstance(properties, dict):
+            references = properties.get("connectionReferences")
+            if isinstance(references, dict):
+                for reference in references.values():
+                    if not isinstance(reference, dict):
+                        continue
+                    api = reference.get("api")
+                    if isinstance(api, dict) and api.get("name"):
+                        connectors.add(str(api["name"]))
+
+    serialized = json.dumps(definition, ensure_ascii=False)
+    connectors.update(API_ID_PATTERN.findall(serialized))
+    return sorted(connectors)
+
+
+def has_non_success_run_after(action: dict[str, object]) -> bool:
+    run_after = action["runAfter"]
+    if not isinstance(run_after, dict):
+        return False
+    for statuses in run_after.values():
+        values = statuses if isinstance(statuses, list) else [statuses]
+        if any(str(status).lower() != "succeeded" for status in values):
+            return True
+    return False
+
+
+def has_retry_policy(action: dict[str, object]) -> bool:
+    raw = action["raw"]
+    if not isinstance(raw, dict):
+        return False
+    if isinstance(raw.get("retryPolicy"), dict):
+        return True
+    inputs = raw.get("inputs")
+    if isinstance(inputs, dict) and isinstance(inputs.get("retryPolicy"), dict):
+        return True
+    runtime = raw.get("runtimeConfiguration")
+    return isinstance(runtime, dict) and isinstance(runtime.get("retryPolicy"), dict)
+
+
+def is_http_like(action: dict[str, object]) -> bool:
+    action_type = str(action["type"]).lower()
+    if action_type == "http":
+        return True
+    inputs = action["inputs"]
+    if not isinstance(inputs, dict):
+        return False
+    host = inputs.get("host")
+    if isinstance(host, dict):
+        operation = str(host.get("operationId") or "")
+        api_id = str(host.get("apiId") or "")
+        return "http" in operation.lower() or "webcontents" in api_id.lower()
+    return "uri" in inputs and "method" in inputs
+
+
+def is_child_or_desktop_reference(action: dict[str, object]) -> bool:
+    if str(action["type"]).lower() == "workflow":
+        return True
+    inputs = action["inputs"]
+    if not isinstance(inputs, dict):
+        return False
+    host = inputs.get("host")
+    if isinstance(host, dict) and "uiflow" in str(host.get("apiId") or "").lower():
+        return True
+    return False
+
+
+def read_solution(root: Path) -> dict[str, object]:
+    path = root / "solution.xml"
+    if not path.is_file():
+        raise FileNotFoundError(f"Required solution.xml not found under {root}")
+
+    document = ET.parse(path).getroot()
+    publisher = document.find(".//Publisher")
+    missing_dependencies = document.findall(
+        ".//MissingDependencies/MissingDependency"
+    )
+    return {
+        "uniqueName": document.findtext(".//UniqueName") or "",
+        "version": document.findtext(".//Version") or "",
+        "managed": document.findtext(".//Managed") or "",
+        "publisher": publisher.findtext("UniqueName")
+        if publisher is not None
+        else "",
+        "rootComponentCount": len(document.findall(".//RootComponents/RootComponent")),
+        "missingDependencyCount": len(missing_dependencies),
+    }
+
+
+def read_customizations(root: Path) -> dict[str, object]:
+    path = root / "customizations.xml"
+    if not path.is_file():
+        return {
+            "present": False,
+            "file": "customizations.xml",
+            "size": 0,
+            "componentCounts": {},
+        }
+
+    document = ET.parse(path).getroot()
+    element_counts = Counter(
+        element.tag.rsplit("}", 1)[-1].casefold()
+        for element in document.iter()
+    )
+    tracked_components = {
+        "Entity": "entity",
+        "Workflow": "workflow",
+        "Role": "role",
+        "OptionSet": "optionset",
+        "WebResource": "webresource",
+        "EntityRelationship": "entityrelationship",
+    }
+    return {
+        "present": True,
+        "file": "customizations.xml",
+        "size": path.stat().st_size,
+        "rootElement": document.tag.rsplit("}", 1)[-1],
+        "componentCounts": {
+            label: element_counts[normalized_name]
+            for label, normalized_name in tracked_components.items()
+            if element_counts[normalized_name]
+        },
+    }
+
+
+def read_environment_variables(root: Path) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    env_root = root / "environmentvariabledefinitions"
+    if not env_root.is_dir():
+        return result
+
+    for path in sorted(env_root.rglob("environmentvariabledefinition.xml")):
+        definition = ET.parse(path).getroot()
+        label = definition.find("./displayname/label")
+        default_value = definition.find("defaultvalue")
+        result.append(
+            {
+                "file": path.relative_to(root).as_posix(),
+                "schemaName": definition.attrib.get("schemaname")
+                or path.parent.name,
+                "displayName": label.attrib.get("description", "")
+                if label is not None
+                else "",
+                "type": definition.findtext("type") or "",
+                "secretStore": definition.findtext("secretstore") or "",
+                "required": definition.findtext("isrequired") or "",
+                "defaultValuePresent": default_value is not None
+                and bool((default_value.text or "").strip()),
+            }
+        )
+    return result
+
+
+def read_desktop_binaries(root: Path) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    binary_root = root / "desktopflowbinaries"
+    if not binary_root.is_dir():
+        return result
+
+    for path in sorted(binary_root.rglob("*.json")):
+        data = load_json(path)
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected a JSON object in {path}")
+
+        modules = data.get("ModuleReferences")
+        screens = data.get("Screens")
+        images = data.get("Images")
+        connectors = data.get("ConnectorReferences")
+        result.append(
+            {
+                "file": path.relative_to(root).as_posix(),
+                "size": path.stat().st_size,
+                "kind": path.name.split("_", 1)[0],
+                "keys": sorted(str(key) for key in data),
+                "moduleNames": sorted(
+                    str(item.get("Name"))
+                    for item in modules
+                    if isinstance(item, dict) and item.get("Name")
+                )
+                if isinstance(modules, list)
+                else [],
+                "connectorCount": len(connectors)
+                if isinstance(connectors, list)
+                else 0,
+                "screenCount": len(screens) if isinstance(screens, list) else 0,
+                "imageCount": len(images) if isinstance(images, list) else 0,
+            }
+        )
+    return result
+
+
+def read_workflows(
+    root: Path,
+) -> tuple[list[dict[str, object]], Counter[str], Counter[str]]:
+    result: list[dict[str, object]] = []
+    connector_counts: Counter[str] = Counter()
+    action_type_counts: Counter[str] = Counter()
+    workflow_root = root / "Workflows"
+    if not workflow_root.is_dir():
+        return result, connector_counts, action_type_counts
+
+    for path in sorted(workflow_root.rglob("*.json")):
+        data = load_json(path)
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected a JSON object in {path}")
+
+        properties = data.get("properties")
+        if not isinstance(properties, dict):
+            properties = {}
+        definition = get_definition(data)
+        actions = list(walk_actions(definition.get("actions")))
+        triggers = definition.get("triggers")
+        if not isinstance(triggers, dict):
+            triggers = {}
+
+        action_types = Counter(str(action["type"]) for action in actions)
+        action_type_counts.update(action_types)
+        connectors = connector_names(data, definition)
+        connector_counts.update(connectors)
+
+        non_success = [
+            action for action in actions if has_non_success_run_after(action)
+        ]
+        retry_actions = [action for action in actions if has_retry_policy(action)]
+        http_like = [action for action in actions if is_http_like(action)]
+        child_or_desktop = [
+            action for action in actions if is_child_or_desktop_reference(action)
+        ]
+        waits = [
+            action
+            for action in actions
+            if str(action["type"]).lower() in {"wait", "until"}
+            or re.search(r"\b(wait|delay|espera)\b", str(action["name"]), re.I)
+        ]
+
+        relative_file = path.relative_to(root).as_posix()
+        result.append(
+            {
+                "file": relative_file,
+                "name": str(
+                    properties.get("displayName")
+                    or properties.get("name")
+                    or data.get("name")
+                    or friendly_name(path.name)
+                ),
+                "state": str(
+                    properties.get("state") or properties.get("flowState") or ""
+                ),
+                "triggers": len(triggers),
+                "actions": len(actions),
+                "foreach": action_types.get("Foreach", 0),
+                "maxForeachDepth": max(
+                    (int(action["foreachDepth"]) for action in actions),
+                    default=0,
+                ),
+                "scopes": action_types.get("Scope", 0),
+                "variables": sum(
+                    action_types.get(action_type, 0)
+                    for action_type in (
+                        "InitializeVariable",
+                        "SetVariable",
+                        "AppendToArrayVariable",
+                        "AppendToStringVariable",
+                        "IncrementVariable",
+                        "DecrementVariable",
+                    )
+                ),
+                "compose": action_types.get("Compose", 0),
+                "condition": action_types.get("If", 0),
+                "switch": action_types.get("Switch", 0),
+                "httpLike": len(http_like),
+                "terminate": action_types.get("Terminate", 0),
+                "runAfterNonSuccess": len(non_success),
+                "retryPolicy": len(retry_actions),
+                "desktopOrChildRefs": len(child_or_desktop),
+                "waitOrDelay": len(waits),
+                "connectors": connectors,
+                "types": dict(sorted(action_types.items())),
+                "sensitiveKeywordClasses": sensitive_keyword_classes(definition),
+                "runAfterSamples": [
+                    str(action["path"]) for action in non_success[:5]
+                ],
+            }
+        )
+
+    return result, connector_counts, action_type_counts
+
+
+def analyze_solution(root: Path) -> dict[str, object]:
+    root = root.resolve()
+    if not root.is_dir():
+        raise NotADirectoryError(f"Extracted solution directory not found: {root}")
+
+    workflows, connectors, action_types = read_workflows(root)
+    environment_variables = read_environment_variables(root)
+    desktop_binaries = read_desktop_binaries(root)
+    return {
+        "schemaVersion": 1,
+        "solution": read_solution(root),
+        "customizations": read_customizations(root),
+        "environmentVariables": environment_variables,
+        "desktopBinaries": desktop_binaries,
+        "workflows": workflows,
+        "connectors": dict(sorted(connectors.items())),
+        "actionTypes": dict(sorted(action_types.items())),
+        "totals": {
+            "workflowCount": len(workflows),
+            "totalActions": sum(int(item["actions"]) for item in workflows),
+            "environmentVariableCount": len(environment_variables),
+            "desktopBinaryJsonCount": len(desktop_binaries),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate static metrics for an extracted Power Platform solution."
+    )
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    metrics = analyze_solution(args.root)
+    write_json(args.output, metrics)
+    print(
+        json.dumps(
+            {
+                "metricsPath": str(args.output.resolve()),
+                "workflowCount": metrics["totals"]["workflowCount"],
+                "totalActions": metrics["totals"]["totalActions"],
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/power-automate-desktop-assessment/scripts/extract_solution.py
+++ b/submissions/power-automate-desktop-assessment/scripts/extract_solution.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import shutil
+from uuid import uuid4
+import zipfile
+
+
+DEFAULT_MAX_MEMBERS = 50_000
+DEFAULT_MAX_UNCOMPRESSED_BYTES = 1024**3
+DEFAULT_MAX_MEMBER_BYTES = 256 * 1024**2
+COPY_CHUNK_BYTES = 1024**2
+
+
+def extract_solution(
+    zip_path: Path,
+    output_dir: Path,
+    *,
+    max_members: int = DEFAULT_MAX_MEMBERS,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_member_bytes: int = DEFAULT_MAX_MEMBER_BYTES,
+) -> dict[str, object]:
+    zip_path = zip_path.resolve()
+    output_dir = output_dir.resolve()
+
+    if not zip_path.is_file():
+        raise FileNotFoundError(f"Solution ZIP not found: {zip_path}")
+    if output_dir == Path(output_dir.anchor):
+        raise ValueError("Refusing to use a filesystem root as the extraction directory")
+    if output_dir == zip_path or output_dir in zip_path.parents:
+        raise ValueError("Extraction directory must not contain the source ZIP")
+    if output_dir.exists():
+        raise FileExistsError(
+            f"Extraction directory already exists; use a new run path: {output_dir}"
+        )
+
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir = output_dir.with_name(
+        f".{output_dir.name}.tmp-{uuid4().hex}"
+    )
+    staging_dir.mkdir()
+
+    try:
+        with zipfile.ZipFile(zip_path) as archive:
+            members = archive.infolist()
+            if len(members) > max_members:
+                raise ValueError(
+                    f"Archive has {len(members)} entries; limit is {max_members}"
+                )
+
+            planned_bytes = sum(member.file_size for member in members)
+            if planned_bytes > max_uncompressed_bytes:
+                raise ValueError(
+                    "Archive expands beyond the configured safety limit "
+                    f"({planned_bytes} > {max_uncompressed_bytes} bytes)"
+                )
+
+            validated_members: list[tuple[zipfile.ZipInfo, PurePosixPath]] = []
+            staging_root = staging_dir.resolve()
+            for member in members:
+                relative = PurePosixPath(member.filename.replace("\\", "/"))
+                if not relative.parts:
+                    continue
+                if relative.is_absolute() or ".." in relative.parts:
+                    raise ValueError(
+                        f"Unsafe archive member: {member.filename!r}"
+                    )
+                if any(":" in part for part in relative.parts):
+                    raise ValueError(
+                        f"Unsafe drive-qualified archive member: "
+                        f"{member.filename!r}"
+                    )
+                destination = staging_root.joinpath(*relative.parts).resolve()
+                if (
+                    destination != staging_root
+                    and staging_root not in destination.parents
+                ):
+                    raise ValueError(
+                        f"Archive member escapes the extraction directory: "
+                        f"{member.filename!r}"
+                    )
+                if member.file_size > max_member_bytes:
+                    raise ValueError(
+                        f"Archive member exceeds the per-file safety limit: "
+                        f"{member.filename!r}"
+                    )
+                validated_members.append((member, relative))
+
+            extracted_bytes = 0
+            for member, relative in validated_members:
+                destination = staging_dir.joinpath(*relative.parts)
+                if member.is_dir():
+                    destination.mkdir(parents=True, exist_ok=True)
+                    continue
+
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                member_bytes = 0
+                with archive.open(member) as source, destination.open("xb") as target:
+                    while chunk := source.read(COPY_CHUNK_BYTES):
+                        member_bytes += len(chunk)
+                        extracted_bytes += len(chunk)
+                        if member_bytes > max_member_bytes:
+                            raise ValueError(
+                                f"Archive member exceeds the per-file safety limit: "
+                                f"{member.filename!r}"
+                            )
+                        if extracted_bytes > max_uncompressed_bytes:
+                            raise ValueError(
+                                "Archive exceeds the total extraction safety limit"
+                            )
+                        target.write(chunk)
+
+        staging_dir.replace(output_dir)
+    except Exception:
+        if staging_dir.exists():
+            shutil.rmtree(staging_dir)
+        raise
+
+    files = [path for path in output_dir.rglob("*") if path.is_file()]
+    return {
+        "extractPath": str(output_dir),
+        "fileCount": len(files),
+        "uncompressedBytes": sum(path.stat().st_size for path in files),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Safely extract an exported Power Platform solution ZIP."
+    )
+    parser.add_argument("zip_path", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--max-members", type=int, default=DEFAULT_MAX_MEMBERS)
+    parser.add_argument(
+        "--max-uncompressed-bytes",
+        type=int,
+        default=DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    )
+    parser.add_argument(
+        "--max-member-bytes",
+        type=int,
+        default=DEFAULT_MAX_MEMBER_BYTES,
+    )
+    args = parser.parse_args()
+
+    result = extract_solution(
+        args.zip_path,
+        args.output_dir,
+        max_members=args.max_members,
+        max_uncompressed_bytes=args.max_uncompressed_bytes,
+        max_member_bytes=args.max_member_bytes,
+    )
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/power-automate-desktop-assessment/scripts/render_report.py
+++ b/submissions/power-automate-desktop-assessment/scripts/render_report.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+import re
+
+
+MICROSOFT_LEARN_SOURCES = [
+    "https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/error-handling",
+    "https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/understand-limits",
+    "https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/build-readable-flow-scripts",
+    "https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/optimize-flow-performance",
+    "https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/secure-your-data",
+    "https://learn.microsoft.com/en-us/power-automate/guidance/desktop-flow-coding-guidelines/monitor-automation",
+]
+
+
+def load_metrics(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as stream:
+        data = json.load(stream)
+    if not isinstance(data, dict) or not isinstance(data.get("totals"), dict):
+        raise ValueError(f"Invalid assessment metrics: {path}")
+    return data
+
+
+def markdown(value: object) -> str:
+    text = " ".join(str(value if value is not None else "").splitlines())
+    text = html.escape(text, quote=True).replace("\\", "\\\\")
+    return re.sub(r"([`*_{}\[\]()#+!|])", r"\\\1", text)
+
+
+def inline_code(value: object) -> str:
+    text = " ".join(str(value if value is not None else "").splitlines())
+    text = html.escape(text, quote=True).replace("`", "&#96;")
+    return f"`{text}`"
+
+
+def artifact_name(item: dict[str, object]) -> str:
+    name = str(item.get("name") or Path(str(item.get("file") or "")).stem)
+    return re.sub(r"\s+", " ", name).strip()
+
+
+def finding(
+    priority: str,
+    title: str,
+    artifact_type: str,
+    technical_source: str,
+    assessment_area: str,
+    observed_condition: str,
+    target_state: str,
+    remediation: str,
+    expected_impact: str,
+    *,
+    effort: str,
+    owner: str,
+) -> dict[str, str]:
+    return {
+        "priority": priority,
+        "title": title,
+        "artifactType": artifact_type,
+        "technicalSource": technical_source,
+        "assessmentArea": assessment_area,
+        "observedCondition": observed_condition,
+        "targetState": target_state,
+        "remediation": remediation,
+        "expectedImpact": expected_impact,
+        "effort": effort,
+        "owner": owner,
+    }
+
+
+def build_findings(metrics: dict[str, object]) -> list[dict[str, str]]:
+    solution = metrics["solution"]
+    workflows = metrics["workflows"]
+    environment_variables = metrics["environmentVariables"]
+    desktop_binaries = metrics.get("desktopBinaries") or []
+    if not isinstance(solution, dict):
+        raise ValueError("Metrics solution section must be an object")
+    if not isinstance(workflows, list):
+        raise ValueError("Metrics workflows section must be an array")
+    if not isinstance(environment_variables, list):
+        raise ValueError("Metrics environmentVariables section must be an array")
+    if not isinstance(desktop_binaries, list):
+        raise ValueError("Metrics desktopBinaries section must be an array")
+
+    typed_workflows = [item for item in workflows if isinstance(item, dict)]
+    findings: list[dict[str, str]] = []
+
+    missing_dependencies = int(solution.get("missingDependencyCount") or 0)
+    if missing_dependencies:
+        findings.append(
+            finding(
+                "High",
+                "Resolve missing dependencies [Solution Artifact]",
+                "Solution-level artifacts",
+                "solution.xml",
+                "ALM / dependencies",
+                f"solution.xml declares {missing_dependencies} missing dependencies.",
+                "The release package resolves every required component and imports cleanly into a test environment.",
+                "Resolve each dependency in the source environment and validate a clean import into a test environment.",
+                "Reduces failed or incomplete imports and prevents missing-component runtime behavior.",
+                effort="Medium",
+                owner="Maker/Admin",
+            )
+        )
+
+    large = [
+        item for item in typed_workflows if int(item.get("actions") or 0) > 100
+    ]
+    if large:
+        for item in large:
+            name = artifact_name(item)
+            findings.append(
+                finding(
+                    "High",
+                    f"{name} [Cloud Flow]",
+                    "Cloud Flows",
+                    str(item.get("file") or ""),
+                    "Maintainability / architecture",
+                    f"{name} contains {item.get('actions')} actions.",
+                    "The production flow has a focused responsibility, with reusable logic separated into governed child flows where appropriate.",
+                    "Separate orchestration from reusable business, integration, and error-handling responsibilities using child flows where appropriate.",
+                    "Reduces regression risk, review effort, and troubleshooting time.",
+                    effort="High",
+                    owner="Maker/Developer",
+                )
+            )
+
+    nested = [
+        item
+        for item in typed_workflows
+        if int(item.get("maxForeachDepth") or 0) > 1
+    ]
+    if nested:
+        for item in nested:
+            name = artifact_name(item)
+            findings.append(
+                finding(
+                    "High",
+                    f"{name} [Cloud Flow]",
+                    "Cloud Flows",
+                    str(item.get("file") or ""),
+                    "Performance / platform limits",
+                    f"{name} contains {item.get('foreach')} Foreach actions with a maximum nested depth of {item.get('maxForeachDepth')}.",
+                    "The flow filters and shapes data before loops and avoids nested iteration where data operations or source-side queries can be used.",
+                    "Filter at source, normalize arrays, use data operations, and batch independent work before entering loops.",
+                    "Reduces action volume, duration, connector requests, and throttling exposure.",
+                    effort="Medium",
+                    owner="Maker/Developer",
+                )
+            )
+
+    error_gaps = [
+        item
+        for item in typed_workflows
+        if int(item.get("actions") or 0) > 10
+        and int(item.get("scopes") or 0) == 0
+        and int(item.get("runAfterNonSuccess") or 0) == 0
+        and int(item.get("terminate") or 0) == 0
+    ]
+    if error_gaps:
+        for item in error_gaps:
+            name = artifact_name(item)
+            findings.append(
+                finding(
+                    "High",
+                    f"{name} [Cloud Flow]",
+                    "Cloud Flows",
+                    str(item.get("file") or ""),
+                    "Reliability / error handling",
+                    f"{name} has more than 10 actions and no detected Scope, non-success runAfter path, or Terminate action.",
+                    "Critical paths use consistent Try/Catch scopes, non-success runAfter handling, bounded retry, contextual logging, and explicit terminal status.",
+                    "Add Try/Catch scopes, failure and timeout runAfter paths, bounded retries, contextual logging, and explicit terminal behavior.",
+                    "Improves diagnostic consistency and prevents ambiguous or apparently successful partial runs.",
+                    effort="Medium",
+                    owner="Maker/Developer",
+                )
+            )
+
+    required_without_default = [
+        item
+        for item in environment_variables
+        if isinstance(item, dict)
+        and str(item.get("required") or "").lower() in {"1", "true"}
+        and not bool(item.get("defaultValuePresent"))
+    ]
+    if required_without_default:
+        for item in required_without_default:
+            name = str(
+                item.get("displayName")
+                or item.get("schemaName")
+                or "Environment variable"
+            )
+            findings.append(
+                finding(
+                    "Medium",
+                    f"{name} [Environment Variable]",
+                    "Environment Variables",
+                    str(item.get("file") or ""),
+                    "Configuration / deployment",
+                    f"{name} is required and has no non-empty default.",
+                    "The required setting is supplied and validated for each target environment before activation.",
+                    "Provide the environment-specific value through the deployment process and document ownership and secret handling.",
+                    "Prevents post-import failures caused by missing mandatory configuration.",
+                    effort="Low",
+                    owner="Maker/Admin",
+                )
+            )
+
+    optional_without_default = [
+        item
+        for item in environment_variables
+        if isinstance(item, dict)
+        and str(item.get("required") or "").lower() in {"", "0", "false"}
+        and not bool(item.get("defaultValuePresent"))
+    ]
+    if optional_without_default:
+        for item in optional_without_default:
+            name = str(
+                item.get("displayName")
+                or item.get("schemaName")
+                or "Environment variable"
+            )
+            findings.append(
+                finding(
+                    "Observation",
+                    f"{name} [Environment Variable]",
+                    "Environment Variables",
+                    str(item.get("file") or ""),
+                    "Configuration / deployment",
+                    f"{name} is optional and has no non-empty default.",
+                    "Optional and mandatory settings are classified explicitly, with deployment validation for values needed by the target environment.",
+                    "Confirm whether the setting is operationally mandatory and, if so, validate its value during deployment without embedding secrets in the solution.",
+                    "Avoids false assumptions about optional settings while reducing configuration-related runtime failures.",
+                    effort="Low",
+                    owner="Maker/Admin",
+                )
+            )
+
+    legacy_pattern = re.compile(r"(^|[/_-])(old|test|teste|unknown)([/_-]|$)", re.I)
+    legacy = [
+        item
+        for item in typed_workflows
+        if legacy_pattern.search(str(item.get("file") or ""))
+    ]
+    if legacy:
+        for item in legacy:
+            name = artifact_name(item)
+            findings.append(
+                finding(
+                    "Medium",
+                    f"{name} [Cloud Flow]",
+                    "Cloud Flows",
+                    str(item.get("file") or ""),
+                    "ALM / release hygiene",
+                    f"The {name} filename indicates an OLD, TEST, or Unknown artifact.",
+                    "Release solutions contain only required, clearly named production components.",
+                    "Confirm usage, remove the component if obsolete, or rename it with clear production intent.",
+                    "Reduces release, ownership, and accidental activation risk.",
+                    effort="Low",
+                    owner="Maker/CoE",
+                )
+            )
+
+    if str(solution.get("managed") or "") == "0":
+        findings.append(
+            finding(
+                "Observation",
+                "Confirm package type [Solution Artifact]",
+                "Solution-level artifacts",
+                "solution.xml",
+                "ALM / package type",
+                "The exported solution is unmanaged.",
+                "The package type matches the documented ALM stage and target environment.",
+                "Confirm the target environment and produce a managed release artifact when required by the ALM strategy.",
+                "Avoids unintended unmanaged customization in controlled environments.",
+                effort="Low",
+                owner="Maker/Admin",
+            )
+        )
+
+    module_names = sorted(
+        {
+            str(module_name)
+            for item in desktop_binaries
+            if isinstance(item, dict)
+            for module_name in item.get("moduleNames", [])
+        }
+    )
+    if {"UIAutomation", "WebAutomation"} & set(module_names):
+        findings.append(
+            finding(
+                "Observation",
+                "Desktop automation [Desktop Flow / PAD]",
+                "Desktop Flow / PAD",
+                ", ".join(
+                    str(item.get("file") or "")
+                    for item in desktop_binaries
+                    if isinstance(item, dict)
+                ),
+                "Runtime / UI automation",
+                "Desktop-flow metadata references UI or web automation modules, but package analysis does not include runtime, selector, or action-log evidence.",
+                "UI and web automation have stable selectors, explicit waits and timeouts, tested session behavior, and actionable V2 logs.",
+                "Review selectors, static-analysis results, machine prerequisites, V2 action logs, and attended/unattended test evidence.",
+                "Reduces intermittent runtime failures and improves troubleshooting readiness.",
+                effort="Medium",
+                owner="Maker/Operations",
+            )
+        )
+
+    return findings
+
+
+def render_report(metrics: dict[str, object]) -> str:
+    solution = metrics["solution"]
+    totals = metrics["totals"]
+    workflows = metrics["workflows"]
+    connectors = metrics.get("connectors") or {}
+    desktop_binaries = metrics.get("desktopBinaries") or []
+    customizations = metrics.get("customizations") or {}
+    if not isinstance(solution, dict) or not isinstance(totals, dict):
+        raise ValueError("Metrics solution and totals sections must be objects")
+    if not isinstance(workflows, list):
+        raise ValueError("Metrics workflows section must be an array")
+    if not isinstance(customizations, dict):
+        raise ValueError("Metrics customizations section must be an object")
+
+    findings = build_findings(metrics)
+    priorities = {item["priority"] for item in findings}
+    high_count = sum(item["priority"] == "High" for item in findings)
+    if priorities & {"Critical", "High"}:
+        overall_health = "Red"
+    elif "Medium" in priorities:
+        overall_health = "Amber"
+    else:
+        overall_health = "Green"
+    confidence = "Medium"
+    title = (
+        str(solution.get("uniqueName") or "Power Automate Desktop")
+        + " "
+        + str(solution.get("version") or "")
+    ).strip()
+
+    lines = [
+        f"# {markdown(title)} Assessment",
+        "",
+        "## Executive summary",
+        "",
+        f"**Overall health:** {overall_health}",
+        f"**Assessment confidence:** {confidence} (static package analysis)",
+        f"**Scope reviewed:** {totals.get('workflowCount', 0)} cloud workflows, "
+        f"{totals.get('desktopBinaryJsonCount', 0)} desktop-flow artifacts, and "
+        f"{totals.get('environmentVariableCount', 0)} environment variable definitions.",
+        f"**Key conclusion:** {high_count} high-priority static-analysis findings require review before production sign-off.",
+        "",
+        "## Strengths",
+        "",
+        "- The solution package could be inventoried without modifying the source automation.",
+        "- Metrics retain source filenames for traceability and omit configuration or secret values.",
+        "- The assessment separates cloud workflow definitions from desktop-flow binary metadata.",
+        "",
+        "## Top risks",
+        "",
+        "| Priority | Severity | Area | Finding | Recommended action |",
+        "|---:|---|---|---|---|",
+    ]
+
+    for index, item in enumerate(findings[:8], start=1):
+        lines.append(
+            f"| {index} | {markdown(item['priority'])} | "
+            f"{markdown(item['assessmentArea'])} | "
+            f"{markdown(item['observedCondition'])} | "
+            f"{markdown(item['remediation'])} |"
+        )
+    if not findings:
+        lines.append("| 1 | Observation | Static review | No threshold-based risks were detected. | Complete runtime and governance review. |")
+
+    lines.extend(["", "## Detailed findings", ""])
+    artifact_order = (
+        "Cloud Flows",
+        "Desktop Flow / PAD",
+        "Environment Variables",
+        "Solution-level artifacts",
+    )
+    for artifact_type in artifact_order:
+        artifact_findings = [
+            item for item in findings if item["artifactType"] == artifact_type
+        ]
+        if not artifact_findings:
+            continue
+        lines.extend([f"### {artifact_type}", ""])
+        for item in artifact_findings:
+            lines.extend(
+                [
+                    f"#### [{markdown(item['priority'])}] {markdown(item['title'])}",
+                    "",
+                    f"**Technical source:** {inline_code(item['technicalSource'])}",
+                    f"**Assessment area:** {markdown(item['assessmentArea'])}",
+                    f"**Observed condition:** {markdown(item['observedCondition'])}",
+                    f"**Target state / best practice:** {markdown(item['targetState'])}",
+                    f"**Recommended remediation:** {markdown(item['remediation'])}",
+                    f"**Expected business/operational impact:** {markdown(item['expectedImpact'])}",
+                    f"**Priority:** {markdown(item['priority'])}",
+                    f"**Effort:** {markdown(item['effort'])}",
+                    f"**Owner:** {markdown(item['owner'])}",
+                    "",
+                ]
+            )
+
+    roadmap_sections = (
+        ("Quick wins (0-2 weeks)", "Low"),
+        ("Stabilization (2-6 weeks)", "Medium"),
+        ("Structural improvements (6+ weeks)", "High"),
+    )
+    lines.extend(["## Remediation roadmap", ""])
+    for heading, effort in roadmap_sections:
+        lines.extend([f"### {heading}"])
+        effort_findings = [
+            item for item in findings if item["effort"] == effort
+        ]
+        if effort_findings:
+            lines.extend(
+                f"- {markdown(item['remediation'])}" for item in effort_findings
+            )
+        else:
+            lines.append("- No remediation was assigned to this horizon.")
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Open questions and missing evidence",
+            "",
+            "- Business volume, SLA, observed runtime, and failure impact.",
+            "- Cloud-flow run history and connector throttling evidence.",
+            "- Desktop-flow V2 action logs, static-analysis output, and selector review.",
+            "- Machine, connection, credential, DLP, licensing, and support ownership configuration.",
+            "",
+            "## Appendix: Inventory",
+            "",
+            "### Solution artifacts",
+            "",
+            f"- `solution.xml`: {solution.get('rootComponentCount', 0)} root component(s), "
+            f"{solution.get('missingDependencyCount', 0)} missing dependency declaration(s).",
+            f"- `customizations.xml`: "
+            f"{'present' if customizations.get('present') else 'not present'}, "
+            f"{customizations.get('size', 0)} byte(s), component counts "
+            f"{markdown(customizations.get('componentCounts', {}))}.",
+            "",
+            "### Cloud workflows",
+            "",
+            "| Workflow | Actions | Foreach | Max depth | Non-success runAfter |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+
+    typed_workflows = [item for item in workflows if isinstance(item, dict)]
+    for item in sorted(
+        typed_workflows,
+        key=lambda value: int(value.get("actions") or 0),
+        reverse=True,
+    ):
+        lines.append(
+            f"| {markdown(artifact_name(item))} | {item.get('actions', 0)} | "
+            f"{item.get('foreach', 0)} | {item.get('maxForeachDepth', 0)} | "
+            f"{item.get('runAfterNonSuccess', 0)} |"
+        )
+
+    lines.extend(["", "### Connectors", ""])
+    if isinstance(connectors, dict) and connectors:
+        for connector, count in sorted(connectors.items()):
+            lines.append(
+                f"- {inline_code(connector)}: referenced by {count} workflow(s)"
+            )
+    else:
+        lines.append("- No cloud connector references were detected.")
+
+    lines.extend(["", "### Desktop-flow artifacts", ""])
+    if isinstance(desktop_binaries, list) and desktop_binaries:
+        for item in desktop_binaries:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                f"- {inline_code(item.get('file', ''))} "
+                f"(screens: {item.get('screenCount', 0)}, images: {item.get('imageCount', 0)})"
+            )
+    else:
+        lines.append("- No desktop-flow binary JSON artifacts were detected.")
+
+    lines.extend(["", "### Microsoft Learn references", ""])
+    lines.extend(f"- {source}" for source in MICROSOFT_LEARN_SOURCES)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Render a portable Markdown assessment from metrics JSON."
+    )
+    parser.add_argument("--metrics", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    report = render_report(load_metrics(args.metrics))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8", newline="\n") as stream:
+        stream.write(report)
+    print(
+        json.dumps(
+            {
+                "reportPath": str(args.output.resolve()),
+                "characters": len(report),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/power-automate-desktop-assessment/scripts/run_assessment.py
+++ b/submissions/power-automate-desktop-assessment/scripts/run_assessment.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import shutil
+from uuid import uuid4
+
+from analyze_solution import analyze_solution, write_json
+from extract_solution import extract_solution
+from render_report import render_report
+
+
+def run_assessment(
+    zip_path: Path,
+    work_dir: Path,
+    output_dir: Path | None = None,
+) -> dict[str, object]:
+    zip_path = zip_path.resolve()
+    work_dir = work_dir.resolve()
+    run_dir = work_dir / f"run-{uuid4().hex[:12]}"
+    resolved_output_dir = (
+        output_dir.resolve() if output_dir is not None else run_dir / "output"
+    )
+    resolved_output_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        resolved_output_dir.mkdir()
+    except FileExistsError as error:
+        raise FileExistsError(
+            f"Output directory already exists; use a new path: "
+            f"{resolved_output_dir}"
+        ) from error
+
+    extract_dir = run_dir / "solution_extract"
+    metrics_path = resolved_output_dir / "assessment_metrics.json"
+    report_path = resolved_output_dir / "assessment_report.md"
+    metrics_staging_path = resolved_output_dir / ".assessment_metrics.json.tmp"
+    report_staging_path = resolved_output_dir / ".assessment_report.md.tmp"
+
+    try:
+        extraction = extract_solution(zip_path, extract_dir)
+        metrics = analyze_solution(extract_dir)
+        write_json(metrics_staging_path, metrics)
+
+        report = render_report(metrics)
+        with report_staging_path.open(
+            "w",
+            encoding="utf-8",
+            newline="\n",
+        ) as stream:
+            stream.write(report)
+        metrics_staging_path.replace(metrics_path)
+        report_staging_path.replace(report_path)
+    except Exception:
+        if resolved_output_dir.exists():
+            shutil.rmtree(resolved_output_dir)
+        raise
+
+    return {
+        "extraction": extraction,
+        "runDirectory": str(run_dir),
+        "metricsPath": str(metrics_path),
+        "reportPath": str(report_path),
+        "workflowCount": metrics["totals"]["workflowCount"],
+        "totalActions": metrics["totals"]["totalActions"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the portable Power Automate solution assessment workflow."
+    )
+    parser.add_argument("--zip", required=True, type=Path)
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=Path("/tmp/pad-assessment"),
+    )
+    parser.add_argument("--output-dir", type=Path)
+    args = parser.parse_args()
+
+    result = run_assessment(args.zip, args.work_dir, args.output_dir)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a Power Automate Desktop assessment skill
- cover maintainability, reliability, security, performance, troubleshooting, scaling, ALM, and governance
- include evidence-based finding and report templates grounded in Microsoft Learn guidance
- target Cowork, Copilot Studio, and Scout

## Validation

- `npm run check:submissions`
- `npm run import:submissions`
- `npm run build`
- `git diff --check`

By contributing this skill, I agree that it is shared under the repository's MIT license.