### PR TITLE
Add skill: Persona Reaction Panel 

### DIFF
--- a/submissions/persona-reaction-panel/README.md
+++ b/submissions/persona-reaction-panel/README.md
@@ -1,0 +1,52 @@
+# Persona Reaction Panel
+
+Pre-test any internal-facing artefact — launch email, all-staff deck, learning-hub page, change announcement, video script — against a defined set of **role-based personas** *before it ships*. The panel surfaces blackspots, domain coverage gaps, and "credible detractor" risks while they are still cheap to fix, and closes with a **SHIP / REVISE / HOLD** verdict.
+
+## Why this exists
+
+Most comms QA happens after the fact: something lands badly with one team, and you find out from the replies. This skill moves that discovery *before* send. Existing gallery skills help you **produce** content; this one simulates how your **audience** will receive it.
+
+## A framework, not a dataset
+
+The skill ships with **no personas**. You supply your own in a personas file — `references/personas.template.md` is a starter you fill in with your organisation's roles. Every reaction the panel produces is anchored to an attribute *you* defined, which keeps the simulation honest and stops it drifting into generic "AI magic" feedback. Your personas stay in your own copy; nothing organisation-specific is bundled or shared.
+
+## When to use it
+
+- Before any artefact going to a broad internal population or multiple teams/domains.
+- When prioritising which of several drafts to send first.
+- For role-based enablement or learning-journey material.
+
+**Not** for 1:1 private comms, performance/HR matters, or legal/contractual language — and it only reacts to a draft you supply; it won't write one for you.
+
+## What you need first
+
+A **personas file** describing the roles in your audience. Define as many personas as your audience has distinct roles — **8–12 is a good range for an enterprise** — and group them into **domains** (e.g. Client, Delivery, Data, Technology, Corporate Functions) so the panel can spot coverage gaps.
+
+Each persona needs, at minimum:
+
+- **Role / what they do**
+- **Motivations**
+- **Pain points**
+- **How the tool or change helps them**
+- **Comms anchors** — what makes a message land vs. what makes them disengage
+- **Confidence** — fully defined, or still in draft (draft personas are treated as lower-confidence and their recommendations routed to human validation)
+
+### Filling in the template
+
+1. Open `references/personas.template.md` in your copy of the skill.
+2. List the distinct roles in your artefact's audience and group them into domains.
+3. Complete every field for each persona. Two clearly-labelled `REPLACE ME` examples show the level of specificity that works.
+4. Ground the fields in real role definitions or research where you have them; mark anything you're inferring as **draft — lower confidence** so the panel treats it as a hypothesis.
+5. Be specific and honest — the panel anchors every reaction to what you write here, so vague personas produce vague reactions.
+
+## How to run it
+
+1. Add the skill to your agent (Cowork or Copilot Studio) with your completed personas file in place.
+2. Give the agent your draft artefact and ask it to *"run the persona panel"* or *"pressure-test this against our personas."*
+3. You get: a per-persona reaction (six anchored answers each), a synthesis (domain coverage, blackspots, risks, suggested edits, tick-and-stick recommendations), and the SHIP / REVISE / HOLD net read.
+
+## Good to know
+
+- Role personas are role-level, not individual-psychology-level.
+- The panel won't invent personas mid-run — if your artefact targets an audience your personas don't represent, it says so and HOLDs.
+- The skill identifies reactions, risks, and constructive moves; **sign-off stays human**. Validate high-stakes recommendations with a named owner.

--- a/submissions/persona-reaction-panel/SKILL.md
+++ b/submissions/persona-reaction-panel/SKILL.md
@@ -5,42 +5,22 @@ description: Pre-simulate how a defined set of role-based personas will react to
 
 # Persona Reaction Panel
 
-Pre-test any internal-facing artefact (launch email, all-staff deck, learning-hub page, change announcement, video script) against a defined set of **role-based personas** before it ships — so you catch blackspots, credible-detractor risks, and domain gaps while they are still cheap to fix.
+Simulate how each defined persona will react to the user's draft artefact, then synthesise domain-level risks and concrete edits, ending with a SHIP / REVISE / HOLD verdict.
 
-This skill ships as a **framework, not a dataset**. It contains no one's personas — you supply your own in a personas file (`references/personas.template.md` is a starter you fill in with your organisation's roles). Every reaction the panel produces is anchored to an attribute *you* defined, which keeps the simulation honest and stops it drifting into generic "AI magic" feedback.
+**Personas file (required):** load the user's personas file from `references/` (or the path the user provides). Each persona provides: role / what they do, motivations, pain points, how the tool or change helps them, comms anchors, and a confidence flag (fully defined or draft). Personas are grouped into domains. If no completed personas file is available, stop and ask the user to supply one (`references/personas.template.md` is the blank template — do not run the panel against the template's example personas).
 
-## When to use
-- Before any artefact going to a broad internal population or multiple teams/domains.
-- When prioritising which of several drafts to send first.
-- For role-based enablement or learning-journey material.
-
-## When NOT to use
-- 1:1 private comms.
-- Performance / HR matters.
-- Legal / contractual language.
-- A status report or new-work identification — this skill only reacts to a draft you supply.
-
-## What you need first
-A **personas file** describing the roles in your audience. Each persona needs, at minimum:
-- **Role / what they do**
-- **Motivations**
-- **Pain points**
-- **How the tool or change helps them**
-- **Comms anchors** — what makes a message land vs. what makes them disengage
-- **Confidence** — fully defined, or still in draft (flag draft personas as lower-confidence)
-
-See `references/personas.template.md`. Define as many personas as your audience has distinct roles (8–12 is a good range for an enterprise). Group them into **domains** so you can spot coverage gaps.
+**Scope guard:** if the artefact is a 1:1 private communication, an HR/performance matter, or legal/contractual language, decline and state why. Only react to a draft the user supplies — do not write one.
 
 ## How a run works
 
 ### Step 1 — Load the personas file (in full)
-Read your personas file completely before reacting. It is the ONLY source of truth for how each persona responds — never simulate from memory or generic assumptions.
+Read the personas file completely before reacting. It is the ONLY source of truth for how each persona responds — never simulate from memory or generic assumptions.
 
 ### Step 2 — Read the artefact
-Read the draft in full. Identify: what is asked, what is claimed, what is implied, what is left out, the audience it assumes, and which of your domains it actually serves.
+Read the draft in full. Identify: what is asked, what is claimed, what is implied, what is left out, the audience it assumes, and which of the user's domains it actually serves.
 
 ### Step 3 — Per-persona reaction (repeat for each persona)
-Six short answers per persona, each anchored to a quoted attribute from your personas file:
+Six short answers per persona, each anchored to a quoted attribute from the personas file:
 1. **Will they read it?** — would it land so they'd engage? (anchor: their role / pain point / motivation)
 2. **What do they take away?** — first-read interpretation. (anchor)
 3. **What do they push back on?** — the line, claim, or omission that stops them. (anchor a real pain point — do not invent a fear the file does not support)
@@ -48,9 +28,9 @@ Six short answers per persona, each anchored to a quoted attribute from your per
 5. **What would make them tick and stick?** — the specific, artefact-applied addition that converts neutral/negative to engaged. (anchor)
 6. **Does it move them?** — net effect (up / flat / down), one sentence.
 
-**Anti-drift rule (critical):** every paragraph must contain a quoted phrase or named attribute from your personas file. If it can't be anchored, omit it. Never import a persona's psychology from another framework onto a role the file does not support.
+**Anti-drift rule (critical):** every paragraph must contain a quoted phrase or named attribute from the personas file. If it can't be anchored, omit it. Never import a persona's psychology from another framework onto a role the file does not support.
 
-**Confidence rule:** for personas you flagged as still in draft, prefix the reaction with a confidence flag and route their recommendations to human validation.
+**Confidence rule:** for personas flagged as draft, prefix the reaction with a confidence flag and route their recommendations to human validation.
 
 ### Step 4 — Synthesis
 1. **Domain coverage** — which domains the artefact serves well, weakly, or excludes. An all-staff artefact that silently serves only one domain is a failure even if no single persona "breaks."
@@ -62,7 +42,7 @@ Six short answers per persona, each anchored to a quoted attribute from your per
 ### Step 5 — Net read
 - **SHIP** — no persona/domain risk, ≤2 minor edits.
 - **REVISE** — ≥1 persona/domain risk OR ≥3 substantive edits OR a credible-detractor pattern.
-- **HOLD** — targets an audience your personas don't represent, OR a domain is materially excluded, OR a draft persona is load-bearing and cannot yet be validated.
+- **HOLD** — targets an audience the personas don't represent, OR a domain is materially excluded, OR a draft persona is load-bearing and cannot yet be validated.
 
 ### Step 6 — Output
 Save a dated file with the net read at the top; surface the synthesis inline and keep the per-persona reactions in the file. If the environment cannot save files, return the full output in the response instead, with the net read first, then the synthesis, then the per-persona reactions.
@@ -74,8 +54,5 @@ Save a dated file with the net read at the top; surface the synthesis inline and
 
 ## Limits
 - Role personas are role-level, not individual-psychology-level.
-- Don't invent new personas mid-run. If the artefact targets an audience your personas don't represent, say so and HOLD.
-- The skill identifies reactions, risks and constructive moves; **sign-off stays human.** Validate high-stakes recommendations with a named owner.
-
----
-*A reusable framework. Bring your own personas; keep your own context private.*
+- Don't invent new personas mid-run. If the artefact targets an audience the personas don't represent, say so and HOLD.
+- Identify reactions, risks and constructive moves; sign-off stays human. Route high-stakes recommendations to a named owner for validation.

--- a/submissions/persona-reaction-panel/SKILL.md
+++ b/submissions/persona-reaction-panel/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: persona-reaction-panel
+description: Pre-simulate how a defined set of role-based personas will react to an internal comms, launch, or enablement artefact before it ships. Use when the user asks to "run the persona panel", "pressure-test this comms against our personas", "QA this launch email/deck before it goes out", "how will each team react to this", or wants persona- and domain-level feedback on a broad internal artefact. Requires a personas file — bring your own (see references/personas.template.md). Do NOT use for 1:1 private comms, HR/performance matters, or legal/contractual language.
+---
+
+# Persona Reaction Panel
+
+Pre-test any internal-facing artefact (launch email, all-staff deck, learning-hub page, change announcement, video script) against a defined set of **role-based personas** before it ships — so you catch blackspots, credible-detractor risks, and domain gaps while they are still cheap to fix.
+
+This skill ships as a **framework, not a dataset**. It contains no one's personas — you supply your own in a personas file (`references/personas.template.md` is a starter you fill in with your organisation's roles). Every reaction the panel produces is anchored to an attribute *you* defined, which keeps the simulation honest and stops it drifting into generic "AI magic" feedback.
+
+## When to use
+- Before any artefact going to a broad internal population or multiple teams/domains.
+- When prioritising which of several drafts to send first.
+- For role-based enablement or learning-journey material.
+
+## When NOT to use
+- 1:1 private comms.
+- Performance / HR matters.
+- Legal / contractual language.
+- A status report or new-work identification — this skill only reacts to a draft you supply.
+
+## What you need first
+A **personas file** describing the roles in your audience. Each persona needs, at minimum:
+- **Role / what they do**
+- **Motivations**
+- **Pain points**
+- **How the tool or change helps them**
+- **Comms anchors** — what makes a message land vs. what makes them disengage
+- **Confidence** — fully defined, or still in draft (flag draft personas as lower-confidence)
+
+See `references/personas.template.md`. Define as many personas as your audience has distinct roles (8–12 is a good range for an enterprise). Group them into **domains** so you can spot coverage gaps.
+
+## How a run works
+
+### Step 1 — Load the personas file (in full)
+Read your personas file completely before reacting. It is the ONLY source of truth for how each persona responds — never simulate from memory or generic assumptions.
+
+### Step 2 — Read the artefact
+Read the draft in full. Identify: what is asked, what is claimed, what is implied, what is left out, the audience it assumes, and which of your domains it actually serves.
+
+### Step 3 — Per-persona reaction (repeat for each persona)
+Six short answers per persona, each anchored to a quoted attribute from your personas file:
+1. **Will they read it?** — would it land so they'd engage? (anchor: their role / pain point / motivation)
+2. **What do they take away?** — first-read interpretation. (anchor)
+3. **What do they push back on?** — the line, claim, or omission that stops them. (anchor a real pain point — do not invent a fear the file does not support)
+4. **What did it miss for them?** — the defined need that isn't addressed.
+5. **What would make them tick and stick?** — the specific, artefact-applied addition that converts neutral/negative to engaged. (anchor)
+6. **Does it move them?** — net effect (up / flat / down), one sentence.
+
+**Anti-drift rule (critical):** every paragraph must contain a quoted phrase or named attribute from your personas file. If it can't be anchored, omit it. Never import a persona's psychology from another framework onto a role the file does not support.
+
+**Confidence rule:** for personas you flagged as still in draft, prefix the reaction with a confidence flag and route their recommendations to human validation.
+
+### Step 4 — Synthesis
+1. **Domain coverage** — which domains the artefact serves well, weakly, or excludes. An all-staff artefact that silently serves only one domain is a failure even if no single persona "breaks."
+2. **Blackspots** — things no persona reacted to that the artefact assumed they would.
+3. **Persona/domain risks** — who the artefact actively damages, and why. Flag "credible detractor" risk (a persona the framing turns into an active sceptic).
+4. **Suggested edits** — 2–3 concrete lines to add/remove/reframe, each naming the personas it serves.
+5. **Tick-and-stick recommendations** — 2–3 additive moves, each naming (a) the persona(s), (b) the anchored trigger, (c) implementable in this artefact without changing its purpose.
+
+### Step 5 — Net read
+- **SHIP** — no persona/domain risk, ≤2 minor edits.
+- **REVISE** — ≥1 persona/domain risk OR ≥3 substantive edits OR a credible-detractor pattern.
+- **HOLD** — targets an audience your personas don't represent, OR a domain is materially excluded, OR a draft persona is load-bearing and cannot yet be validated.
+
+### Step 6 — Output
+Save a dated file with the net read at the top; surface the synthesis inline and keep the per-persona reactions in the file. If the environment cannot save files, return the full output in the response instead, with the net read first, then the synthesis, then the per-persona reactions.
+
+## Tick-and-stick discipline
+1. Anchor every recommendation to a defined persona attribute. No anchor → drop it.
+2. Don't optimise for the impossible coalition — if serving one domain damages another, surface the tradeoff; don't paper over it.
+3. Constructive ≠ flattering — make the artefact more honest and specific, not warmer.
+
+## Limits
+- Role personas are role-level, not individual-psychology-level.
+- Don't invent new personas mid-run. If the artefact targets an audience your personas don't represent, say so and HOLD.
+- The skill identifies reactions, risks and constructive moves; **sign-off stays human.** Validate high-stakes recommendations with a named owner.
+
+---
+*A reusable framework. Bring your own personas; keep your own context private.*

--- a/submissions/persona-reaction-panel/metadata.json
+++ b/submissions/persona-reaction-panel/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "Persona Reaction Panel",
+  "description": "Pre-test an internal launch, comms, or enablement artefact against your own role-based personas before it ships — surfaces blackspots, domain gaps, credible-detractor risks, and concrete edits. Bring your own personas file.",
+  "platforms": ["Cowork", "Copilot Studio"],
+  "tags": ["communications", "change-management", "launch-readiness", "personas", "qa"],
+  "author": "Olivia Zhang",
+  "version": "1.0.0"
+}

--- a/submissions/persona-reaction-panel/references/personas.template.md
+++ b/submissions/persona-reaction-panel/references/personas.template.md
@@ -1,0 +1,44 @@
+# Personas — [Your Organisation] role-based personas
+
+> **This is a TEMPLATE.** Replace the examples below with the real roles in YOUR audience.
+> Nothing here ships to anyone else — it stays in your own copy of the skill.
+> The panel anchors every reaction to what you write here, so be specific and honest.
+
+## How to fill this in
+1. List the distinct roles in the audience for your artefact (8–12 works well for an enterprise).
+2. Group them into **domains** (e.g. Client, Delivery, Data, Technology, Corporate Functions) so the panel can spot coverage gaps.
+3. For each persona, complete every field. Mark any persona you're unsure about as **draft — lower confidence**.
+4. Keep the fields grounded in real role definitions / research where you have them; flag anything you're inferring so the panel treats it as a hypothesis.
+
+## Persona fields (copy this block once per persona)
+- **Persona / named:**
+- **Domain:**
+- **What they do:**
+- **Motivations:**
+- **Pain points:**
+- **How the tool/change helps:**
+- **Comms anchors:** (what makes a message land vs. what makes them disengage)
+- **Confidence:** fully defined | draft (lower confidence)
+
+---
+
+## Example 1 (REPLACE ME) — Account / Client Lead
+- **Domain:** Client & Growth
+- **What they do:** Owns the client relationship and commercial outcome; briefs, status, scope.
+- **Motivations:** Client satisfaction, account growth, margin protection, smooth cross-team orchestration.
+- **Pain points:** Endless status updates; scattered briefs; the time tax of stitching inputs from multiple teams.
+- **How the tool/change helps:** Drafts briefs; summarises long threads into actions; preps pitch narratives.
+- **Comms anchors:** Lands when it shows time back and protects margin; disengages from anything that adds process. Time-poor — values short, high-signal content.
+- **Confidence:** fully defined
+
+## Example 2 (REPLACE ME) — Data / Insights Analyst
+- **Domain:** Data & Insights
+- **What they do:** Turns data into defensible insight — analysis, dashboards, measurement.
+- **Motivations:** Statistical rigour, data quality, defensible methodology.
+- **Pain points:** Admin reporting cycles that eat time better spent on insight; repetitive ad-hoc requests.
+- **How the tool/change helps:** Drafts narratives from data; summarises findings; builds charts.
+- **Comms anchors:** Lands when it returns time from admin to insight and respects method; sceptical of any output presented without provenance.
+- **Confidence:** fully defined
+
+---
+Add the rest of your personas below using the field block above.


### PR DESCRIPTION
## What this skill does

**Persona Reaction Panel** pre-tests any internal-facing artefact (launch email, all-staff deck, learning-hub page, change announcement, video script) against a set of role-based personas *before it ships* — surfacing blackspots, domain coverage gaps, "credible detractor" risks, and 2–3 concrete edits, then issuing a SHIP / REVISE / HOLD verdict.

It fills a gap in the gallery: existing skills help you *produce* content (blog auditors, deck builders, LinkedIn writers); this one simulates how your *audience* will receive it while changes are still cheap.

## Design notes

- **Framework, not a dataset.** The skill ships with no personas — users fill in `references/personas.template.md` with their own organisation's roles. Nothing organisation-specific is bundled.
- **Anti-drift rule.** Every persona reaction must anchor to a quoted attribute from the user's own personas file. If it can't be anchored, it's omitted — this keeps the simulation honest and stops generic "AI feedback" drift.
- **Confidence flags.** Personas marked as draft get lower-confidence treatment and their recommendations are routed to human validation.
- **Human sign-off is explicit.** The skill identifies reactions and risks; the Limits section states sign-off stays human.
- **Environment-aware output.** Saves a dated results file where the environment supports it; otherwise returns the full structured output inline (works in both Cowork and Copilot Studio).

## Testing

Developed and used in practice in Microsoft 365 Copilot (Cowork) against real internal comms drafts with an 8–12 persona file; the template ships with two illustrative example personas users replace with their own.

## Checklist

- [x] Folder name matches the SKILL.md frontmatter slug (`persona-reaction-panel`)
- [x] metadata.json includes required name, description, platforms, tags
- [x] No confidential or organisation-specific data included
- [x] Shared under the repository's MIT license