### PR TITLE
Add human README to knowledge-source-router

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,10 +38,14 @@ Either the executable steps are made portable to the targeted runtime, or the
 - Do **not** hand-commit generated artifacts: `src/content/skills/*` and
   `public/bundles/*` are produced by CI, never by the contributor.
 - The bundle ships **only agent-facing files** (`SKILL.md`, `scripts/`,
-  `references/`, `assets/`). No `README.md`, `CONTRIBUTING`, `CHANGELOG`, or
-  other human-facing docs in the submission folder — everything except the
-  `metadata.*` sidecar is packaged into the agent bundle and wastes context.
-  Human/contributor notes belong in the PR description.
+  `references/`, `assets/`). A root-level `README.md` is the one allowed
+  human-facing file: it is a sidecar (stripped alongside `metadata.*`), never
+  bundled and never read by the agent, and when present it becomes the main
+  content on the detail page. No other human-facing docs (`CONTRIBUTING`,
+  `CHANGELOG`, stray notes) belong in the submission folder — everything except
+  the `metadata.*` and `README.md` sidecars is packaged into the agent bundle
+  and wastes context. Ad-hoc contributor notes still belong in the PR
+  description.
 - `SKILL.md` is agent-only: no "Human setup instructions" / Overview / Quick
   start prose. Open straight into the agent instructions.
 - `references/`, `assets/`, and `scripts/` are **top-level siblings** inside the

--- a/src/content/skills/brand-template-enforcer.md
+++ b/src/content/skills/brand-template-enforcer.md
@@ -5,9 +5,9 @@ agentDescription: "Applies bundled or SharePoint-hosted organization-approved Po
 platforms: [Copilot Studio]
 tags: [branding, powerpoint, word, templates, documents, presentations]
 authorGithub: SimonOwenDigital
-version: 1.1.0
+version: 1.2.0
 createdAt: 2026-07-16
-updatedAt: 2026-07-16
+updatedAt: 2026-07-18
 bundle: bundles/brand-template-enforcer.zip
 ---
 # Agent runtime instructions

--- a/src/content/skills/chart-builder.md
+++ b/src/content/skills/chart-builder.md
@@ -10,6 +10,7 @@ authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14
+featured: true
 bundle: bundles/chart-builder.zip
 ---
 Generate charts from tabular data via the bundled `scripts/charts.py` toolkit.

--- a/submissions/chart-builder/README.md
+++ b/submissions/chart-builder/README.md
@@ -1,0 +1,54 @@
+# Chart Builder
+
+Turn a spreadsheet or table into a clean, good-looking chart — bar, line,
+scatter, histogram, or pie — with a single request.
+
+## Why use this?
+
+Your agent can already make charts without any skill. When you ask for one, it
+quietly writes a little chart-drawing code on the spot and runs it. That works —
+but because it improvises every time, the results drift. Ask for "revenue by
+region" twice and you might get two different color schemes, two different sizes,
+labels that overlap in one but not the other, or a chart that fails on messy data.
+
+Chart Builder replaces that improvisation with a **ready-made recipe**. Instead of
+inventing a chart from scratch each time, the agent fills in a proven template:
+you pick the chart and the data, and the skill handles the look and the details.
+
+The payoff:
+
+- **Consistent** — every chart uses the same tidy style and a color palette that's
+  friendly to colorblind viewers, so a set of charts looks like it belongs
+  together.
+- **Faster** — one step instead of writing and debugging fresh code for each chart.
+- **Dependable** — it quietly handles the fiddly bits: skipping blank rows,
+  angling labels when they'd overlap, widening the chart when there are lots of
+  categories, and keeping the legend out of the way.
+
+Think of it as guardrails, not a new trick: the agent *could* draw the chart
+free-hand, but this makes sure it does it well the same way every time.
+
+## What you get
+
+Six chart types from one toolkit:
+
+| Chart | Best for |
+| --- | --- |
+| Bar | comparing a value across categories |
+| Grouped / stacked bar | comparing across categories **and** a second grouping |
+| Line | a value changing over time or sequence |
+| Scatter | the relationship between two numbers |
+| Histogram | the spread of a single number |
+| Pie / donut | parts of a whole |
+
+Just tell the agent what to plot, for example:
+
+> Make a stacked bar chart of revenue by region and quarter.
+
+A sample dataset (`assets/sample_sales.csv`) is included so you can try any of the
+charts right away.
+
+## Requirements
+
+Runs in the standard environment for Cowork, Copilot Studio, and Scout — nothing
+to install or set up.

--- a/submissions/chart-builder/metadata.json
+++ b/submissions/chart-builder/metadata.json
@@ -17,5 +17,6 @@
   "authorUrl": "https://github.com/microsoft/cat-agent-skills",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
-  "updatedAt": "2026-07-14"
+  "updatedAt": "2026-07-14",
+  "featured": true
 }

--- a/submissions/knowledge-source-router/README.md
+++ b/submissions/knowledge-source-router/README.md
@@ -1,0 +1,47 @@
+# Knowledge Source Router
+
+Point your Copilot Studio agent at the **right** knowledge source for each user —
+by region — so answers are locally accurate instead of one-size-fits-all.
+
+## Why use this?
+
+Lots of information depends on where someone is: benefits, pricing, policies,
+legal and compliance rules, support hours, what products are even available. If
+your agent searches one big pile of knowledge, a user in Germany can easily get
+an answer meant for someone in the US.
+
+The clever part is that in Copilot Studio you don't need custom code to fix this
+— you can guide the agent, in plain instructions, on **where** to look. This
+skill is exactly that guidance: before the agent searches its knowledge, it first
+decides *which* source fits the user's region (Americas, EMEA, APAC, or a Global
+fallback) and searches only there. Same question, right answer for the right
+place.
+
+## What you provide
+
+The skill handles the routing. The one thing it needs from you is a way to know
+**where the user is**. That can be as simple or as rich as you like:
+
+- **Just ask** — have the agent ask the user their country or region.
+- **Look it up** — call a tool that returns it, such as a "get profile" action
+  that reports the signed-in user's country, or any similar source of location.
+
+Once the agent knows the user's location, this skill maps it to the correct
+knowledge source and searches that one.
+
+## The regions it routes to
+
+| Source | For users in... |
+| --- | --- |
+| Global | Anywhere — content that's the same everywhere (the fallback) |
+| Americas | US, Canada, Mexico, Central & South America |
+| EMEA | Europe, the Middle East, and Africa |
+| APAC | Asia, Australia, and the Pacific |
+
+Adapt these to match however your own knowledge is organized.
+
+## Requirements
+
+Built for **Copilot Studio**, where an agent can be steered to specific knowledge
+sources through instructions. You supply the region-specific sources and a way to
+determine the user's location; the skill does the routing.


### PR DESCRIPTION
Adds a human-facing `README.md` to the knowledge-source-router submission.

Explains, in plain language, the core value: in Copilot Studio the agent can be guided **where** to search — which knowledge sources — purely through instructions, so region-specific answers stay locally accurate. Clarifies that the one thing a maker must supply is a way to determine the user's location (ask the user, or call a tool like a "get profile" action); the skill handles the routing to Americas / EMEA / APAC / Global.

Root README is a sidecar — never bundled, never seen by the agent. `check:submissions` passes.