### PR TITLE
Regenerate skill content from submissions during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,15 @@ jobs:
           # A GITHUB_TOKEN push does not retrigger workflows, so this run still
           # owns the deploy below; the commit only keeps tomorrow's diff stable.
           git push || echo "::warning::Could not push refreshed ratings; will retry next run."
+      # Regenerate every skill page + bundle from submissions/ before building.
+      # PR CI only commits generated content back to SAME-REPO PR branches; fork
+      # PRs are validate-only, so their src/content/skills/<slug>.md never lands
+      # on main and the skill would 404 / be missing from the gallery. Importing
+      # here makes the deployed site reflect submissions/ regardless of how a PR
+      # was merged. Idempotent: it rewrites the same files a same-repo PR did.
+      - name: Import skill submissions
+        if: steps.ratings.outputs.should_deploy == 'true'
+        run: npm run import:submissions
       - name: Build
         if: steps.ratings.outputs.should_deploy == 'true'
         run: npm run build


### PR DESCRIPTION
## Problem

When a skill PR is merged **from a fork**, its generated content page never reaches `main`, so the skill 404s on the live site and is missing from the gallery (this just happened with #67, fixed manually in #71).

Root cause: PR CI (`.github/workflows/ci.yml`) only runs `import:submissions` and commits the generated `src/content/skills/<slug>.md` (+ `public/bundles/*.zip`) back to **same-repo** PR branches. Fork PRs have no write token, so they're validate-only — the generated file is never created. The deploy workflow then runs plain `astro build`, which renders whatever content files are committed and does **not** regenerate from `submissions/`. Result: fork-merged skills are absent until someone runs the importer manually.

## Fix

Add an `Import skill submissions` step to the deploy `build` job, right before `astro build`, gated on the same `should_deploy` condition. This regenerates every skill page and bundle from `submissions/` at deploy time, so the published site always reflects `submissions/` regardless of how a PR was merged (fork or same-repo). It's idempotent with the same-repo PR extraction step.

## Verification

Ran the exact deploy sequence locally: `npm run import:submissions` then `npm run build` — both succeed, 54 pages built.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>