### PR TITLE
Add shareable contributor badge posters (page + OG image)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,16 @@
         "astro": "^7.0.7"
       },
       "devDependencies": {
+        "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/typography": "^0.5.16",
         "@tailwindcss/vite": "^4.1.4",
         "@types/adm-zip": "^0.5.8",
         "adm-zip": "^0.5.17",
         "croner": "^9.1.0",
         "gray-matter": "^4.0.3",
+        "satori": "^0.26.0",
         "tailwindcss": "^4.1.4",
         "tsx": "^4.22.4"
       }
@@ -938,6 +942,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha1-dilo86pECLeIbq0Y+z6Cts4C70E=",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha1-VqG7uKNqR/5IDT6QswtSDImFOqU=",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -1484,6 +1508,234 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha1-PpKpB9iNh5JWxYU0fFshp/O7W0Y=",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha1-52HgtogSfbZIefRVF4ySRoqa6r4=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha1-uMtWTX9rPzfZtDEp9dxf4XHiSeQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha1-Sb0/rtpcSfUzAtlw5uedAG3hjn0=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha1-4TRBc6onv7TYgKtXbRrPHBZI+so=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha1-NMRF66Re/Wj2EwsqtCbXanQkJT0=",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha1-MNpHCH3YFTGCGYuU/p+NmUiQ2uU=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha1-XXW4/1yDEDcpwco3eZhzAnU8UNQ=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha1-QRq+367l7cV8u3cBc2zsulIuJvM=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha1-/kmEA48DcvJ54/9XC3KTTdfrKlw=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha1-06BTz3/2hwh6IQYzDA/arnBiVNE=",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha1-fN2hzinvcgnigZHZF/pb7wYkpK0=",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha1-ywrQRSXWXz3vTI00YVeleXbVs4g=",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -2212,6 +2464,23 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha1-XR5+ngVvVGqtQd8cUEP4+F054ks=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2746,11 +3015,31 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha1-ibfhaIQFYzGjXWta0GQzLJHapsM=",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -2821,6 +3110,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -2887,6 +3183,40 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha1-SKF/f+bU1PG8oxd93xbFYXlQdBs=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha1-nq63FAlHv11kn8SaGeS7ql9gJxM=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha1-mlI0GfMorSd3rnkMKWppMtRwqpo=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -2901,6 +3231,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha1-zdgJn3ECThSeT2/hen1G7NVfHjI=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -3108,6 +3450,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha1-AS9OTYjs7IOX3zLVtO+J1CJVnA4=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.22.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
@@ -3168,6 +3520,13 @@
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -3248,6 +3607,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha1-YVh+XZWP2rtak2ijAsJTY/T2n1A=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/flattie": {
       "version": "1.1.1",
@@ -3412,6 +3778,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha1-r16XToO7L+/kTVUYKwBOyBjAd3Y=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-escaper": {
@@ -3779,6 +4158,17 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha1-gxzzeNmLztOB2KsRj4Ur1Q2B5Gs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.5.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -4102,6 +4492,24 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha1-toelg/LkLmb/386ApXBwaWboB8k=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -4167,6 +4575,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha1-cjwJkgg2um0+WvAZ+SvAlxwC5RQ=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -4342,6 +4757,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/satori": {
+      "version": "0.26.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/satori/-/satori-0.26.0.tgz",
+      "integrity": "sha1-vZnfBU+G/7STmsjWCqkqOlsNnIA=",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/satteri": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
@@ -4507,6 +4945,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -4688,6 +5133,17 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha1-j9iEVpbi4UqLZ9ePqeDdLK1i/sg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -5040,6 +5496,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha1-0tG6BvDoHC62UMPlrYsLSt3h6EM=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,16 @@
     "astro": "^7.0.7"
   },
   "devDependencies": {
+    "@fontsource/dm-sans": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@types/adm-zip": "^0.5.8",
     "adm-zip": "^0.5.17",
     "croner": "^9.1.0",
     "gray-matter": "^4.0.3",
+    "satori": "^0.26.0",
     "tailwindcss": "^4.1.4",
     "tsx": "^4.22.4"
   }

--- a/src/lib/badge-data.ts
+++ b/src/lib/badge-data.ts
@@ -1,0 +1,23 @@
+import { getCollection } from "astro:content";
+import { getRating } from "./ratings";
+import type { BadgeSkill } from "./badges";
+
+/**
+ * The badge-relevant view of the skills collection, used by every build-time
+ * surface that resolves badges (the contributors page, the poster page, and the
+ * OG-image endpoint). The client-side reveal reads the same fields off
+ * `/skills.json`, so all four stay in lockstep as long as they map identically.
+ */
+export async function loadBadgeSkills(): Promise<BadgeSkill[]> {
+  const skills = await getCollection("skills");
+  return skills.map((s) => ({
+    slug: s.id,
+    name: s.data.name,
+    author: s.data.author,
+    authorGithub: s.data.authorGithub ?? null,
+    featured: s.data.featured,
+    rating: getRating(s.id),
+    createdAt: s.data.createdAt ?? null,
+    platforms: s.data.platforms,
+  }));
+}

--- a/src/lib/badge-poster.ts
+++ b/src/lib/badge-poster.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import satori from "satori";
+import { Resvg } from "@resvg/resvg-js";
+import type { PosterTile } from "./badges";
+
+const require = createRequire(import.meta.url);
+
+// Brand palette — the same navy / cream / gold the badge medallions are painted in.
+const NAVY = "#0d1836";
+const NAVY_DEEP = "#080f28";
+const CREAM = "#f5efe0";
+const CREAM_MUTED = "#c3cbe0";
+const GOLD = "#e8b64a";
+const HAIRLINE = "rgba(245, 239, 224, 0.14)";
+const TILE_BG = "rgba(255, 255, 255, 0.05)";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+/** Read one vendored @fontsource `.woff` (satori reads ttf/otf/woff, not woff2). */
+function fontFile(pkg: string, file: string): Buffer {
+  return readFileSync(require.resolve(`${pkg}/files/${file}`));
+}
+
+// Loaded once per build process.
+let fontsCache: Parameters<typeof satori>[1]["fonts"] | null = null;
+function fonts() {
+  if (fontsCache) return fontsCache;
+  fontsCache = [
+    {
+      name: "DM Sans",
+      data: fontFile("@fontsource/dm-sans", "dm-sans-latin-400-normal.woff"),
+      weight: 400,
+      style: "normal",
+    },
+    {
+      name: "DM Sans",
+      data: fontFile("@fontsource/dm-sans", "dm-sans-latin-700-normal.woff"),
+      weight: 700,
+      style: "normal",
+    },
+    {
+      name: "JetBrains Mono",
+      data: fontFile(
+        "@fontsource/jetbrains-mono",
+        "jetbrains-mono-latin-500-normal.woff",
+      ),
+      weight: 500,
+      style: "normal",
+    },
+  ];
+  return fontsCache;
+}
+
+const badgeCache = new Map<string, string>();
+/** Inline a badge medallion PNG as a data URI (satori can't fetch by URL at build). */
+function badgeDataUri(image: string): string {
+  const cached = badgeCache.get(image);
+  if (cached) return cached;
+  const buf = readFileSync(join(process.cwd(), "public", "badges", `${image}.png`));
+  const uri = `data:image/png;base64,${buf.toString("base64")}`;
+  badgeCache.set(image, uri);
+  return uri;
+}
+
+export interface PosterInput {
+  login: string;
+  title: string;
+  image: string;
+  caption: string;
+  tiles: PosterTile[];
+  siteLabel: string;
+}
+
+// Minimal satori element helper (avoids JSX in a .ts lib).
+type El = {
+  type: string;
+  props: { style: Record<string, unknown>; children?: unknown };
+};
+const box = (style: Record<string, unknown>, children?: unknown): El => ({
+  type: "div",
+  props: { style: { display: "flex", ...style }, children },
+});
+const text = (style: Record<string, unknown>, value: string): El => ({
+  type: "div",
+  props: { style, children: value },
+});
+
+function posterElement(input: PosterInput): El {
+  const tiles = input.tiles.map((t) =>
+    box(
+      {
+        flexDirection: "column",
+        gap: 4,
+        padding: "16px 22px",
+        background: TILE_BG,
+        border: `1px solid ${HAIRLINE}`,
+        borderRadius: 16,
+      },
+      [
+        text(
+          { fontSize: 40, fontWeight: 700, color: CREAM, lineHeight: 1 },
+          t.num,
+        ),
+        text(
+          {
+            fontFamily: "JetBrains Mono",
+            fontSize: 17,
+            fontWeight: 500,
+            letterSpacing: 1,
+            textTransform: "uppercase",
+            color: CREAM_MUTED,
+          },
+          t.label,
+        ),
+      ],
+    ),
+  );
+
+  return box(
+    {
+      width: WIDTH,
+      height: HEIGHT,
+      flexDirection: "column",
+      position: "relative",
+      background: NAVY,
+      fontFamily: "DM Sans",
+    },
+    [
+      // Ambient glow behind the medallion.
+      box({
+        position: "absolute",
+        top: -160,
+        left: -120,
+        width: 620,
+        height: 620,
+        borderRadius: 620,
+        backgroundImage: `radial-gradient(circle, rgba(232,182,74,0.22), rgba(13,24,54,0))`,
+      }),
+      // Main content row.
+      box(
+        {
+          flex: 1,
+          alignItems: "center",
+          gap: 56,
+          padding: "64px 72px 40px",
+        },
+        [
+          {
+            type: "img",
+            props: {
+              src: badgeDataUri(input.image),
+              width: 360,
+              height: 360,
+              style: { width: 360, height: 360, objectFit: "contain" },
+            },
+          } as unknown as El,
+          box({ flexDirection: "column", flex: 1 }, [
+            text(
+              {
+                fontFamily: "JetBrains Mono",
+                fontSize: 24,
+                fontWeight: 500,
+                letterSpacing: 3,
+                textTransform: "uppercase",
+                color: GOLD,
+              },
+              `Issued to @${input.login}`,
+            ),
+            text(
+              {
+                fontSize: 68,
+                fontWeight: 700,
+                color: CREAM,
+                lineHeight: 1.05,
+                marginTop: 10,
+              },
+              input.title,
+            ),
+            text(
+              {
+                fontSize: 30,
+                fontWeight: 400,
+                color: CREAM_MUTED,
+                lineHeight: 1.35,
+                marginTop: 18,
+                maxWidth: 640,
+              },
+              `\u201C${input.caption}\u201D`,
+            ),
+            box({ gap: 16, marginTop: 30 }, tiles),
+          ]),
+        ],
+      ),
+      // Footer bar: brand wordmark left, gallery URL right.
+      box(
+        {
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "22px 72px",
+          borderTop: `1px solid ${HAIRLINE}`,
+          background: NAVY_DEEP,
+        },
+        [
+          box({ alignItems: "baseline", gap: 10 }, [
+            text(
+              { fontSize: 26, fontWeight: 700, color: GOLD, letterSpacing: 1 },
+              "CAT",
+            ),
+            text(
+              { fontSize: 26, fontWeight: 700, color: CREAM },
+              "Agent Skills",
+            ),
+          ]),
+          text(
+            {
+              fontFamily: "JetBrains Mono",
+              fontSize: 22,
+              fontWeight: 500,
+              color: CREAM_MUTED,
+            },
+            input.siteLabel,
+          ),
+        ],
+      ),
+    ],
+  );
+}
+
+/** Render a contributor's badge poster as a 1200×630 PNG buffer (build-time only). */
+export async function renderBadgePng(input: PosterInput): Promise<Buffer> {
+  const svg = await satori(posterElement(input) as never, {
+    width: WIDTH,
+    height: HEIGHT,
+    fonts: fonts(),
+  });
+  const png = new Resvg(svg, {
+    fitTo: { mode: "width", value: WIDTH },
+    font: { loadSystemFonts: false },
+  })
+    .render()
+    .asPng();
+  return Buffer.from(png);
+}

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -277,3 +277,65 @@ export function resolveBadge(login: string, skills: BadgeSkill[]): ResolvedBadge
   const badge = pickBadge(stats, buildContext(skills));
   return { badge, caption: captionFor(badge, stats.login), stats };
 }
+
+/** A single evidence tile: a big number/label pair under a revealed badge. */
+export interface PosterTile {
+  num: string;
+  label: string;
+}
+
+const TILE_DATE_FMT = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+/** Format a timestamp as the compact "latest" tile value (UTC, so build + client agree). */
+export function formatTileDate(ms: number | null): string | null {
+  return ms ? TILE_DATE_FMT.format(new Date(ms)) : null;
+}
+
+/**
+ * The evidence tiles for a revealed badge, ordered so each badge leads with the
+ * stat that earned it (crowd favorites lead with votes, the factory with volume,
+ * and so on). Capped at three so the row stays tidy. Single source of truth for
+ * the on-site reveal, the poster page, and the composed OG image — so they never
+ * drift.
+ */
+export function posterTiles(badge: BadgeMeta, stats: ContributorStats): PosterTile[] {
+  const latest = formatTileDate(stats.newestCreatedAtMs);
+  const t: Record<string, PosterTile | null> = {
+    skills: {
+      num: String(stats.skillCount),
+      label: stats.skillCount === 1 ? "skill" : "skills",
+    },
+    featured:
+      stats.featuredCount > 0
+        ? { num: String(stats.featuredCount), label: "featured" }
+        : null,
+    votes:
+      stats.totalRating > 0
+        ? {
+            num: String(stats.totalRating),
+            label: stats.totalRating === 1 ? "upvote" : "upvotes",
+          }
+        : null,
+    platforms:
+      stats.platforms.length > 0
+        ? {
+            num: String(stats.platforms.length),
+            label: stats.platforms.length === 1 ? "platform" : "platforms",
+          }
+        : null,
+    latest: latest ? { num: latest, label: "latest" } : null,
+  };
+  const order =
+    badge.id === "top-rated"
+      ? [t.votes, t.skills, t.featured]
+      : badge.id === "teachers-pet"
+        ? [t.featured, t.skills, t.latest]
+        : badge.id === "skill-factory"
+          ? [t.skills, t.featured, t.latest]
+          : [t.skills, t.platforms, t.latest];
+  return order.filter((x): x is PosterTile => Boolean(x)).slice(0, 3);
+}

--- a/src/pages/authors.astro
+++ b/src/pages/authors.astro
@@ -1,28 +1,17 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import { getCollection } from "astro:content";
-import { getRating } from "../lib/ratings";
 import { withBase } from "../lib/url";
 import { formatDate } from "../lib/skills";
-import { allAuthors, type BadgeSkill } from "../lib/badges";
+import { allAuthors } from "../lib/badges";
+import { loadBadgeSkills } from "../lib/badge-data";
 
 // Build the public contribution ledger from the baked skills. Everything here is
 // public (author, github login, featured, dates); the snarky badge is layered on
-// client-side when a visitor looks up their own handle.
-const skills = await getCollection("skills");
-const badgeSkills: BadgeSkill[] = skills.map((s) => ({
-  slug: s.id,
-  name: s.data.name,
-  author: s.data.author,
-  authorGithub: s.data.authorGithub ?? null,
-  featured: s.data.featured,
-  rating: getRating(s.id),
-  createdAt: s.data.createdAt ?? null,
-  platforms: s.data.platforms,
-}));
-
+// client-side when a visitor looks up their own handle. The same loader feeds the
+// poster page + OG image, so the directory and the shared posters never disagree.
+const badgeSkills = await loadBadgeSkills();
 const authors = allAuthors(badgeSkills);
-const totalSkills = skills.length;
+const totalSkills = badgeSkills.length;
 const featuredTotal = badgeSkills.filter((s) => s.featured).length;
 
 // How many skill chips to show per author card before collapsing to "+N more".
@@ -577,6 +566,31 @@ const MAX_CHIPS = 8;
       font-size: 0.75rem;
       color: var(--muted);
     }
+    #you-result .award-share {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      margin-top: 1.15rem;
+      padding: 0.5rem 0.95rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface-2);
+      color: var(--accent-text);
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-decoration: none;
+      transition:
+        border-color 0.15s ease,
+        background 0.15s ease;
+    }
+    #you-result .award-share:hover {
+      border-color: var(--accent);
+      background: var(--accent-soft);
+    }
+    #you-result .award-share:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
     #you-result .badge-empty {
       display: flex;
       align-items: center;
@@ -624,6 +638,9 @@ const MAX_CHIPS = 8;
       #you-result .award-note {
         animation: riseIn 0.5s ease 0.42s both;
       }
+      #you-result .award-share {
+        animation: riseIn 0.5s ease 0.48s both;
+      }
     }
     @keyframes badgeIn {
       from {
@@ -660,6 +677,7 @@ const MAX_CHIPS = 8;
       computeStats,
       resolveBadge,
       captionFor,
+      posterTiles,
       BADGES,
       type BadgeId,
     } from "../lib/badges";
@@ -692,14 +710,6 @@ const MAX_CHIPS = 8;
       );
     }
 
-    const dateFmt = new Intl.DateTimeFormat("en-US", {
-      month: "short",
-      day: "numeric",
-    });
-    function fmtLatest(ms: number | null) {
-      return ms ? dateFmt.format(new Date(ms)) : null;
-    }
-
     function show(html: string) {
       if (!result) return;
       result.innerHTML = html;
@@ -719,53 +729,26 @@ const MAX_CHIPS = 8;
       )}</span><span class="stat-label">${esc(label)}</span></div>`;
     }
 
-    // Evidence tiles, ordered so each badge leads with the stat that earned it
-    // (crowd favorites lead with votes, the factory with volume, and so on).
-    // Capped at three so the row stays tidy.
+    // Evidence tiles come from the shared `posterTiles` helper so the on-site
+    // reveal, the poster page, and the OG image always render identical stats.
     function tilesFor(badge: any, stats: any) {
-      const latest = fmtLatest(stats.newestCreatedAtMs);
-      const t = {
-        skills: statTile(
-          String(stats.skillCount),
-          stats.skillCount === 1 ? "skill" : "skills",
-        ),
-        featured:
-          stats.featuredCount > 0
-            ? statTile(String(stats.featuredCount), "featured")
-            : "",
-        votes:
-          stats.totalRating > 0
-            ? statTile(
-                String(stats.totalRating),
-                stats.totalRating === 1 ? "upvote" : "upvotes",
-              )
-            : "",
-        platforms:
-          stats.platforms && stats.platforms.length
-            ? statTile(
-                String(stats.platforms.length),
-                stats.platforms.length === 1 ? "platform" : "platforms",
-              )
-            : "",
-        latest: latest ? statTile(latest, "latest") : "",
-      };
-      const order =
-        badge.id === "top-rated"
-          ? [t.votes, t.skills, t.featured]
-          : badge.id === "teachers-pet"
-            ? [t.featured, t.skills, t.latest]
-            : badge.id === "skill-factory"
-              ? [t.skills, t.featured, t.latest]
-              : [t.skills, t.platforms, t.latest];
-      return order.filter(Boolean).slice(0, 3).join("");
+      return posterTiles(badge, stats)
+        .map((t) => statTile(t.num, t.label))
+        .join("");
     }
 
     function cardHtml(login: string, stats: any, badge: any, caption: string) {
       const tiles = tilesFor(badge, stats);
-      const who =
-        login && login !== "preview"
-          ? `Issued to @${esc(login)}`
-          : "Badge preview";
+      const real = login && login !== "preview";
+      const who = real ? `Issued to @${esc(login)}` : "Badge preview";
+      // Only offer the share link when a poster page actually exists for this
+      // login (i.e. they're a real contributor), so the link never 404s.
+      const shareable = real && !!resolveBadge(login, data);
+      const share = shareable
+        ? `<a class="award-share" href="${BASE}/badge/${encodeURIComponent(
+            login,
+          )}/">Share your badge <span aria-hidden="true">↗</span></a>`
+        : "";
       return `
         <div class="award">
           <div class="award-stage">
@@ -781,6 +764,7 @@ const MAX_CHIPS = 8;
             <p class="award-quote">&ldquo;${esc(caption)}&rdquo;</p>
             <div class="award-stats">${tiles}</div>
             <p class="award-note">${esc(badge.meaning || "")}</p>
+            ${share}
           </div>
         </div>`;
     }

--- a/src/pages/badge/[login].astro
+++ b/src/pages/badge/[login].astro
@@ -1,0 +1,436 @@
+---
+import "../../styles/global.css";
+import { withBase } from "../../lib/url";
+import {
+  allAuthors,
+  resolveBadge,
+  posterTiles,
+  type PosterTile,
+} from "../../lib/badges";
+import { loadBadgeSkills } from "../../lib/badge-data";
+
+export async function getStaticPaths() {
+  const skills = await loadBadgeSkills();
+  return allAuthors(skills)
+    .map((stats) => {
+      const resolved = resolveBadge(stats.login, skills);
+      if (!resolved) return null;
+      return {
+        params: { login: stats.login },
+        props: {
+          login: stats.login,
+          title: resolved.badge.title,
+          image: resolved.badge.image,
+          meaning: resolved.badge.meaning,
+          caption: resolved.caption,
+          tiles: posterTiles(resolved.badge, resolved.stats),
+        },
+      };
+    })
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+}
+
+interface Props {
+  login: string;
+  title: string;
+  image: string;
+  meaning: string;
+  caption: string;
+  tiles: PosterTile[];
+}
+
+const { login, title, image, meaning, caption, tiles } = Astro.props as Props;
+
+const pngPath = withBase(`/badge/${login}.png`);
+const pagePath = withBase(`/badge/${login}/`);
+const galleryPath = withBase("/");
+const authorsPath = withBase("/authors");
+const badgePng = withBase(`/badges/${image}.png`);
+const badgeSvg = withBase(`/badges/${image}.svg`);
+
+// Absolute URLs for social unfurl + share intents (fall back to prod origin).
+const origin = Astro.site ?? new URL("https://microsoft.github.io");
+const ogImage = new URL(pngPath, origin).href;
+const pageUrl = new URL(pagePath, origin).href;
+const siteLabel = `${origin.host}${import.meta.env.BASE_URL.replace(/\/$/, "")}`;
+
+const pageTitle = `${title} — @${login} · CAT Agent Skills`;
+const ogDescription = `${caption} — @${login}'s contributor badge on CAT Agent Skills.`;
+const shareText = `I earned the “${title}” contributor badge on CAT Agent Skills.`;
+
+const shareX = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+  shareText,
+)}&url=${encodeURIComponent(pageUrl)}`;
+const shareLinkedIn = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+  pageUrl,
+)}`;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{pageTitle}</title>
+    <meta name="description" content={ogDescription} />
+    <link rel="icon" type="image/png" href={withBase("/paw.png")} />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={pageTitle} />
+    <meta property="og:description" content={ogDescription} />
+    <meta property="og:url" content={pageUrl} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content={`${title} badge issued to @${login}`} />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={pageTitle} />
+    <meta name="twitter:description" content={ogDescription} />
+    <meta name="twitter:image" content={ogImage} />
+  </head>
+
+  <body class="poster">
+    <main class="stage">
+      <article class="card">
+        <div class="glow" aria-hidden="true"></div>
+
+        <div class="card-main">
+          <div class="medallion">
+            <img
+              src={badgePng}
+              alt={`${title} badge`}
+              width="320"
+              height="320"
+              onerror={`this.onerror=null;this.src='${badgeSvg}'`}
+            />
+          </div>
+
+          <div class="details">
+            <p class="eyebrow">Issued to @{login}</p>
+            <h1 class="title">{title}</h1>
+            <p class="quote">&ldquo;{caption}&rdquo;</p>
+
+            <ul class="tiles">
+              {
+                tiles.map((t) => (
+                  <li class="tile">
+                    <span class="tile-num">{t.num}</span>
+                    <span class="tile-label">{t.label}</span>
+                  </li>
+                ))
+              }
+            </ul>
+
+            <p class="meaning">{meaning}</p>
+          </div>
+        </div>
+
+        <footer class="brand">
+          <span class="wordmark"><span class="cat">CAT</span> Agent Skills</span>
+          <span class="site">{siteLabel}</span>
+        </footer>
+      </article>
+
+      <nav class="actions" aria-label="Share and explore">
+        <a class="btn btn-primary" href={galleryPath}>Explore the gallery</a>
+        <a class="btn" href={pngPath} download={`cat-badge-${login}.png`}
+          >Download image</a
+        >
+        <a class="btn" href={shareX} target="_blank" rel="noopener">
+          Share on X
+        </a>
+        <a class="btn" href={shareLinkedIn} target="_blank" rel="noopener">
+          Share on LinkedIn
+        </a>
+      </nav>
+
+      <a class="back" href={authorsPath}>‹ All contributors</a>
+    </main>
+
+    <style>
+      .poster {
+        /* Self-contained navy showcase — theme-independent on purpose, so the
+           page always matches the medallion art and the shared unfurl card. */
+        overflow-x: hidden;
+        --p-navy: #0d1836;
+        --p-navy-deep: #080f28;
+        --p-cream: #f5efe0;
+        --p-cream-muted: #c3cbe0;
+        --p-gold: #e8b64a;
+        --p-hair: rgba(245, 239, 224, 0.14);
+        --p-tile: rgba(255, 255, 255, 0.05);
+        margin: 0;
+        min-height: 100vh;
+        background:
+          radial-gradient(
+            1100px 520px at 12% -8%,
+            rgba(232, 182, 74, 0.16),
+            transparent 60%
+          ),
+          radial-gradient(
+            900px 500px at 108% 118%,
+            rgba(59, 84, 135, 0.4),
+            transparent 55%
+          ),
+          var(--p-navy);
+        color: var(--p-cream);
+        font-family: var(--font-sans);
+        -webkit-font-smoothing: antialiased;
+      }
+
+      .stage {
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1.75rem;
+        padding: clamp(1.25rem, 4vw, 3.5rem);
+      }
+
+      .card {
+        position: relative;
+        width: min(920px, 100%);
+        border: 1px solid var(--p-hair);
+        border-radius: 24px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 40%),
+          var(--p-navy);
+        box-shadow:
+          0 40px 90px -40px rgba(0, 0, 0, 0.7),
+          inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        overflow: hidden;
+        animation: rise 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+      }
+
+      .glow {
+        position: absolute;
+        top: -180px;
+        left: -120px;
+        width: 560px;
+        height: 560px;
+        border-radius: 50%;
+        background: radial-gradient(
+          circle,
+          rgba(232, 182, 74, 0.22),
+          transparent 68%
+        );
+        pointer-events: none;
+      }
+
+      .card-main {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: clamp(1.5rem, 4vw, 3.25rem);
+        padding: clamp(1.75rem, 4vw, 3rem);
+      }
+
+      .medallion {
+        flex-shrink: 0;
+      }
+      .medallion img {
+        display: block;
+        width: clamp(180px, 26vw, 300px);
+        height: auto;
+        filter: drop-shadow(0 18px 34px rgba(0, 0, 0, 0.45));
+      }
+
+      .details {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .eyebrow {
+        margin: 0;
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 0.9rem;
+        font-weight: 500;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--p-gold);
+      }
+
+      .title {
+        margin: 0.4rem 0 0;
+        font-size: clamp(2rem, 5vw, 3.25rem);
+        font-weight: 700;
+        line-height: 1.04;
+        letter-spacing: -0.01em;
+        color: var(--p-cream);
+      }
+
+      .quote {
+        margin: 0.85rem 0 0;
+        font-size: clamp(1.05rem, 2.2vw, 1.4rem);
+        line-height: 1.4;
+        font-style: italic;
+        color: var(--p-cream-muted);
+        max-width: 40ch;
+      }
+
+      .tiles {
+        list-style: none;
+        margin: 1.5rem 0 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .tile {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        padding: 0.7rem 1.05rem;
+        background: var(--p-tile);
+        border: 1px solid var(--p-hair);
+        border-radius: 14px;
+      }
+      .tile-num {
+        font-size: 1.55rem;
+        font-weight: 700;
+        line-height: 1;
+        color: var(--p-cream);
+      }
+      .tile-label {
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 0.72rem;
+        font-weight: 500;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--p-cream-muted);
+      }
+
+      .meaning {
+        margin: 1.4rem 0 0;
+        font-size: 0.9rem;
+        color: var(--p-cream-muted);
+        opacity: 0.85;
+      }
+
+      .brand {
+        position: relative;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 1.1rem clamp(1.75rem, 4vw, 3rem);
+        border-top: 1px solid var(--p-hair);
+        background: var(--p-navy-deep);
+      }
+      .wordmark {
+        font-weight: 700;
+        letter-spacing: 0.01em;
+      }
+      .wordmark .cat {
+        color: var(--p-gold);
+      }
+      .site {
+        font-family: "JetBrains Mono", ui-monospace, monospace;
+        font-size: 0.85rem;
+        color: var(--p-cream-muted);
+        overflow-wrap: anywhere;
+      }
+
+      .actions {
+        width: min(920px, 100%);
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.7rem;
+      }
+
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.6rem 1.15rem;
+        border-radius: 999px;
+        border: 1px solid var(--p-hair);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--p-cream);
+        font-size: 0.92rem;
+        font-weight: 600;
+        text-decoration: none;
+        transition:
+          background 0.15s ease,
+          border-color 0.15s ease,
+          transform 0.15s ease;
+      }
+      .btn:hover {
+        background: rgba(255, 255, 255, 0.09);
+        border-color: rgba(245, 239, 224, 0.3);
+      }
+      .btn:active {
+        transform: translateY(1px);
+      }
+      .btn-primary {
+        background: var(--p-gold);
+        border-color: var(--p-gold);
+        color: #2a1c04;
+      }
+      .btn-primary:hover {
+        background: #f0c463;
+        border-color: #f0c463;
+      }
+      .btn:focus-visible,
+      .back:focus-visible {
+        outline: 2px solid var(--p-gold);
+        outline-offset: 3px;
+      }
+
+      .back {
+        color: var(--p-cream-muted);
+        font-size: 0.88rem;
+        text-decoration: none;
+        opacity: 0.85;
+      }
+      .back:hover {
+        opacity: 1;
+        color: var(--p-cream);
+      }
+
+      @keyframes rise {
+        from {
+          opacity: 0;
+          transform: translateY(16px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .card-main {
+          flex-direction: column;
+          text-align: center;
+        }
+        .details {
+          width: 100%;
+        }
+        .quote {
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .tiles {
+          justify-content: center;
+        }
+        .brand {
+          flex-direction: column;
+          align-items: center;
+          gap: 0.4rem;
+          text-align: center;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .card {
+          animation: none;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/badge/[login].png.ts
+++ b/src/pages/badge/[login].png.ts
@@ -1,0 +1,47 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { allAuthors, resolveBadge, posterTiles } from "../../lib/badges";
+import { loadBadgeSkills } from "../../lib/badge-data";
+import { renderBadgePng } from "../../lib/badge-poster";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const skills = await loadBadgeSkills();
+  return allAuthors(skills)
+    .map((stats) => {
+      const resolved = resolveBadge(stats.login, skills);
+      if (!resolved) return null;
+      return {
+        params: { login: stats.login },
+        props: {
+          login: stats.login,
+          title: resolved.badge.title,
+          image: resolved.badge.image,
+          caption: resolved.caption,
+          tiles: posterTiles(resolved.badge, resolved.stats),
+        },
+      };
+    })
+    .filter((p): p is NonNullable<typeof p> => p !== null);
+};
+
+function siteLabelFrom(site: URL | undefined): string {
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  const host = site?.host ?? "microsoft.github.io";
+  return `${host}${base}`;
+}
+
+export const GET: APIRoute = async ({ props, site }) => {
+  const png = await renderBadgePng({
+    login: props.login,
+    title: props.title,
+    image: props.image,
+    caption: props.caption,
+    tiles: props.tiles,
+    siteLabel: siteLabelFrom(site),
+  });
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+};


### PR DESCRIPTION
## What

Once a contributor enters their handle on **/authors** and their badge resolves, they now get a **"Share your badge ↗"** link to a standalone poster page at `/badge/<login>/`. That page's social-unfurl thumbnail is a **build-time 1200×630 PNG** at `/badge/<login>.png`, composing the medallion + "Issued to @login" + title + caption + stat tiles + the site URL.

Everything is static (GitHub Pages) and regenerates on the existing scheduled build (`deploy.yml` push + daily cron) — no backend, no workflow change.

## How

- **`src/lib/badges.ts`** — extracted `posterTiles()` (+ `formatTileDate()`, UTC) as the **single source of truth** for the stat tiles. The on-site reveal, the poster page, and the OG image all resolve badge/caption/tiles from the same helpers, so they never drift. Captions are already deterministic (FNV-1a hash of the login), so the quote is identical across all three surfaces.
- **`src/lib/badge-data.ts`** *(new)* — shared `loadBadgeSkills()` loader; `authors.astro` frontmatter now consumes it too.
- **`src/lib/badge-poster.ts`** *(new)* — composes the OG PNG with **satori → resvg** at build time; DM Sans + JetBrains Mono vendored via `@fontsource` (build-only dev-deps).
- **`src/pages/badge/[login].png.ts`** *(new)* — static OG-image endpoint over `allAuthors()`.
- **`src/pages/badge/[login].astro`** *(new)* — standalone navy poster page mirroring the PNG, with per-user OG/Twitter meta (`summary_large_image`, absolute PNG URL), a "Explore the gallery" CTA, download, and X/LinkedIn share.
- **`src/pages/authors.astro`** — "Share your badge ↗" link in the reveal, shown **only for real contributors** so it never 404s.

## Notes

- Adds 4 build-time dev-deps (`satori`, `@resvg/resvg-js`, `@fontsource/dm-sans`, `@fontsource/jetbrains-mono`). Nothing new ships to the client beyond the static PNGs/HTML. Native `@resvg/resvg-js` resolves on ubuntu-latest + darwin-arm64 (both prebuilt).
- One PNG per contributor (~17 today) → negligible build cost.
- **Site-only** change (respects the one-concern PR-scope rule); no `submissions/**` or generated-content edits.

## Verification

- `npm run build` green (153 pages, 17 PNGs + 17 poster pages).
- `npm run check:submissions` passes.
- Quote parity confirmed site == poster page == PNG for `adilei` (Teacher's Pet) and `simonowendigital` (Skill Factory).
- OG/Twitter tags verified in the built HTML (absolute prod PNG URL, 1200×630).
- Poster page clean at desktop 1440 + true-mobile 390 (CDP device-metrics screenshots).

Rebased on `main` (includes #114's directory-grid fix).