### PR TITLE
Use full width on wide screens for skill galleries

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -51,7 +51,7 @@ const fullTitle =
       class="sticky top-0 z-30 border-b border-border bg-bg/80 backdrop-blur-md"
     >
       <div
-        class="mx-auto flex max-w-7xl items-center justify-between gap-3 px-4 py-3 sm:gap-4 sm:px-6"
+        class="mx-auto flex max-w-8xl items-center justify-between gap-3 px-4 py-3 sm:gap-4 sm:px-6"
       >
         <a
           href={withBase("/")}
@@ -155,7 +155,7 @@ const fullTitle =
 
     <footer class="border-t border-border bg-bg">
       <div
-        class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-2 px-4 py-8 text-sm text-muted sm:flex-row sm:px-6"
+        class="mx-auto flex max-w-8xl flex-col items-center justify-between gap-2 px-4 py-8 text-sm text-muted sm:flex-row sm:px-6"
       >
         <p>
           Community gallery of skills for <span class="text-fg"

--- a/src/pages/authors.astro
+++ b/src/pages/authors.astro
@@ -22,7 +22,7 @@ const MAX_CHIPS = 8;
   title="Contributors"
   description="Everyone who has shipped a skill to the CAT Agent Skills gallery — look up your handle to reveal your own personal contributor badge."
 >
-  <section class="mx-auto max-w-7xl px-4 py-10 sm:px-6">
+  <section class="mx-auto max-w-8xl px-4 py-10 sm:px-6">
     <header class="mb-8">
       <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl">
         Contributors
@@ -314,8 +314,10 @@ const MAX_CHIPS = 8;
       }
     }
     @media (min-width: 1120px) {
+      /* Fluid past 3 columns so wide screens fill with a 4th/5th card instead
+         of stretching three cards across the whole row. */
       .author-grid {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
       }
     }
     .author-card {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,7 @@ const popularTags = allTags.slice(0, 8);
 <Layout>
   <!-- Hero -->
   <section class="border-b border-border bg-surface/40">
-    <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-10">
+    <div class="mx-auto max-w-8xl px-4 py-8 sm:px-6 sm:py-10">
       <h1
         class="text-2xl font-bold tracking-tight text-fg sm:text-3xl"
       >
@@ -84,7 +84,7 @@ const popularTags = allTags.slice(0, 8);
   <!-- Platform filters -->
   <section class="border-b border-border bg-bg">
     <div
-      class="mx-auto flex max-w-7xl flex-wrap items-center gap-3 px-4 py-4 sm:px-6"
+      class="mx-auto flex max-w-8xl flex-wrap items-center gap-3 px-4 py-4 sm:px-6"
     >
       <span class="text-xs font-semibold uppercase tracking-wider text-subtle"
         >Platform</span
@@ -121,7 +121,7 @@ const popularTags = allTags.slice(0, 8);
 
   <!-- Tag filters -->
   <section class="border-b border-border bg-bg">
-    <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
+    <div class="mx-auto max-w-8xl px-4 py-4 sm:px-6">
       <div
         id="tag-row"
         class="relative flex flex-nowrap items-center gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-visible sm:pb-0"
@@ -215,7 +215,7 @@ const popularTags = allTags.slice(0, 8);
   </section>
 
   <!-- Gallery -->
-  <section class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-10">
+  <section class="mx-auto max-w-8xl px-4 py-8 sm:px-6 sm:py-10">
     <div class="mb-5 flex flex-wrap items-center justify-between gap-4">
       <h2 class="text-lg font-semibold text-fg">
         Skills <span id="result-count" class="text-muted"
@@ -266,7 +266,7 @@ const popularTags = allTags.slice(0, 8);
 
     <div
       id="gallery"
-      class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
+      class="grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(17rem,1fr))]"
     >
       {
         skills.map((skill) => (

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -27,7 +27,7 @@ const { tag, skills } = Astro.props;
   title={`#${tag} skills`}
   description={`Copilot Studio skills tagged "${tag}".`}
 >
-  <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 sm:py-10">
+  <div class="mx-auto max-w-8xl px-4 py-8 sm:px-6 sm:py-10">
     <a
       href={withBase("/")}
       class="inline-flex items-center gap-1.5 text-sm text-muted hover:text-fg transition-colors"
@@ -55,7 +55,7 @@ const { tag, skills } = Astro.props;
     </p>
 
     <div
-      class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
+      class="mt-7 grid grid-cols-1 gap-4 sm:grid-cols-[repeat(auto-fill,minmax(17rem,1fr))]"
     >
       {
         skills.map((skill) => (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -26,6 +26,11 @@
 
   --font-sans: "DM Sans", "Segoe UI", system-ui, -apple-system,
     BlinkMacSystemFont, sans-serif;
+
+  /* Shared page container width. Wider than Tailwind's default 7xl (80rem)
+     so wide screens aren't wasted: the gallery gains a 6th column instead of
+     squeezing 5 into a 1280px column with large empty margins on either side. */
+  --container-8xl: 110rem;
 }
 
 /* Enable `dark:` utilities based on the theme attribute (not OS prefs). */


### PR DESCRIPTION
## Problem

On wide screens the gallery wastes horizontal space. Every page container capped at `max-w-7xl` (1280px), while the grid jumped to 5 columns at the `2xl` breakpoint (1536px) — so cards got squeezed into a 1280px column with large empty margins on both sides.

## Changes

- Add a `--container-8xl` (110rem / 1760px) theme token and switch the shared container from `max-w-7xl` → `max-w-8xl` across the header, footer, home, tags, and authors pages so the chrome and content stay aligned.
- Make the skill grids fluid: `grid-cols-[repeat(auto-fill,minmax(17rem,1fr))]` instead of fixed breakpoints, so they naturally gain a 6th column on wide screens while matching prior column counts at common widths.
- The authors grid now goes fluid past 1120px instead of hard-capping at 3 columns.

Layout-only change — no submissions or generated artifacts touched.

## Verification

Measured rendered container width / columns (Playwright, real viewport widths):

| viewport | container | columns | before |
|---|---|---|---|
| 1280 | 1280 | 4 | 4 (unchanged) |
| 1440 | 1440 | 4 | capped at 1280 |
| 1536 | 1488 | 5 | 5 squeezed into 1280 |
| 1920 | 1760 | **6** | 1280 / 5, big margins |
| 2560 | 1760 | **6** | 1280 / 5, big margins |

Production `npm run build` passes (148 pages).