### PR TITLE
Add optional human-facing README as gallery main content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ pre-packaged zip:
 ```
 submissions/<slug>/
 ├── metadata.json     # OR metadata.yaml — catalog details (sidecar, not bundled)
+├── README.md         # optional human-facing note (not bundled; see below)
 └── EITHER an unpacked canonical Agent Skill…
     ├── SKILL.md      # frontmatter (name + agent description) + instructions
     ├── scripts/      # optional executable code
@@ -33,14 +34,20 @@ Copy [`submissions/_template/`](submissions/_template) to get started. The
 `meeting-summarizer` → `/skills/meeting-summarizer`. See
 [`submissions/README.md`](submissions/README.md) for the full reference.
 
-> **Everything except `metadata.*` is bundled into the agent-facing `.zip`,
-> verbatim.** The download bundle *is* the skill the agent loads, so it must
-> contain **only agent-facing files** (`SKILL.md`, `scripts/`, `references/`,
-> `assets/`). **Do not include a `README.md` or any other human-facing file**
-> (CONTRIBUTING, CHANGELOG, docs written for people, etc.) in your submission
-> folder — it will be packaged into the bundle and waste the agent's context.
-> Put contributor notes in your pull request description instead. Only
-> `metadata.json`/`metadata.yaml` is stripped out as a sidecar.
+> **Everything except `metadata.*` and `README.md` is bundled into the
+> agent-facing `.zip`, verbatim.** The download bundle *is* the skill the agent
+> loads, so it must contain **only agent-facing files** (`SKILL.md`, `scripts/`,
+> `references/`, `assets/`). Don't drop stray human-facing docs (CONTRIBUTING,
+> CHANGELOG, etc.) next to your payload — they'd be packaged into the bundle and
+> waste the agent's context; put those in your pull request description instead.
+
+> **Writing for a human? Add an optional `README.md`.** A root-level `README.md`
+> is the one human-facing companion the gallery understands: it's **never
+> bundled** and **never part of `SKILL.md`**. When you include one, it **becomes
+> the main content** on the detail page — your own overview, setup, and usage in
+> your words — while the exact `SKILL.md` (or `.json` / `.zip`) stays one click
+> away as the download. It's optional and works for every entry type; without it,
+> the page falls back to showing the skill's instructions.
 
 ### Cowork plugins
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ plus one skill payload — an unpacked `SKILL.md` (+ optional dirs) or a `.zip`:
 ```
 submissions/<slug>/
 ├── metadata.json  # OR metadata.yaml — catalog details (sidecar, not bundled)
+├── README.md      # OPTIONAL human-facing note (not bundled) — shown on the page
 └── EITHER an unpacked skill…       OR a pre-packaged bundle:
     ├── SKILL.md   # name + agent description + instructions   └── <name>.zip
     ├── scripts/   # optional executable code
@@ -62,7 +63,10 @@ submissions/<slug>/
 
 A skill carries **two** descriptions: the **agent** description in `SKILL.md`
 frontmatter (what the model reads to decide when to invoke), and the **catalog**
-description in `metadata.json` (the friendly one-liner shown in the gallery).
+description in `metadata.json` (the friendly one-liner shown in the gallery). An optional **`README.md`** adds a third, human-only voice: it never ships to the
+agent and, when present, **becomes the main content** on the detail page — the
+author's overview, setup, and usage — with the exact `SKILL.md` still offered as
+the download.
 
 `submissions/my-great-skill/SKILL.md`:
 

--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -46,6 +46,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -69,12 +70,19 @@ import {
 const ROOT = join(import.meta.dirname, "..");
 const SUBMISSIONS_DIR = join(ROOT, "submissions");
 const CONTENT_DIR = join(ROOT, "src", "content", "skills");
+// Generated per-entry human-facing "guide" pages (from an optional
+// README.md in a submission). A separate collection dir so the `skills` glob
+// never picks them up.
+const GUIDES_DIR = join(ROOT, "src", "content", "guides");
 const BUNDLES_DIR = join(ROOT, "public", "bundles");
 
 // Instruction file match key. Compared against a lowercased basename, so it
 // matches the canonical `SKILL.md` (and a legacy lowercase `skill.md`). The
 // generated bundle always emits it as uppercase `SKILL.md`.
 const INSTRUCTIONS_NAME = "skill.md";
+// Optional, human-facing companion doc (never bundled, never seen by the agent).
+// When present it becomes the detail page's main content.
+const README_NAME = "readme.md";
 const METADATA_NAMES = ["metadata.json", "metadata.yaml", "metadata.yml"];
 // Canonical name emitted for the instruction file inside every download bundle.
 const BUNDLE_INSTRUCTIONS_NAME = "SKILL.md";
@@ -116,6 +124,12 @@ type Submission = {
   skillMd?: string;
   metaName?: string;
   metaText?: string;
+  /**
+   * Optional human-facing companion doc (the submission's `README.md`). When
+   * present it becomes the detail page's main content. Never bundled into a
+   * download and never part of the agent-facing `SKILL.md`.
+   */
+  readmeMd?: string;
   /** For an automation: the raw Scout automation `.json`, shipped verbatim. */
   automationJson?: string;
   automationJsonName?: string;
@@ -236,6 +250,25 @@ function writeIfChanged(path: string, content: string): void {
   writeFileSync(path, content, "utf8");
 }
 
+/**
+ * Publish (or remove) the optional human-facing overview for an entry.
+ * When the submission has a `README.md`, it is written verbatim to
+ * `src/content/guides/<slug>.md` (a separate collection the detail page renders
+ * as the main content). When it does not, any previously generated guide is
+ * deleted so removing a README restores the default body. No-op in `--check`
+ * mode.
+ */
+function writeGuide(slug: string, sub: Submission): void {
+  if (checkOnly) return;
+  const out = join(GUIDES_DIR, `${slug}.md`);
+  if (sub.readmeMd && sub.readmeMd.trim()) {
+    mkdirSync(GUIDES_DIR, { recursive: true });
+    writeIfChanged(out, `${sub.readmeMd.replace(/^\s+/, "").replace(/\s+$/, "")}\n`);
+  } else if (existsSync(out)) {
+    rmSync(out);
+  }
+}
+
 /** Recursively list every file under `dir`, with forward-slash relative paths. */
 function listFiles(dir: string, baseDir = dir): SubFile[] {
   const out: SubFile[] = [];
@@ -267,6 +300,10 @@ function classifyPayload(sub: Submission, files: SubFile[]): void {
     const isRoot = !file.path.includes("/");
     if (base === INSTRUCTIONS_NAME && isRoot && sub.skillMd === undefined) {
       sub.skillMd = file.data.toString("utf8");
+    } else if (base === README_NAME && isRoot) {
+      // Human-facing companion doc: adopt as the overview if not already
+      // provided alongside the payload, and never ship it in the bundle.
+      if (sub.readmeMd === undefined) sub.readmeMd = file.data.toString("utf8");
     } else if (METADATA_NAMES.includes(base)) {
       // Sidecar — never bundled. Adopt as catalog source only if not already set.
       if (sub.metaText === undefined) {
@@ -364,6 +401,7 @@ function processSubmission(sub: Submission): ImportProblem | null {
   if (!checkOnly) {
     mkdirSync(CONTENT_DIR, { recursive: true });
     writeIfChanged(join(CONTENT_DIR, `${slug}.md`), buildContent(meta, parsed.content));
+    writeGuide(slug, sub);
     if (hasBundle) {
       mkdirSync(BUNDLES_DIR, { recursive: true });
       // The bundle is the canonical Agent Skill: a root-level SKILL.md (what
@@ -511,6 +549,7 @@ function processPlugin(sub: Submission): ImportProblem | null {
     const body = buildPluginBody({ overview, skills: pv.skills, connectors: pv.connectors });
     mkdirSync(CONTENT_DIR, { recursive: true });
     writeIfChanged(join(CONTENT_DIR, `${slug}.md`), buildContent(meta, body));
+    writeGuide(slug, sub);
     mkdirSync(BUNDLES_DIR, { recursive: true });
     // Ship the M365 app package verbatim (deterministic order + fixed mtime).
     writeBundle(pluginFiles, join(BUNDLES_DIR, `${slug}.zip`));
@@ -654,6 +693,7 @@ function processAutomationInstaller(sub: Submission): ImportProblem | null {
     const body = buildInstallerBody(iv.install, slug);
     mkdirSync(CONTENT_DIR, { recursive: true });
     writeIfChanged(join(CONTENT_DIR, `${slug}.md`), buildContent(meta, body));
+    writeGuide(slug, sub);
     mkdirSync(BUNDLES_DIR, { recursive: true });
     // Ship the installer package verbatim (deterministic order + fixed mtime).
     writeBundle(files, join(BUNDLES_DIR, `${slug}.zip`));
@@ -759,6 +799,7 @@ function processAutomation(sub: Submission): ImportProblem | null {
     });
     mkdirSync(CONTENT_DIR, { recursive: true });
     writeIfChanged(join(CONTENT_DIR, `${slug}.md`), buildContent(meta, body));
+    writeGuide(slug, sub);
     mkdirSync(BUNDLES_DIR, { recursive: true });
     // Ship the automation `.json` verbatim so the gallery download equals the
     // exact file Scout imports.
@@ -792,6 +833,11 @@ function loadSubmission(dir: string): Submission {
     sub.metaName = metaFile.toLowerCase();
     sub.metaText = readFileSync(join(dir, metaFile), "utf8");
   }
+
+  // Optional human-facing companion doc (top-level, next to the payload). Works
+  // for every entry type; never bundled and never part of the agent payload.
+  const readmeFile = topFiles.find((n) => n.toLowerCase() === README_NAME);
+  if (readmeFile) sub.readmeMd = readFileSync(join(dir, readmeFile), "utf8");
 
   if (zips.length > 0 && hasRootSkill) {
     problems.push(

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,4 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 import { skillSchema } from "./lib/skill-schema";
 
@@ -7,4 +7,12 @@ const skills = defineCollection({
   schema: skillSchema,
 });
 
-export const collections = { skills };
+// Optional human-facing "overview" for an entry, generated from a
+// submission's README.md. Keyed by the same slug as its skill so the detail page
+// can look it up. Plain markdown — any frontmatter is ignored.
+const guides = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/guides" }),
+  schema: z.object({}).passthrough(),
+});
+
+export const collections = { skills, guides };

--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -38,6 +38,13 @@ const isInstaller = isAutomation && Boolean(d.bundle?.endsWith(".zip"));
 const noun = isPlugin ? "plugin" : isAutomation ? "automation" : "skill";
 const { Content } = await render(skill);
 
+// Optional human-facing overview (generated from a submission's
+// README.md, keyed by the same slug). When present it replaces the default
+// body as the detail page's main content.
+const guides = await getCollection("guides");
+const guide = guides.find((g) => g.id === skill.id);
+const GuideContent = guide ? (await render(guide)).Content : null;
+
 // For importable `.json` automations, parse the published file at build time so
 // we can render its trigger + prompt steps as structured UI instead of raw
 // markdown. Installer `.zip` automations have no schedule/steps — their
@@ -154,7 +161,11 @@ if (updated && updated !== created) meta.push(["Updated", updated]);
         <hr class="my-7 border-border" />
 
         {
-          isAutomation && automation ? (
+          GuideContent ? (
+            <article class="prose max-w-none dark:prose-invert prose-headings:text-fg prose-a:text-accent-text prose-strong:text-fg prose-code:text-accent-text prose-code:before:content-[''] prose-code:after:content-[''] prose-table:text-muted prose-th:text-fg">
+              <GuideContent />
+            </article>
+          ) : isAutomation && automation ? (
             <div>
               <div class="mb-6">
                 <h2 class="mb-2 text-sm font-semibold uppercase tracking-wider text-accent-text">

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -13,6 +13,8 @@ two shapes:
 submissions/<slug>/
 ├── metadata.json     # OR metadata.yaml — catalog details for this gallery
 │                     # (a SIDECAR — never packaged into the download bundle)
+├── README.md         # OPTIONAL — human-facing overview shown on the detail page
+│                     # (never bundled, never seen by the agent)
 └── EITHER an unpacked canonical Agent Skill…
     ├── SKILL.md      # frontmatter (name + agent description) + instructions
     ├── scripts/      # optional executable code
@@ -27,16 +29,20 @@ The `<slug>` is the folder name — use lowercase, hyphenated names, e.g.
 copying [`_template/`](./_template).
 
 Bundling is **verbatim** — whatever you put in `scripts/`/`references/`/`assets/`
-(or inside your `.zip`) ships exactly as authored. Only `metadata.*` is stripped;
-it is a sidecar and never lands inside the bundle.
+(or inside your `.zip`) ships exactly as authored. Only `metadata.*` and the
+optional `README.md` are stripped; they are sidecars and never land inside the
+bundle.
 
-> ⚠️ **No READMEs or other human-facing files.** Because bundling is verbatim,
-> anything in the folder (other than the `metadata.*` sidecar) is packaged into
-> the agent-facing `.zip` and loaded as part of the skill. A `README.md`,
-> `CONTRIBUTING`, `CHANGELOG`, or any doc written for people just wastes the
-> agent's context. Ship **only agent-facing files** (`SKILL.md`, `scripts/`,
-> `references/`, `assets/`) and put contributor/human notes in your PR
-> description instead.
+> ℹ️ **Talking to a human? Use `README.md`.** A root-level `README.md` is the one
+> file meant for people, not the agent. It is **never bundled** and **never part
+> of `SKILL.md`** — and when present it **becomes the main content** on the detail
+> page (your own overview, setup steps, tips, and examples), with the exact
+> `SKILL.md` still offered as the download. Without one, the page falls back to
+> the skill's own instructions. It's optional and works for every entry type
+> (skill, plugin, automation, installer). Everything *else* in the folder is
+> agent-facing and ships verbatim, so don't add stray docs like `CHANGELOG` or
+> `CONTRIBUTING` next to your payload — they'd just waste the agent's context. Put
+> those in your PR description.
 
 ## Two descriptions — they are different on purpose
 
@@ -64,6 +70,17 @@ Turn the transcript into concise notes and action items…
 ```
 
 The human-friendly **display name** lives in `metadata.json` (`name`), not here.
+
+## `README.md` — an optional human-facing overview
+
+Want to tell the person adding your skill how to set it up, what to expect, or a
+few tips? Drop a `README.md` in the submission folder. It's **optional**, plain
+Markdown, and written for **people** — so it never ships in the download bundle
+and the agent never reads it. When present, it **becomes the main content** on
+the detail page (in your own words), while the exact `SKILL.md` stays available as
+the download. Leave it out and the page falls back to showing the skill's
+instructions. It works the same way for every entry type: skill, plugin,
+automation, and automation installer.
 
 ## `metadata.json` — catalog details
 

--- a/submissions/_template-automation-installer/README.md
+++ b/submissions/_template-automation-installer/README.md
@@ -1,5 +1,10 @@
 # Scout automation installer template
 
+> **Heads up:** this README is contributor guidance for the template. If you keep
+> a `README.md` in your own submission it **becomes the main content** on the
+> gallery detail page — so replace this text with a human-facing overview of your
+> automation, or delete the file to fall back to the auto-generated page.
+
 Copy this folder to `submissions/<your-slug>/` to submit a **Scout automation
 installer** — a `.zip` that installs an automation via an `INSTALL.md` (install
 procedure + the automation prompt) plus one or more JSON config files the

--- a/submissions/_template-automation/README.md
+++ b/submissions/_template-automation/README.md
@@ -1,5 +1,10 @@
 # Scout automation template
 
+> **Heads up:** this README is contributor guidance for the template. If you keep
+> a `README.md` in your own submission it **becomes the main content** on the
+> gallery detail page — so replace this text with a human-facing overview of your
+> automation, or delete the file to fall back to the auto-generated page.
+
 Copy this folder to `submissions/<your-slug>/` to submit a **Scout automation** —
 a scheduled/triggered `.json` (a schedule plus an ordered list of prompt steps)
 that runs **only** in Scout.

--- a/submissions/_template-plugin/README.md
+++ b/submissions/_template-plugin/README.md
@@ -1,5 +1,10 @@
 # Cowork plugin template
 
+> **Heads up:** this README is contributor guidance for the template. If you keep
+> a `README.md` in your own submission it **becomes the main content** on the
+> gallery detail page — so replace this text with a human-facing overview of your
+> plugin, or delete the file to fall back to the auto-generated page.
+
 Copy this folder to `submissions/<your-slug>/` to submit a **Cowork plugin** — a
 Microsoft 365 app package that bundles one or more skills (plus optional MCP
 connectors) and runs **only** in Copilot Cowork.

--- a/submissions/_template/README.md
+++ b/submissions/_template/README.md
@@ -1,0 +1,26 @@
+# Overview
+
+**Optional — delete this file if you don't need it.**
+
+This `README.md` is for **humans**, not the agent. When you include it, it
+**becomes the main content** on your skill's gallery page (in place of the
+agent-facing `SKILL.md` instructions), while the exact `SKILL.md` is still offered
+as the download. It's never bundled and the agent never reads it.
+
+Use it to write, in your own voice, whatever helps someone decide to add your
+skill and get a good result:
+
+## Before you start
+
+Anything they need first — a runtime, a package (`pip install …`), a connected
+account, or required permissions.
+
+## How to use it
+
+What to ask for, in plain language, and what the skill does in response. Concrete
+examples beat abstract description.
+
+## Good to know
+
+Limits, gotchas, and tips — the things you'd tell a colleague trying it for the
+first time.

--- a/submissions/_template/SKILL.md
+++ b/submissions/_template/SKILL.md
@@ -7,11 +7,11 @@ description: >-
 ---
 
 Write the agent-facing instructions here as Markdown — this body becomes the
-"Instructions" section on the detail page and the downloadable `skill.md`. The
-body loads only *after* the agent has already decided to use the skill, so don't
-restate *when* to use it here — that belongs in the frontmatter `description`.
-Go straight into how to do the task, in the imperative (address the agent, not
-the skill — avoid "You are the … skill").
+"Instructions" section on the detail page (when there's no `README.md`) and the
+downloadable `skill.md`. The body loads only *after* the agent has already
+decided to use the skill, so don't restate *when* to use it here — that belongs
+in the frontmatter `description`. Go straight into how to do the task, in the
+imperative (address the agent, not the skill — avoid "You are the … skill").
 
 ## Instructions
 1. Concrete, numbered steps the agent should follow.


### PR DESCRIPTION
Skill authors can add an optional `README.md` to a submission folder. When present, it **becomes the main content** on the gallery detail page — in place of the agent-facing `SKILL.md` instructions (or automation steps / plugin overview) — while the exact `SKILL.md`/`.json`/`.zip` stays available as the download. The README is **never bundled** and never seen by the agent. Without one, the page falls back to the existing agent-facing body. Works for every entry type, no toggles.

## Changes
- `scripts/import-submissions.ts`: read optional root `README.md` (all types), exclude from bundles, write/remove `src/content/guides/<slug>.md`
- `src/content.config.ts`: add loose `guides` collection
- `src/pages/skills/[slug].astro`: render the guide as the body when present
- Docs + templates: document the optional README in `CONTRIBUTING.md`, `README.md`, `submissions/README.md`, and submission templates

## Verified
- Build: 86 pages, all 22 submissions valid, importer idempotent
- With a README → renders human content; without → falls back to instructions