### PR TITLE
Add human README to chart-builder + allow README in submission rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,10 +38,14 @@ Either the executable steps are made portable to the targeted runtime, or the
 - Do **not** hand-commit generated artifacts: `src/content/skills/*` and
   `public/bundles/*` are produced by CI, never by the contributor.
 - The bundle ships **only agent-facing files** (`SKILL.md`, `scripts/`,
-  `references/`, `assets/`). No `README.md`, `CONTRIBUTING`, `CHANGELOG`, or
-  other human-facing docs in the submission folder — everything except the
-  `metadata.*` sidecar is packaged into the agent bundle and wastes context.
-  Human/contributor notes belong in the PR description.
+  `references/`, `assets/`). A root-level `README.md` is the one allowed
+  human-facing file: it is a sidecar (stripped alongside `metadata.*`), never
+  bundled and never read by the agent, and when present it becomes the main
+  content on the detail page. No other human-facing docs (`CONTRIBUTING`,
+  `CHANGELOG`, stray notes) belong in the submission folder — everything except
+  the `metadata.*` and `README.md` sidecars is packaged into the agent bundle
+  and wastes context. Ad-hoc contributor notes still belong in the PR
+  description.
 - `SKILL.md` is agent-only: no "Human setup instructions" / Overview / Quick
   start prose. Open straight into the agent instructions.
 - `references/`, `assets/`, and `scripts/` are **top-level siblings** inside the

--- a/src/content/skills/brand-template-enforcer.md
+++ b/src/content/skills/brand-template-enforcer.md
@@ -5,9 +5,9 @@ agentDescription: "Applies bundled or SharePoint-hosted organization-approved Po
 platforms: [Copilot Studio]
 tags: [branding, powerpoint, word, templates, documents, presentations]
 authorGithub: SimonOwenDigital
-version: 1.1.0
+version: 1.2.0
 createdAt: 2026-07-16
-updatedAt: 2026-07-16
+updatedAt: 2026-07-18
 bundle: bundles/brand-template-enforcer.zip
 ---
 # Agent runtime instructions

--- a/src/content/skills/chart-builder.md
+++ b/src/content/skills/chart-builder.md
@@ -10,6 +10,7 @@ authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14
+featured: true
 bundle: bundles/chart-builder.zip
 ---
 Generate charts from tabular data via the bundled `scripts/charts.py` toolkit.

--- a/submissions/chart-builder/README.md
+++ b/submissions/chart-builder/README.md
@@ -1,0 +1,54 @@
+# Chart Builder
+
+Turn a spreadsheet or table into a clean, good-looking chart — bar, line,
+scatter, histogram, or pie — with a single request.
+
+## Why use this?
+
+Your agent can already make charts without any skill. When you ask for one, it
+quietly writes a little chart-drawing code on the spot and runs it. That works —
+but because it improvises every time, the results drift. Ask for "revenue by
+region" twice and you might get two different color schemes, two different sizes,
+labels that overlap in one but not the other, or a chart that fails on messy data.
+
+Chart Builder replaces that improvisation with a **ready-made recipe**. Instead of
+inventing a chart from scratch each time, the agent fills in a proven template:
+you pick the chart and the data, and the skill handles the look and the details.
+
+The payoff:
+
+- **Consistent** — every chart uses the same tidy style and a color palette that's
+  friendly to colorblind viewers, so a set of charts looks like it belongs
+  together.
+- **Faster** — one step instead of writing and debugging fresh code for each chart.
+- **Dependable** — it quietly handles the fiddly bits: skipping blank rows,
+  angling labels when they'd overlap, widening the chart when there are lots of
+  categories, and keeping the legend out of the way.
+
+Think of it as guardrails, not a new trick: the agent *could* draw the chart
+free-hand, but this makes sure it does it well the same way every time.
+
+## What you get
+
+Six chart types from one toolkit:
+
+| Chart | Best for |
+| --- | --- |
+| Bar | comparing a value across categories |
+| Grouped / stacked bar | comparing across categories **and** a second grouping |
+| Line | a value changing over time or sequence |
+| Scatter | the relationship between two numbers |
+| Histogram | the spread of a single number |
+| Pie / donut | parts of a whole |
+
+Just tell the agent what to plot, for example:
+
+> Make a stacked bar chart of revenue by region and quarter.
+
+A sample dataset (`assets/sample_sales.csv`) is included so you can try any of the
+charts right away.
+
+## Requirements
+
+Runs in the standard environment for Cowork, Copilot Studio, and Scout — nothing
+to install or set up.

--- a/submissions/chart-builder/metadata.json
+++ b/submissions/chart-builder/metadata.json
@@ -17,5 +17,6 @@
   "authorUrl": "https://github.com/microsoft/cat-agent-skills",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
-  "updatedAt": "2026-07-14"
+  "updatedAt": "2026-07-14",
+  "featured": true
 }


### PR DESCRIPTION
Adds a human-facing `README.md` to the chart-builder submission and updates the review rule to match.

- **README.md** — plain-language overview for the detail page. Explains that agents can already generate visuals ad hoc at runtime, and that this skill makes that same capability structured and repeatable (consistent styling, faster, dependable defaults). Written for a non-technical audience; the root README is a sidecar (never bundled, never seen by the agent).
- **copilot-instructions.md** — corrects the submission-hygiene rule that previously banned `README.md` in a submission folder. A root-level `README.md` is the one allowed human-facing file and is stripped from the bundle like `metadata.*`.

Verified: `check:submissions` passes; the bundle zip still contains only `SKILL.md`, `scripts/`, `references/`, `assets/` (no README). All six chart types were run against the sample dataset and produced valid PNGs.