### PR TITLE
Reorder badge priority: Skill Factory > Teacher's Pet > Crowd Favorite

### DIFF
--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -77,9 +77,9 @@ export const BADGES: Record<BadgeId, BadgeMeta> = {
 
 /** Assignment order — first matching rule wins. */
 export const BADGE_ORDER: BadgeId[] = [
-  "top-rated",
   "skill-factory",
   "teachers-pet",
+  "top-rated",
   "house-cat",
 ];
 
@@ -250,11 +250,11 @@ export function buildContext(skills: BadgeSkill[]): BadgeContext {
 
 /** Assign a badge from stats. Ordered, first match wins. */
 export function pickBadge(stats: ContributorStats, ctx: BadgeContext): BadgeMeta {
-  if (stats.totalRating > 0 && ctx.ratingLeaders.has(stats.login))
-    return BADGES["top-rated"];
   if (stats.skillCount >= ctx.factoryThreshold) return BADGES["skill-factory"];
   if (stats.featuredCount > 0 && ctx.featuredLeaders.has(stats.login))
     return BADGES["teachers-pet"];
+  if (stats.totalRating > 0 && ctx.ratingLeaders.has(stats.login))
+    return BADGES["top-rated"];
   return BADGES["house-cat"];
 }
 


### PR DESCRIPTION
## What & why

Reorders the personal-badge assignment priority so that being **featured** (and shipping volume) outranks community likes.

Previously the first check in `pickBadge()` was `top-rated` (Crowd Favorite), so contributors who *also* had featured skills or ≥5 skills landed on **Crowd Favorite** purely because they had upvotes. Featured/volume should win first — this fixes featured authors being mislabeled as Crowd Favorite.

## The change (site-only, one file)

`src/lib/badges.ts` only:

- **`pickBadge(stats, ctx)`** — reordered the first-match-wins if-chain. Each guard condition is unchanged; only the order changed, and House Cat stays the fallback:

  | Order | Before | After |
  |------|--------|-------|
  | 1 | top-rated (Crowd Favorite) | **skill-factory (The Skill Factory)** |
  | 2 | skill-factory | **teachers-pet (Teacher's Pet)** |
  | 3 | teachers-pet | **top-rated (Crowd Favorite)** |
  | 4 | house-cat (fallback) | house-cat (fallback) |

- **`BADGE_ORDER`** — realigned to `[skill-factory, teachers-pet, top-rated, house-cat]`. Its comment claims to be the assignment order, so it's kept truthful. It is **not consumed anywhere** in `src/` (verified via grep) — purely documentary, no behavior change.

Captions, the poster page/PNG, and the on-site reveal all resolve by `badge.id`, so they follow the new assignment automatically. Nothing else touched.

## Validation

- ✅ `npm run build` — green, 153 pages built.
- ✅ `npm run check:submissions` — all 33 submissions pass.
- ✅ Behavior check via a throwaway script (removed before commit) that reconstructs the old order inline and diffs it against the new `pickBadge`:
  - A contributor who is **both** a featured-leader **and** a rating-leader (<5 skills): `Crowd Favorite → Teacher's Pet` ✅
  - A contributor with **≥5 skills** who is also a rating-leader: `Crowd Favorite → The Skill Factory` ✅
  - A rating-leader only: stays **Crowd Favorite** ✅
  - A plain shipper: stays **House Cat** ✅

## Scope

Site-only, single concern — only `src/lib/badges.ts`. No `submissions/**` changes and no CI-generated content (`src/content/skills/*`, `public/bundles/*`) committed.