### PR TITLE
Backfill author and authorUrl on all skill submissions

### DIFF
--- a/src/content/skills/anonymised-case-study-writer.md
+++ b/src/content/skills/anonymised-case-study-writer.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to create, improve, anonymi
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [writing, case-study, marketing, documents, content, privacy]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/blog-content-auditor.md
+++ b/src/content/skills/blog-content-auditor.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to audit, review, score, ra
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [blog, content, audit, writing, seo, productivity]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/blog-post-structure-pass.md
+++ b/src/content/skills/blog-post-structure-pass.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to restructure, reorganise,
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [blog, writing, editing, content, structure, productivity]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/brand-template-enforcer.md
+++ b/src/content/skills/brand-template-enforcer.md
@@ -4,6 +4,8 @@ description: Ensure every generated PowerPoint deck or Word document starts from
 agentDescription: "Applies bundled or SharePoint-hosted organization-approved PowerPoint and Word templates whenever the agent is about to create, generate, export, or substantially rebuild a presentation, slide deck, report, proposal, brief, memo, letter, or other .pptx, .docx, or .dotx deliverable. Use before any file-generation tool or document-creation skill so the output starts from the appropriate brand template instead of a blank file. Do not use for read-only analysis or minor edits that do not create a new Office file."
 platforms: [Copilot Studio]
 tags: [branding, powerpoint, word, templates, documents, presentations]
+author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 1.2.0
 createdAt: 2026-07-16

--- a/src/content/skills/brand-voice-pass.md
+++ b/src/content/skills/brand-voice-pass.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to rewrite, humanise, de-AI
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [writing, content, voice, style, editing, productivity]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/conference-session-abstract-pack.md
+++ b/src/content/skills/conference-session-abstract-pack.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to create a conference sess
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [writing, conference, abstract, speaking, content, productivity]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/content-quality-auditor.md
+++ b/src/content/skills/content-quality-auditor.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to assess, audit, score, re
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [content, quality, audit, documents, productivity, governance]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/linkedin-content-system.md
+++ b/src/content/skills/linkedin-content-system.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to create LinkedIn posts, p
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [linkedin, social-media, writing, marketing, content]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/persona-reaction-panel.md
+++ b/src/content/skills/persona-reaction-panel.md
@@ -5,6 +5,7 @@ agentDescription: "Pre-simulate how a defined set of role-based personas will re
 platforms: [Cowork, Copilot Studio]
 tags: [communications, change-management, launch-readiness, personas, qa]
 author: Olivia Zhang
+authorUrl: "https://github.com/Olivia2327"
 authorGithub: adilei
 version: 1.0.0
 bundle: bundles/persona-reaction-panel.zip

--- a/src/content/skills/pov-line-generator.md
+++ b/src/content/skills/pov-line-generator.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks for a point of view, punchy
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [writing, positioning, marketing, content, social-media]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/power-automate-desktop-assessment.md
+++ b/src/content/skills/power-automate-desktop-assessment.md
@@ -4,6 +4,8 @@ description: Assess Power Automate Desktop and hybrid automation projects with e
 agentDescription: "Assess Power Automate Desktop and hybrid cloud/desktop automation projects for maintainability, reliability, security, performance, troubleshooting readiness, scaling, and governance using current Microsoft guidance and evidence-based review practices."
 platforms: [Cowork, Copilot Studio]
 tags: [power-automate, desktop-flows, automation, assessment, governance]
+author: Ricardo Calejo
+authorUrl: "https://github.com/dvsRCalejo"
 authorGithub: adilei
 version: 1.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/presentation-talk-track-builder.md
+++ b/src/content/skills/presentation-talk-track-builder.md
@@ -5,6 +5,7 @@ agentDescription: "Writes natural, first-person spoken presenter scripts (talk t
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [presentations, speaker-notes, pptx, writing, productivity]
 author: Jagmeet Chabra
+authorUrl: "https://github.com/jchha001"
 authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-16

--- a/src/content/skills/skill-authoring-coach.md
+++ b/src/content/skills/skill-authoring-coach.md
@@ -5,6 +5,7 @@ agentDescription: "Use this skill when the user asks to create, improve, review,
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [skills, authoring, documentation, productivity, agent]
 author: Simon Owen
+authorUrl: "https://github.com/SimonOwenDigital"
 authorGithub: SimonOwenDigital
 version: 0.1.0
 createdAt: 2026-07-17

--- a/src/content/skills/spend-more-time-with-friends-and-family.md
+++ b/src/content/skills/spend-more-time-with-friends-and-family.md
@@ -5,6 +5,7 @@ platforms: [Scout]
 type: automation
 tags: [scout, automation, teams, out-of-office, knowledge]
 author: Adi Leibowitz
+authorUrl: "https://github.com/adilei"
 authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14

--- a/src/content/skills/vacation-urgent-forwarder.md
+++ b/src/content/skills/vacation-urgent-forwarder.md
@@ -4,7 +4,8 @@ description: "A Scout automation installer that, only during a configured vacati
 platforms: [Scout]
 type: automation
 tags: [scout, automation, email, teams, out-of-office]
-author: CAT Agent Skills
+author: Giorgio Ughini
+authorUrl: "https://github.com/GiorgioUghini"
 authorGithub: GiorgioUghini
 version: 1.0.0
 createdAt: 2026-07-16

--- a/submissions/anonymised-case-study-writer/metadata.json
+++ b/submissions/anonymised-case-study-writer/metadata.json
@@ -15,6 +15,7 @@
     "privacy"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/blog-content-auditor/metadata.json
+++ b/submissions/blog-content-auditor/metadata.json
@@ -15,6 +15,7 @@
     "productivity"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/blog-post-structure-pass/metadata.json
+++ b/submissions/blog-post-structure-pass/metadata.json
@@ -15,6 +15,7 @@
     "productivity"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/brand-template-enforcer/metadata.json
+++ b/submissions/brand-template-enforcer/metadata.json
@@ -12,6 +12,8 @@
     "documents",
     "presentations"
   ],
+  "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "1.2.0",
   "createdAt": "2026-07-16",
   "updatedAt": "2026-07-18"

--- a/submissions/brand-voice-pass/metadata.json
+++ b/submissions/brand-voice-pass/metadata.json
@@ -15,6 +15,7 @@
     "productivity"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/conference-session-abstract-pack/metadata.json
+++ b/submissions/conference-session-abstract-pack/metadata.json
@@ -15,6 +15,7 @@
     "productivity"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/content-quality-auditor/metadata.json
+++ b/submissions/content-quality-auditor/metadata.json
@@ -15,6 +15,7 @@
     "governance"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/linkedin-content-system/metadata.json
+++ b/submissions/linkedin-content-system/metadata.json
@@ -14,6 +14,7 @@
     "content"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/persona-reaction-panel/metadata.json
+++ b/submissions/persona-reaction-panel/metadata.json
@@ -4,5 +4,6 @@
   "platforms": ["Cowork", "Copilot Studio"],
   "tags": ["communications", "change-management", "launch-readiness", "personas", "qa"],
   "author": "Olivia Zhang",
+  "authorUrl": "https://github.com/Olivia2327",
   "version": "1.0.0"
 }

--- a/submissions/pov-line-generator/metadata.json
+++ b/submissions/pov-line-generator/metadata.json
@@ -14,6 +14,7 @@
     "social-media"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/power-automate-desktop-assessment/metadata.json
+++ b/submissions/power-automate-desktop-assessment/metadata.json
@@ -3,6 +3,8 @@
   "description": "Assess Power Automate Desktop and hybrid automation projects with evidence-based findings and prioritized remediation guidance.",
   "platforms": ["Cowork", "Copilot Studio"],
   "tags": ["power-automate", "desktop-flows", "automation", "assessment", "governance"],
+  "author": "Ricardo Calejo",
+  "authorUrl": "https://github.com/dvsRCalejo",
   "version": "1.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-18"

--- a/submissions/presentation-talk-track-builder/metadata.json
+++ b/submissions/presentation-talk-track-builder/metadata.json
@@ -4,6 +4,7 @@
   "platforms": ["Cowork", "Copilot Studio", "Scout"],
   "tags": ["presentations", "speaker-notes", "pptx", "writing", "productivity"],
   "author": "Jagmeet Chabra",
+  "authorUrl": "https://github.com/jchha001",
   "version": "1.0.0",
   "createdAt": "2026-07-16",
   "updatedAt": "2026-07-17"

--- a/submissions/skill-authoring-coach/metadata.json
+++ b/submissions/skill-authoring-coach/metadata.json
@@ -14,6 +14,7 @@
     "agent"
   ],
   "author": "Simon Owen",
+  "authorUrl": "https://github.com/SimonOwenDigital",
   "version": "0.1.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/spend-more-time-with-friends-and-family/metadata.json
+++ b/submissions/spend-more-time-with-friends-and-family/metadata.json
@@ -3,6 +3,7 @@
   "description": "While you're out of office, watches a group chat and answers questions from your local knowledge docs (clearly marked AI-generated), logs anything it can't answer for later, and pings you on Teams if its setup is incomplete.",
   "tags": ["scout", "automation", "teams", "out-of-office", "knowledge"],
   "author": "Adi Leibowitz",
+  "authorUrl": "https://github.com/adilei",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
   "updatedAt": "2026-07-14",

--- a/submissions/vacation-urgent-forwarder/metadata.json
+++ b/submissions/vacation-urgent-forwarder/metadata.json
@@ -2,7 +2,8 @@
   "name": "Vacation Urgent Forwarder",
   "description": "A Scout automation installer that, only during a configured vacation window, scans work email and Teams and forwards genuinely urgent items to your personal email.",
   "tags": ["scout", "automation", "email", "teams", "out-of-office"],
-  "author": "CAT Agent Skills",
+  "author": "Giorgio Ughini",
+  "authorUrl": "https://github.com/GiorgioUghini",
   "version": "1.0.0",
   "createdAt": "2026-07-16",
   "updatedAt": "2026-07-16"


### PR DESCRIPTION
## What

Backfills author attribution across the gallery so every skill has both an `author` and an `authorUrl`:

- **Adds a missing `author`** to the two submissions that had none:
  - `brand-template-enforcer` → **Simon Owen** (`SimonOwenDigital`)
  - `power-automate-desktop-assessment` → **Ricardo Calejo** (`dvsRCalejo`)
- **Adds `authorUrl`** (the author's GitHub profile) to every submission that was missing one — 13 skills in total.

Each `authorUrl` points at the GitHub profile of the actual author. Where the displayed author differed from the PR submitter, the correct person's handle was used:
- `presentation-talk-track-builder` → **Jagmeet Chabra** = `jchha001`
- `vacation-urgent-forwarder` → author corrected from the generic "CAT Agent Skills" to **Giorgio Ughini** (`GiorgioUghini`)

Regenerated `src/content/skills/*.md` for the affected entries via `npm run import:submissions`.

## Scope

Submission-only change (`submissions/**` + regenerated generated artifacts, which Guard PR scope ignores). No site/schema changes here — making `author` a required field will follow in a separate PR.

## Notes

The two former fork-PR skills (`persona-reaction-panel`, `power-automate-desktop-assessment`) have no committed generated artifacts on `main` by design (deploy regenerates them), so this PR only commits their `metadata.json` backfill, not local generated `.md`/bundles.