### PR TITLE
Fix author attribution: derive authorGithub from submission metadata

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,8 +95,11 @@ do the task?* If no — it's documentation, and belongs in the `README.md`.
   `skill.md` still imports, but prefer `SKILL.md`).
 - `metadata.json` should carry the documented fields only
   (`name`, `description`, `platforms`, `tags`, `author`, and the optional
-  `authorUrl`, `version`, `createdAt`, `updatedAt`, `coverColor`, `featured`).
-  Unknown keys are silently stripped by the schema — flag them as noise.
-- Never set `authorGithub` or `bundle` by hand; CI populates them.
+  `authorUrl`, `authorGithub`, `version`, `createdAt`, `updatedAt`, `coverColor`,
+  `featured`). Unknown keys are silently stripped by the schema — flag them as noise.
+- `authorGithub` is normally derived from a `github.com/<login>` `authorUrl`; set
+  it explicitly only to attribute an author whose link isn't a GitHub profile
+  (e.g. LinkedIn), or leave it unset. It is never the PR/merger login. Never set
+  `bundle` by hand; CI populates it.
 - The `SKILL.md` frontmatter `name` must be a lowercase-hyphenated slug that
   matches the submission folder name.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,12 @@ jobs:
       # Same-repo PRs get a write token: extract submission zips into the site
       # (writes src/content/skills/*.md + public/bundles/*.zip) and commit the
       # result back to the PR branch. Hard-fails on missing/invalid metadata.
+      # `authorGithub` is resolved purely from each submission's own metadata
+      # (an explicit handle, or a github.com/<login> authorUrl) — never the
+      # PR/merger login — so attribution is stable no matter who lands the skill.
       - name: Import skill submissions
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: npm run import:submissions
-        env:
-          # Stamp `authorGithub` on skills newly added in this PR with the
-          # submitter's login so the skillbot can @-mention the author on the
-          # first comment of the skill's discussion. Existing skills keep their
-          # already-stamped handle (set-once).
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
       - name: Commit extracted skills
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/skillbot.yml
+++ b/.github/workflows/skillbot.yml
@@ -1,11 +1,12 @@
 name: Skillbot
 
 # When the FIRST comment lands on a skill's discussion, greet the thread and
-# @-mention the skill's author (the PR submitter, stamped into the generated
-# skill frontmatter as `authorGithub` by the import pipeline). The greeting line
-# is a short, skill-themed pun generated with GitHub Models — with a plain
-# static fallback whenever AI is unavailable. The whole job is best-effort: any
-# missing data or failed call results in a no-op or the fallback, never a red X.
+# @-mention the skill's author (their `authorGithub` — resolved from the
+# submission metadata and stored in the generated skill frontmatter by the
+# import pipeline). The greeting line is a short, skill-themed pun generated
+# with GitHub Models — with a plain static fallback whenever AI is unavailable.
+# The whole job is best-effort: any missing data or failed call results in a
+# no-op or the fallback, never a red X.
 
 on:
   discussion_comment:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,12 +129,13 @@ the download bundle):
 | `tags`        | yes      | Lowercase tags for search/filtering.                |
 | `author`      | yes      | Person or team who wrote the skill.                 |
 
-Optional: `authorUrl`, `version`, `createdAt`, `updatedAt`,
+Optional: `authorUrl`, `authorGithub`, `version`, `createdAt`, `updatedAt`,
 `coverColor`, `featured`. (`bundle` is set automatically when your skill ships
-files beyond `SKILL.md`. `authorGithub` — your GitHub login as the PR
-submitter — is also filled in automatically by CI so the *skillbot* can
-@-mention you on the first comment of your skill's discussion; don't set it
-yourself.)
+files beyond `SKILL.md`. `authorGithub` — the author's GitHub login — is
+normally derived from an `authorUrl` that points to a GitHub profile
+(`https://github.com/<login>`); the *skillbot* uses it to @-mention the author
+on the first comment of the skill's discussion. Set it explicitly only when your
+only link isn't a GitHub profile, e.g. LinkedIn.)
 
 ## Validate locally
 

--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -9,8 +9,9 @@
  *   ├── metadata.json  (or metadata.yaml) Catalog metadata for THIS gallery:
  *   │                  `description` (the human catalog/gallery summary),
  *   │                  `platforms`, `tags`, `author`, `authorUrl`, `version`…
- *   │                  (`authorGithub`, the PR submitter's login, is stamped
- *   │                  automatically by CI — see PR_AUTHOR below — not authored.)
+ *   │                  (`authorGithub` is derived from a `github.com/<login>`
+ *   │                  `authorUrl`, or set explicitly for attribution — see
+ *   │                  resolveAuthorGithub. It is never the PR/merger login.)
  *   │                  It is a SIDECAR — never packaged into the download bundle.
  *   └── EITHER an unpacked canonical Agent Skill:
  *   │     ├── SKILL.md     frontmatter `name` + `description` (the AGENT-facing
@@ -192,39 +193,56 @@ function buildContent(meta: Record<string, unknown>, body: string): string {
   return serializeFrontmatter(meta) + body.replace(/^\s+/, "");
 }
 
+// A bare GitHub username: 1-39 chars, alphanumerics or single (non-leading,
+// non-trailing) hyphens. Mirrors the rule enforced by the skill schema.
+const GITHUB_USERNAME = /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i;
+
 /**
- * Resolve the skill author's GitHub handle (the PR submitter's login), used by
- * the "skillbot" to @-mention them on the first discussion comment. Set-once:
- *   1. Keep an explicit `authorGithub` already in the metadata.
- *   2. Otherwise preserve the value already stamped in the generated
- *      `src/content/skills/<slug>.md` (so a later, unrelated PR can never
- *      overwrite the original submitter).
- *   3. Otherwise fall back to `PR_AUTHOR` (set by CI on same-repo PRs) — this is
- *      a skill newly added in the current pull request.
- *   4. Otherwise leave it unset (e.g. local imports, fork PRs).
- * The result is mutated onto `meta` so every publish path stamps it uniformly.
+ * Derive a GitHub login from an author URL, but ONLY when it is a canonical
+ * GitHub *user* profile URL — `https://github.com/<login>` with exactly one
+ * path segment. Returns `undefined` for anything else, so org/repo URLs
+ * (`github.com/microsoft/cat-agent-skills`), Pages sites (`*.github.io`),
+ * LinkedIn, and personal domains never resolve to a handle. Case is preserved.
  */
-function resolveAuthorGithub(slug: string, meta: Record<string, unknown>): void {
+function githubLoginFromUrl(url: unknown): string | undefined {
+  if (typeof url !== "string" || !url.trim()) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return undefined;
+  }
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  if (host !== "github.com") return undefined;
+  const segments = parsed.pathname.split("/").filter(Boolean);
+  if (segments.length !== 1) return undefined;
+  const login = segments[0];
+  return GITHUB_USERNAME.test(login) ? login : undefined;
+}
+
+/**
+ * Resolve the skill author's GitHub handle — the persisted attribution shown in
+ * the gallery and used by the "skillbot" to @-mention the author on the first
+ * discussion comment. It is a PURE function of the submission's own metadata, so
+ * re-importing is idempotent and the result never depends on who merged the PR:
+ *   1. An explicit `authorGithub` in the submission metadata wins (use this when
+ *      the author's only link is not a GitHub profile, e.g. LinkedIn).
+ *   2. Otherwise derive it from a canonical `github.com/<login>` `authorUrl`.
+ *   3. Otherwise leave it UNSET — never stamp the merging maintainer.
+ * The result is mutated onto `meta` (set or deleted) so every publish path
+ * resolves it uniformly.
+ */
+function resolveAuthorGithub(meta: Record<string, unknown>): void {
   if (typeof meta.authorGithub === "string" && meta.authorGithub.trim()) {
     meta.authorGithub = meta.authorGithub.trim();
     return;
   }
-  const existingPath = join(CONTENT_DIR, `${slug}.md`);
-  if (existsSync(existingPath)) {
-    try {
-      const prior = matter(readFileSync(existingPath, "utf8")).data as {
-        authorGithub?: unknown;
-      };
-      if (typeof prior.authorGithub === "string" && prior.authorGithub.trim()) {
-        meta.authorGithub = prior.authorGithub.trim();
-        return;
-      }
-    } catch {
-      // Unparseable existing file: fall through to the PR-author fallback.
-    }
+  const login = githubLoginFromUrl(meta.authorUrl);
+  if (login) {
+    meta.authorGithub = login;
+    return;
   }
-  const prAuthor = process.env.PR_AUTHOR?.trim();
-  if (prAuthor) meta.authorGithub = prAuthor;
+  delete meta.authorGithub;
 }
 
 /** Parse a metadata file (JSON or YAML) into a plain object. */
@@ -393,7 +411,7 @@ function processSubmission(sub: Submission): ImportProblem | null {
   const hasBundle = sub.bundleFiles.length > 0;
   if (hasBundle) meta.bundle = `bundles/${slug}.zip`;
 
-  resolveAuthorGithub(slug, meta);
+  resolveAuthorGithub(meta);
 
   const result = validateSkillData(meta, label);
   if (!result.ok) return { source: label, problems: result.problems };
@@ -536,7 +554,7 @@ function processPlugin(sub: Submission): ImportProblem | null {
     bundle: `bundles/${slug}.zip`,
   };
 
-  resolveAuthorGithub(slug, meta);
+  resolveAuthorGithub(meta);
 
   const result = validateSkillData(meta, label);
   if (!result.ok) return { source: label, problems: result.problems };
@@ -684,7 +702,7 @@ function processAutomationInstaller(sub: Submission): ImportProblem | null {
     bundle: `bundles/${slug}.zip`,
   };
 
-  resolveAuthorGithub(slug, meta);
+  resolveAuthorGithub(meta);
 
   const result = validateSkillData(meta, label);
   if (!result.ok) return { source: label, problems: result.problems };
@@ -786,7 +804,7 @@ function processAutomation(sub: Submission): ImportProblem | null {
     bundle: `bundles/${slug}.json`,
   };
 
-  resolveAuthorGithub(slug, meta);
+  resolveAuthorGithub(meta);
 
   const result = validateSkillData(meta, label);
   if (!result.ok) return { source: label, problems: result.problems };

--- a/src/content/skills/ai-demo-assistant.md
+++ b/src/content/skills/ai-demo-assistant.md
@@ -5,7 +5,7 @@ agentDescription: "Builds a scenario-driven content pack for a Microsoft 365 Cop
 platforms: [Cowork]
 tags: [demo, copilot, microsoft-365, sales-enablement, content, productivity]
 author: Doak Moore
-authorGithub: adilei
+authorGithub: doakm
 version: 1.0.0
 ---
 # AI Demo Assistant

--- a/src/content/skills/ai-usecase-assessment.md
+++ b/src/content/skills/ai-usecase-assessment.md
@@ -6,7 +6,7 @@ platforms: [Scout, Cowork]
 tags: [assessment, ai, agent, use-case, scoring, report, html, intake]
 author: Alicja Gilderdale
 authorUrl: "https://www.linkedin.com/in/alicja-gilderdale/"
-authorGithub: adilei
+authorGithub: alicja-gilderdale
 version: 1.0.0
 createdAt: 2026-07-17
 updatedAt: 2026-07-17

--- a/src/content/skills/chart-builder.md
+++ b/src/content/skills/chart-builder.md
@@ -6,7 +6,6 @@ platforms: [Cowork, Copilot Studio, Scout]
 tags: [data, charts, matplotlib, scripts]
 author: CAT Agent Skills
 authorUrl: "https://github.com/microsoft/cat-agent-skills"
-authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14

--- a/src/content/skills/copilot-agents-news-scout.md
+++ b/src/content/skills/copilot-agents-news-scout.md
@@ -6,7 +6,7 @@ type: automation
 tags: [news, copilot, agent, digest, automation, weekly, teams]
 author: Elliot Margot
 authorUrl: "https://e-margot.ch"
-authorGithub: adilei
+authorGithub: OwnOptic
 version: 1.0.0
 createdAt: 2026-07-18
 updatedAt: 2026-07-18

--- a/src/content/skills/copilot-studio-test-planner.md
+++ b/src/content/skills/copilot-studio-test-planner.md
@@ -6,7 +6,7 @@ type: plugin
 tags: [qa, eval, regression, agent]
 author: Elliot Margot
 authorUrl: "https://e-margot.ch"
-authorGithub: adilei
+authorGithub: OwnOptic
 version: 1.0.0
 createdAt: 2026-07-18
 updatedAt: 2026-07-18

--- a/src/content/skills/copilot-studio-topic-blueprint.md
+++ b/src/content/skills/copilot-studio-topic-blueprint.md
@@ -6,7 +6,7 @@ platforms: [Copilot Studio]
 tags: [agent, blueprint, topics, design, power-platform, orchestration, adaptive-card]
 author: Elliot Margot
 authorUrl: "https://e-margot.ch"
-authorGithub: adilei
+authorGithub: OwnOptic
 version: 1.0.0
 createdAt: 2026-07-18
 updatedAt: 2026-07-18

--- a/src/content/skills/idea-refiner.md
+++ b/src/content/skills/idea-refiner.md
@@ -6,7 +6,7 @@ platforms: [Copilot Studio]
 tags: [productivity, planning, decision-making, refinement, brainstorming]
 author: Mathias Salomonsen
 authorUrl: "https://www.linkedin.com/in/mathias-salomonsen-331949201"
-authorGithub: adilei
+authorGithub: m-salomonsen
 version: 1.0.0
 createdAt: 2026-07-18
 updatedAt: 2026-07-18

--- a/src/content/skills/microsoft-ai-platform-advisor.md
+++ b/src/content/skills/microsoft-ai-platform-advisor.md
@@ -6,7 +6,7 @@ platforms: [Copilot Studio]
 tags: [advisor, discovery, architecture, decision-making, requirements, risk-assessment, microsoft-365-copilot, foundry, foundry-agent-service, agent-365, windows-ai-foundry]
 author: Rafsan Huseynov
 authorUrl: "https://www.linkedin.com/in/rafsanhuseynov"
-authorGithub: adilei
+authorGithub: rafsan-huseynov
 version: 1.0.0
 createdAt: 2026-07-18
 updatedAt: 2026-07-18

--- a/src/content/skills/persona-reaction-panel.md
+++ b/src/content/skills/persona-reaction-panel.md
@@ -6,7 +6,7 @@ platforms: [Cowork, Copilot Studio]
 tags: [communications, change-management, launch-readiness, personas, qa]
 author: Olivia Zhang
 authorUrl: "https://github.com/Olivia2327"
-authorGithub: adilei
+authorGithub: Olivia2327
 version: 1.0.0
 bundle: bundles/persona-reaction-panel.zip
 ---

--- a/src/content/skills/power-automate-desktop-assessment.md
+++ b/src/content/skills/power-automate-desktop-assessment.md
@@ -6,7 +6,7 @@ platforms: [Cowork, Copilot Studio]
 tags: [power-automate, desktop-flows, automation, assessment, governance]
 author: Ricardo Calejo
 authorUrl: "https://github.com/dvsRCalejo"
-authorGithub: adilei
+authorGithub: dvsRCalejo
 version: 1.1.0
 createdAt: 2026-07-17
 updatedAt: 2026-07-18

--- a/src/content/skills/powerpoint-deck-designer.md
+++ b/src/content/skills/powerpoint-deck-designer.md
@@ -6,7 +6,7 @@ platforms: [Copilot Studio]
 tags: [powerpoint, presentations, python, charts]
 author: Ferran Chopo
 authorUrl: "https://www.linkedin.com/in/fchopo"
-authorGithub: adilei
+authorGithub: fchopo
 version: 1.0.0
 bundle: bundles/powerpoint-deck-designer.zip
 slug: powerpoint-deck-designer

--- a/src/content/skills/presentation-talk-track-builder.md
+++ b/src/content/skills/presentation-talk-track-builder.md
@@ -6,7 +6,7 @@ platforms: [Cowork, Copilot Studio, Scout]
 tags: [presentations, speaker-notes, powerpoint, writing, productivity]
 author: Jagmeet Chabra
 authorUrl: "https://github.com/jchha001"
-authorGithub: adilei
+authorGithub: jchha001
 version: 1.0.0
 createdAt: 2026-07-16
 updatedAt: 2026-07-17

--- a/src/content/skills/sharepoint-list-formatter.md
+++ b/src/content/skills/sharepoint-list-formatter.md
@@ -6,7 +6,7 @@ platforms: [Cowork, Copilot Studio, Scout]
 tags: [sharepoint, microsoft-365, productivity, tables, data]
 author: Mathias Salomonsen
 authorUrl: "https://www.linkedin.com/in/mathias-salomonsen-331949201"
-authorGithub: adilei
+authorGithub: m-salomonsen
 version: 1.0.0
 createdAt: 2026-07-17
 updatedAt: 2026-07-17

--- a/src/lib/skill-schema.ts
+++ b/src/lib/skill-schema.ts
@@ -42,12 +42,12 @@ export const skillSchema = z.object({
   // Optional URL to the author's website / profile, shown as a link on the
   // skill page when an `author` is also present.
   authorUrl: z.string().url().optional(),
-  // The GitHub login of the person who submitted the skill (the PR author),
-  // stored WITHOUT a leading `@`. Auto-populated by CI from the pull request
-  // submitter (never authored by hand) so the "skillbot" can @-mention the
-  // author on the first comment of the skill's discussion. A bare GitHub
-  // username: 1-39 chars, alphanumerics or single hyphens, no leading/trailing
-  // hyphen.
+  // The skill author's GitHub login, stored WITHOUT a leading `@`. Resolved by
+  // the importer purely from the submission — an explicit `authorGithub`, else
+  // derived from a `github.com/<login>` `authorUrl`, else unset — never from the
+  // PR/merger login. Used by the "skillbot" to @-mention the author on the first
+  // comment of the skill's discussion. A bare GitHub username: 1-39 chars,
+  // alphanumerics or single hyphens, no leading/trailing hyphen.
   authorGithub: z
     .string()
     .regex(

--- a/submissions/README.md
+++ b/submissions/README.md
@@ -114,7 +114,7 @@ The same fields work in a `metadata.yaml` if you prefer YAML.
 | `tags`        | `metadata.json` | yes      | Lowercase tags for search/filtering.                         |
 | `author`      | `metadata.json` |          | Person or team.                                              |
 | `authorUrl`   | `metadata.json` |          | Link to the author's website/profile.                        |
-| `authorGithub`| —               |          | Submitter's GitHub login. Set automatically by CI from the PR author — don't add it (see below).|
+| `authorGithub`| `metadata.json` |          | Author's GitHub login. Normally derived from a `github.com/<login>` `authorUrl`; set it explicitly only when the author's link isn't a GitHub profile (see below).|
 | `version`     | `metadata.json` |          | Semantic version, e.g. `1.0.0`.                              |
 | `createdAt`   | `metadata.json` |          | `YYYY-MM-DD`.                                                |
 | `updatedAt`   | `metadata.json` |          | `YYYY-MM-DD`.                                                |
@@ -125,15 +125,22 @@ The same fields work in a `metadata.yaml` if you prefer YAML.
 A missing or invalid **required** field fails the PR with a message listing
 exactly what's wrong.
 
-### `authorGithub` (auto-populated)
+### `authorGithub` (attribution)
 
-When you open a pull request, CI stamps the new skill's generated frontmatter
-with `authorGithub` — your GitHub login as the PR submitter. **You never write
-this field by hand.** Once set it stays put: editing another skill later won't
-overwrite it. It exists so the repo's *skillbot* can @-mention you on the first
-comment of your skill's discussion, so you hear about early feedback. (Skills
-contributed from a fork are stamped when a maintainer runs the importer, so the
-mention may be skipped until then.)
+`authorGithub` is the author's GitHub login, stored WITHOUT a leading `@`. The
+importer resolves it purely from your submission — never from whoever merges the
+PR — so attribution is stable no matter who lands the skill:
+
+1. an explicit `authorGithub` in `metadata.json` wins; otherwise
+2. it is derived from `authorUrl` when that points to a GitHub profile
+   (`https://github.com/<login>`); otherwise
+3. it is left unset.
+
+It exists so the repo's *skillbot* can @-mention the author on the first comment
+of the skill's discussion, so they hear about early feedback. **Most contributors
+don't need to set it** — just make `authorUrl` your GitHub profile. Set it
+explicitly only when your only link isn't a GitHub profile (e.g. LinkedIn), or
+leave it blank to opt out of the mention.
 
 ## Cowork plugins (advanced)
 

--- a/submissions/ai-demo-assistant/metadata.json
+++ b/submissions/ai-demo-assistant/metadata.json
@@ -4,5 +4,6 @@
   "platforms": ["Cowork"],
   "tags": ["demo", "copilot", "microsoft-365", "sales-enablement", "content", "productivity"],
   "author": "Doak Moore",
+  "authorGithub": "doakm",
   "version": "1.0.0"
 }

--- a/submissions/ai-usecase-assessment/metadata.json
+++ b/submissions/ai-usecase-assessment/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["assessment", "ai", "agent", "use-case", "scoring", "report", "html", "intake"],
   "author": "Alicja Gilderdale",
   "authorUrl": "https://www.linkedin.com/in/alicja-gilderdale/",
+  "authorGithub": "alicja-gilderdale",
   "version": "1.0.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"

--- a/submissions/campaign-deck-builder/metadata.json
+++ b/submissions/campaign-deck-builder/metadata.json
@@ -13,6 +13,7 @@
   ],
   "author": "Adi Leibowitz",
   "authorUrl": "https://microsoft.github.io/mcscatblog/",
+  "authorGithub": "adilei",
   "version": "1.0.0",
   "createdAt": "2026-07-09",
   "updatedAt": "2026-07-09"

--- a/submissions/copilot-agents-news-scout/metadata.json
+++ b/submissions/copilot-agents-news-scout/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["news", "copilot", "agent", "digest", "automation", "weekly", "teams"],
   "author": "Elliot Margot",
   "authorUrl": "https://e-margot.ch",
+  "authorGithub": "OwnOptic",
   "version": "1.0.0",
   "createdAt": "2026-07-18",
   "updatedAt": "2026-07-18"

--- a/submissions/copilot-studio-test-planner/metadata.json
+++ b/submissions/copilot-studio-test-planner/metadata.json
@@ -4,6 +4,7 @@
   "tags": ["qa", "eval", "regression", "agent"],
   "author": "Elliot Margot",
   "authorUrl": "https://e-margot.ch",
+  "authorGithub": "OwnOptic",
   "version": "1.0.0",
   "createdAt": "2026-07-18",
   "updatedAt": "2026-07-18"

--- a/submissions/copilot-studio-topic-blueprint/metadata.json
+++ b/submissions/copilot-studio-topic-blueprint/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["agent", "blueprint", "topics", "design", "power-platform", "orchestration", "adaptive-card"],
   "author": "Elliot Margot",
   "authorUrl": "https://e-margot.ch",
+  "authorGithub": "OwnOptic",
   "version": "1.0.0",
   "createdAt": "2026-07-18",
   "updatedAt": "2026-07-18"

--- a/submissions/idea-refiner/metadata.json
+++ b/submissions/idea-refiner/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["productivity", "planning", "decision-making", "refinement", "brainstorming"],
   "author": "Mathias Salomonsen",
   "authorUrl": "https://www.linkedin.com/in/mathias-salomonsen-331949201",
+  "authorGithub": "m-salomonsen",
   "version": "1.0.0",
   "createdAt": "2026-07-18",
   "updatedAt": "2026-07-18"

--- a/submissions/knowledge-source-router/metadata.json
+++ b/submissions/knowledge-source-router/metadata.json
@@ -13,6 +13,7 @@
   ],
   "author": "Adi Leibowitz",
   "authorUrl": "https://microsoft.github.io/mcscatblog/",
+  "authorGithub": "adilei",
   "version": "1.0.0",
   "createdAt": "2026-06-23",
   "updatedAt": "2026-06-23",

--- a/submissions/linkedin-content-writer/metadata.json
+++ b/submissions/linkedin-content-writer/metadata.json
@@ -12,6 +12,7 @@
   ],
   "author": "Becky Still, Digital Boop Ltd",
   "authorUrl": "https://digital-boop.co.uk/my-story",
+  "authorGithub": "DigitalBoopLtd",
   "version": "1.0.1",
   "createdAt": "2026-07-14",
   "updatedAt": "2026-07-17"

--- a/submissions/microsoft-ai-platform-advisor/metadata.json
+++ b/submissions/microsoft-ai-platform-advisor/metadata.json
@@ -17,6 +17,7 @@
   ],
   "author": "Rafsan Huseynov",
   "authorUrl": "https://www.linkedin.com/in/rafsanhuseynov",
+  "authorGithub": "rafsan-huseynov",
   "version": "1.0.0",
   "createdAt": "2026-07-18",
   "updatedAt": "2026-07-18"

--- a/submissions/powerpoint-deck-designer/metadata.json
+++ b/submissions/powerpoint-deck-designer/metadata.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "author": "Ferran Chopo",
   "authorUrl": "https://www.linkedin.com/in/fchopo",
+  "authorGithub": "fchopo",
   "description": "Creates polished PowerPoint decks from a JSON specification using python-pptx. Designed as a Copilot Studio Skill that runs natively inside the agent's Python container (no Azure Function or custom connector required). Supports 8 layouts plus native charts (bar, column, line, pie, donut with stacked / 100% stacked variants).",
   "license": "MIT",
   "platforms": ["Copilot Studio"],

--- a/submissions/sharepoint-list-formatter/metadata.json
+++ b/submissions/sharepoint-list-formatter/metadata.json
@@ -5,6 +5,7 @@
   "tags": ["sharepoint", "microsoft-365", "productivity", "tables", "data"],
   "author": "Mathias Salomonsen",
   "authorUrl": "https://www.linkedin.com/in/mathias-salomonsen-331949201",
+  "authorGithub": "m-salomonsen",
   "version": "1.0.0",
   "createdAt": "2026-07-17",
   "updatedAt": "2026-07-17"


### PR DESCRIPTION
## The bug

`authorGithub` in each generated `src/content/skills/<slug>.md` is meant to be the skill's **real author**, but in practice it held the login of **whoever's PR landed the generated file** — the maintainer merging fork submissions, not the author.

**Root cause (two places):**
1. `.github/workflows/ci.yml` — the "Import skill submissions" step (same-repo PRs only) passed `PR_AUTHOR: ${{ github.event.pull_request.user.login }}`. Fork PRs are validate-only (no write token), so their generated files were produced *later* by a maintainer's same-repo bulk PR (e.g. #104 "Backfill author and authorUrl", #107 "Consolidate tags"), where `PR_AUTHOR` resolved to the **merger** (`adilei`).
2. `scripts/import-submissions.ts` `resolveAuthorGithub()` — resolution order was (a) explicit `authorGithub`, (b) **preserve the prior stamped value** (set-once), (c) fall back to `process.env.PR_AUTHOR`, (d) else unset. Step (c) stamped the merger; step (b) then froze that wrong value forever.

Net effect: **16 skills** were stamped `authorGithub: adilei` but were authored by 10 different people. The gallery groups by `authorGithub`, collapsing all 16 under `adilei`.

## The fix (deterministic)

`authorGithub` is now a **pure function of each submission's own metadata** — never the merger:

1. an explicit `authorGithub` in `metadata.json` wins (use this when the author's only link isn't a GitHub profile, e.g. LinkedIn);
2. else derive `<login>` from a canonical `github.com/<login>` `authorUrl` (host `github.com`, optional `www.`, exactly one path segment — so `github.com/org/repo` and `*.github.io` are excluded; case preserved);
3. else leave it **UNSET** — never stamp the merging maintainer.

Both the `PR_AUTHOR` fallback and the set-once preservation are **removed**, and `PR_AUTHOR` is removed from `ci.yml`. The importer is now idempotent/self-correcting: re-running it always reproduces the same result from author-controlled metadata.

**Skillbot double-duty:** `authorGithub` also drives the skillbot @-mention. Since it now holds the real author, the mention targets the right person. Documented tradeoff: a contributor whose only link is non-GitHub isn't auto-mentioned unless they set an explicit `authorGithub`.

## Backfill — before → after (all 16 mis-stamped + 1 regression guard)

| Skill | Real author | Old | New `authorGithub` | How | Source |
|---|---|---|---|---|---|
| ai-usecase-assessment | Alicja Gilderdale | `adilei` | `alicja-gilderdale` | explicit | fork PR #74 |
| copilot-agents-news-scout | Elliot Margot | `adilei` | `OwnOptic` | explicit | fork PR #101 |
| copilot-studio-test-planner | Elliot Margot | `adilei` | `OwnOptic` | explicit | fork PR #101 |
| copilot-studio-topic-blueprint | Elliot Margot | `adilei` | `OwnOptic` | explicit | fork PR #101 |
| microsoft-ai-platform-advisor | Rafsan Huseynov | `adilei` | `rafsan-huseynov` | explicit | fork PR #100 |
| powerpoint-deck-designer | Ferran Chopo | `adilei` | `fchopo` | explicit | fork PR #70 |
| sharepoint-list-formatter | Mathias Salomonsen | `adilei` | `m-salomonsen` | explicit | fork PR #67 |
| idea-refiner | Mathias Salomonsen | `adilei` | `m-salomonsen` | explicit | fork PR #99 |
| ai-demo-assistant | Doak Moore | `adilei` | `doakm` | explicit | fork PR #102 |
| persona-reaction-panel | Olivia Zhang | `adilei` | `Olivia2327` | derived | `authorUrl` github.com/Olivia2327 |
| power-automate-desktop-assessment | Ricardo Calejo | `adilei` | `dvsRCalejo` | derived | `authorUrl` github.com/dvsRCalejo |
| presentation-talk-track-builder | Jagmeet Chabra | `adilei` | `jchha001` | derived | `authorUrl` github.com/jchha001 |
| campaign-deck-builder | Adi Leibowitz | `adilei` | `adilei` | explicit | genuine (authorUrl is github.io) |
| knowledge-source-router | Adi Leibowitz | `adilei` | `adilei` | explicit | genuine (authorUrl is github.io) |
| spend-more-time-with-friends-and-family | Adi Leibowitz | `adilei` | `adilei` | derived | genuine (github.com/adilei) |
| chart-builder | CAT Agent Skills (house account) | `adilei` | *(blank)* | not derivable | authorUrl is org/repo URL |
| **linkedin-content-writer** | Becky Still (Digital Boop) | `DigitalBoopLtd` | `DigitalBoopLtd` | explicit **(regression guard)** | fork PR #51 |

**⚠️ Regression guard:** `linkedin-content-writer` was already correct (`DigitalBoopLtd`), but its `authorUrl` is a personal site — the new derive logic would have **blanked** it. An explicit `authorGithub: DigitalBoopLtd` was added to `metadata.json` to preserve it. (Verified against fork PR #51's author.)

All 8 explicit handles recovered from fork history were verified against the actual PR author login (`gh pr view`).

## What changed

**Backfill** — explicit `authorGithub` added to `metadata.json` for the 12 skills whose author has no `github.com/<login>` `authorUrl`. The other 4 are auto-corrected by the derive logic; `chart-builder` (house account) is left blank.

**Source/infra:**
- `scripts/import-submissions.ts` — rewrote `resolveAuthorGithub()` + added `githubLoginFromUrl()` helper.
- `.github/workflows/ci.yml` — removed `PR_AUTHOR`.
- `src/lib/skill-schema.ts`, `.github/workflows/skillbot.yml` — updated comments to the new semantics.
- `CONTRIBUTING.md`, `submissions/README.md`, `.github/copilot-instructions.md` — documented the new resolution order and the "set explicit `authorGithub` if your only link is non-GitHub" tradeoff.

## Verification

- `npm run import:submissions` → the generated diff is **only** `authorGithub` lines: 13 skills flip `adilei` → real handle, `chart-builder` blanked, zero churn on the ~15 already-correct non-`adilei` skills (case preserved), zero bundle churn.
- `npm run check:submissions` and `npm run build` pass.
- Generated files under `src/content/skills/*` and `public/bundles/*` are **not committed** — CI regenerates them.

## PR scope

This intentionally mixes SITE (`scripts/`, `.github/`, `CONTRIBUTING.md`, `src/lib/`) and SUBMISSION (`submissions/*/metadata.json`, `submissions/README.md`) paths, because the deterministic importer and the one-time backfill belong together. **Needs the `allow-mixed-changes` label** to pass `guard-scope` (confirmed with the repo owner).