### PR TITLE
Add review rule: flag human-facing content in SKILL.md / missing README

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,36 @@ the platforms it targets, for example:
 Either the executable steps are made portable to the targeted runtime, or the
 `platforms` list is narrowed to where the skill genuinely runs.
 
+### Human-facing vs. agent-facing content (README split)
+
+`SKILL.md` is read by the **agent at runtime**; the optional root-level
+`README.md` is read by a **human browsing the gallery**. They have different
+audiences, so onboarding/setup prose does not belong in `SKILL.md`.
+
+Actively flag a submission when human-facing content is embedded in `SKILL.md`
+instead of a `README.md`, for example:
+
+- **Setup / "before you start" guidance** — how to prepare inputs the skill
+  needs (e.g. "fill in your personas file", "create a config with these
+  fields", "8–12 personas is a good range"), installation/upload steps, or
+  "how to add this to your agent" instructions.
+- **Overview / marketing / "why use this" framing**, "at a glance" tables,
+  quick-start example prompts, tested-model notes, and limitations written for
+  a reader deciding whether to adopt the skill.
+- Any second-person "you"-addressed prose that tells the *user* what to do
+  before/around a run, rather than telling the *agent* how to execute one.
+
+When such content exists, ask the author to **move it into a `README.md`
+sidecar** and leave `SKILL.md` as the lean runtime SOP (activation, procedure,
+decision rules, output format). A skill that has meaningful setup or adoption
+guidance but **no `README.md`** should be flagged — that guidance has nowhere
+to live except wrongly inside `SKILL.md`, and the gallery page has no
+human-facing overview. (A `README.md` is optional only when there is genuinely
+no human-facing content to host.)
+
+The distinction to apply: *would the running agent ever need this sentence to
+do the task?* If no — it's documentation, and belongs in the `README.md`.
+
 ### Submission hygiene
 
 - **One concern per PR: submission content OR site/repo changes, never both.**
@@ -56,7 +86,8 @@ Either the executable steps are made portable to the targeted runtime, or the
   and wastes context. Ad-hoc contributor notes still belong in the PR
   description.
 - `SKILL.md` is agent-only: no "Human setup instructions" / Overview / Quick
-  start prose. Open straight into the agent instructions.
+  start / setup-prep prose (see **Human-facing vs. agent-facing content**
+  above). Open straight into the agent instructions.
 - `references/`, `assets/`, and `scripts/` are **top-level siblings** inside the
   submission (or the `.zip`), not nested under one another (e.g. not
   `scripts/references/`).

--- a/src/content/skills/linkedin-content-writer.md
+++ b/src/content/skills/linkedin-content-writer.md
@@ -7,8 +7,9 @@ tags: [linkedin, social-media, writing, content]
 author: "Becky Still, Digital Boop Ltd"
 authorUrl: "https://digital-boop.co.uk/my-story"
 authorGithub: DigitalBoopLtd
-version: 1.0.0
+version: 1.0.1
 createdAt: 2026-07-14
+updatedAt: 2026-07-17
 ---
 # LinkedIn Content Writer
 
@@ -16,54 +17,6 @@ Turn supplied or genuinely accessed material into ready-to-publish, text-based
 LinkedIn content around one supported point. Adapt to conversation-scoped
 preferences, and ask only when missing substance, permission, or approval
 blocks a credible result.
-
-## At a glance
-
-| | |
-| --- | --- |
-| **Best for** | Individuals and organisations with a point or source material to turn into LinkedIn content |
-| **Starts from** | Confirmed facts, notes, drafts, research, approved sources, announcements, or lived experience |
-| **Creates** | Posts, comments, hooks, ideas, rewrites, reviews, and writing profiles |
-| **Protects** | Evidence, caveats, attribution, permissions, and author voice |
-| **Does not** | Publish, schedule, create media, analyse performance, or itself persist preferences |
-
-> **Trust boundary:** Preserve evidence, caveats, attribution, permission, and
-> author voice. Ask for missing substance rather than inventing it.
-
-## Copilot Studio setup
-
-> **Tested setup**
->
-> - **Platform:** Copilot Studio new agent experience
-> - **Model:** GPT-5.5 Chat only
-> - **Other models:** Not verified; test in Preview before publishing
-
-For reliable multi-turn behaviour, add this to the host agent's Instructions:
-
-```
-Do not assume content is for LinkedIn unless the user asks.
-
-For every turn in an active LinkedIn content task, invoke the linkedin-content-writer skill before responding.
-
-This includes initial requests, answers to clarification questions, added facts or preferences, revisions, reviews, corrections, and short follow-up messages. Continue using the skill until the user changes topic or ends the LinkedIn task.
-
-Do not draft, rewrite, polish, review, repurpose, brainstorm, revise, or configure LinkedIn writing preferences without invoking the skill.
-```
-
-## Quick start
-
-- `Draft a LinkedIn post from these confirmed facts: [facts and limitations].`
-- `Review this LinkedIn draft without rewriting it: [draft].`
-- `Configure a conversation-scoped LinkedIn writing profile: [preferences].`
-
-## How it works
-
-| Step | Move |
-| --- | --- |
-| **1 · Ground** | Separate confirmed facts, stated views, constraints, and unknowns |
-| **2 · Focus** | Choose one core point the evidence can support |
-| **3 · Draft** | Write in the requested voice, format, and length |
-| **4 · Check** | Verify factual claims, caveats, and final constraints |
 
 ## Source boundary
 


### PR DESCRIPTION
Adds a dedicated **"Human-facing vs. agent-facing content (README split)"** code-review rule to `.github/copilot-instructions.md`.

## Why

The existing hygiene bullet ("`SKILL.md` is agent-only… no Quick start prose") was too terse and got missed in review — e.g. a submission embedded persona-setup guidance ("fill in your personas file", "8–12 is a good range") directly in `SKILL.md` and shipped with no `README.md`, and the reviewer under-flagged it.

## What it adds

An actionable rule that tells reviewers to flag when:
- setup / "before you start" prep, install/upload steps, or "how to add this to your agent" guidance lives in `SKILL.md`;
- overview / "why use this" / at-a-glance / quick-start / tested-model / limitations prose (reader-facing) lives in `SKILL.md`;
- a skill has meaningful human-facing guidance but **no `README.md`** sidecar to host it.

Plus a simple test: *would the running agent ever need this sentence to do the task? If no — it's documentation, move it to `README.md`.*