### PR TITLE
Stamp featured skill cards and refresh the featured list

### DIFF
--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -53,13 +53,28 @@ const wrapperProps = isInteractive
 <Wrapper class={wrapperClass} {...wrapperProps}>
   <!-- Header: monogram + name + platforms -->
   <div class="flex items-start gap-3">
-    <span
-      class="grid h-11 w-11 shrink-0 place-items-center rounded-lg text-sm font-bold text-white shadow-sm"
-      style={`background-image:${gradient}`}
-      aria-hidden="true"
-    >
-      {mark}
-    </span>
+    <div class="relative shrink-0">
+      <span
+        class="grid h-11 w-11 place-items-center rounded-lg text-sm font-bold text-white shadow-sm"
+        style={`background-image:${gradient}`}
+        aria-hidden="true"
+      >
+        {mark}
+      </span>
+      {
+        featured && (
+          <span
+            class="absolute -right-1.5 -top-1.5 grid h-[18px] w-[18px] place-items-center rounded-full bg-white text-amber-500 shadow ring-1 ring-black/5"
+            title="Hand-picked featured skill"
+            aria-hidden="true"
+          >
+            <svg viewBox="0 0 24 24" fill="currentColor" class="h-2.5 w-2.5">
+              <path d="M12 2.5l2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.9l-5.8 3.05 1.11-6.46-4.7-4.58 6.49-.94L12 2.5z" />
+            </svg>
+          </span>
+        )
+      }
+    </div>
     <div class="min-w-0 flex-1">
       <div class="flex items-start gap-1.5">
         <h3
@@ -68,25 +83,6 @@ const wrapperProps = isInteractive
         >
           {name}
         </h3>
-        {
-          featured && (
-            <span
-              class="flex shrink-0 items-center gap-1 rounded-full border border-amber-300/70 bg-gradient-to-b from-amber-100 to-amber-200 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-800 shadow-sm dark:border-amber-400/30 dark:from-amber-400/25 dark:to-amber-500/15 dark:text-amber-300"
-              title="Featured skill"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                class="h-2.5 w-2.5"
-                aria-hidden="true"
-              >
-                <path d="M12 2.5l2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.9l-5.8 3.05 1.11-6.46-4.7-4.58 6.49-.94L12 2.5z" />
-              </svg>
-              Featured
-            </span>
-          )
-        }
         {
           isPlugin && (
             <span

--- a/src/components/SkillCard.astro
+++ b/src/components/SkillCard.astro
@@ -16,6 +16,7 @@ interface Props {
   /** True when an automation ships as an installer `.zip` (vs an importable `.json`). */
   isInstaller?: boolean;
   rating?: number;
+  featured?: boolean;
 }
 
 const {
@@ -30,6 +31,7 @@ const {
   hasBundle = false,
   isInstaller = false,
   rating = 0,
+  featured = false,
 } = Astro.props;
 
 const gradient = coverGradient(slug, coverColor);
@@ -66,6 +68,25 @@ const wrapperProps = isInteractive
         >
           {name}
         </h3>
+        {
+          featured && (
+            <span
+              class="flex shrink-0 items-center gap-1 rounded-full border border-amber-300/70 bg-gradient-to-b from-amber-100 to-amber-200 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-800 shadow-sm dark:border-amber-400/30 dark:from-amber-400/25 dark:to-amber-500/15 dark:text-amber-300"
+              title="Featured skill"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                class="h-2.5 w-2.5"
+                aria-hidden="true"
+              >
+                <path d="M12 2.5l2.9 5.88 6.49.94-4.7 4.58 1.11 6.46L12 17.9l-5.8 3.05 1.11-6.46-4.7-4.58 6.49-.94L12 2.5z" />
+              </svg>
+              Featured
+            </span>
+          )
+        }
         {
           isPlugin && (
             <span

--- a/src/content/skills/campaign-deck-builder.md
+++ b/src/content/skills/campaign-deck-builder.md
@@ -10,7 +10,6 @@ authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-09
 updatedAt: 2026-07-09
-featured: true
 bundle: bundles/campaign-deck-builder.zip
 ---
 Turn a short interview into a charming, vibrant, highly visual **3-slide

--- a/src/content/skills/chart-builder.md
+++ b/src/content/skills/chart-builder.md
@@ -10,7 +10,6 @@ authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14
-featured: true
 bundle: bundles/chart-builder.zip
 ---
 Generate charts from tabular data via the bundled `scripts/charts.py` toolkit.

--- a/src/content/skills/doc-format-converter.md
+++ b/src/content/skills/doc-format-converter.md
@@ -10,6 +10,7 @@ authorGithub: adner
 version: 1.0.0
 createdAt: 2026-07-16
 updatedAt: 2026-07-16
+featured: true
 bundle: bundles/doc-format-converter.zip
 ---
 Convert documents between formats using the bundled `scripts/convert.py`. It

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -250,6 +250,7 @@ const hiddenTagCount = Math.max(0, allTags.length - COLLAPSED_TAGS);
               hasBundle={Boolean(skill.data.bundle)}
               isInstaller={skill.data.type === "automation" && Boolean(skill.data.bundle?.endsWith(".zip"))}
               rating={getRating(skill.id)}
+              featured={skill.data.featured}
             />
           </div>
         ))

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -70,6 +70,7 @@ const { tag, skills } = Astro.props;
             coverColor={skill.data.coverColor}
             hasBundle={Boolean(skill.data.bundle)}
             isInstaller={skill.data.type === "automation" && Boolean(skill.data.bundle?.endsWith(".zip"))}
+            featured={skill.data.featured}
           />
         ))
       }

--- a/submissions/campaign-deck-builder/metadata.json
+++ b/submissions/campaign-deck-builder/metadata.json
@@ -15,6 +15,5 @@
   "authorUrl": "https://microsoft.github.io/mcscatblog/",
   "version": "1.0.0",
   "createdAt": "2026-07-09",
-  "updatedAt": "2026-07-09",
-  "featured": true
+  "updatedAt": "2026-07-09"
 }

--- a/submissions/chart-builder/metadata.json
+++ b/submissions/chart-builder/metadata.json
@@ -17,6 +17,5 @@
   "authorUrl": "https://github.com/microsoft/cat-agent-skills",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
-  "updatedAt": "2026-07-14",
-  "featured": true
+  "updatedAt": "2026-07-14"
 }

--- a/submissions/doc-format-converter/metadata.json
+++ b/submissions/doc-format-converter/metadata.json
@@ -7,5 +7,6 @@
   "authorUrl": "https://github.com/adner",
   "version": "1.0.0",
   "createdAt": "2026-07-16",
-  "updatedAt": "2026-07-16"
+  "updatedAt": "2026-07-16",
+  "featured": true
 }


### PR DESCRIPTION
## What & why

Featured skills previously only sorted first — they looked identical to everything else in the grid. This adds a gentle visual marker and updates which skills are featured.

### Featured marker
- A small **gold star seal** tucked onto the monogram's corner in `SkillCard.astro`.
- Chosen over a pill because Featured is a *curation* signal, not a type — the Plugin/Automation/Sample pills are 1:1 with a skill, and adding a "Featured" pill to that row caused alignment clashes. Anchoring the star to the fixed-size monogram keeps it aligned across all columns and clear of the type pill and title.
- White disc + gold star so it reads cleanly in both light and dark mode.

### Featured list refresh
Now featured: **Knowledge Source Router**, **Redlining Content**, **Spend More Time With Friends & Family**, **Universal Document Converter**.
Removed: Campaign Deck Builder, Chart Builder.

Only the source `submissions/*/metadata.json` files are committed; the generated `src/content/skills/*` are left for CI to regenerate.

## Verification
- `npm run build` passes (101 pages).
- Verified the star seal in light/dark, with and without a type pill, across grid columns.
- Live preview shows exactly the 4 intended featured cards.