### PR TITLE
Attribute Brand Template Enforcer to Doug Bellingeri (CATDAB)

### DIFF
--- a/src/content/skills/brand-template-enforcer.md
+++ b/src/content/skills/brand-template-enforcer.md
@@ -4,9 +4,9 @@ description: Ensure every generated PowerPoint deck or Word document starts from
 agentDescription: "Applies bundled or SharePoint-hosted organization-approved PowerPoint and Word templates whenever the agent is about to create, generate, export, or substantially rebuild a presentation, slide deck, report, proposal, brief, memo, letter, or other .pptx, .docx, or .dotx deliverable. Use before any file-generation tool or document-creation skill so the output starts from the appropriate brand template instead of a blank file. Do not use for read-only analysis or minor edits that do not create a new Office file."
 platforms: [Copilot Studio]
 tags: [branding, powerpoint, word, templates, documents, presentations]
-author: Simon Owen
-authorUrl: "https://github.com/SimonOwenDigital"
-authorGithub: SimonOwenDigital
+author: Doug Bellingeri
+authorUrl: "https://github.com/CATDAB"
+authorGithub: CATDAB
 version: 1.2.0
 createdAt: 2026-07-16
 updatedAt: 2026-07-18

--- a/submissions/brand-template-enforcer/metadata.json
+++ b/submissions/brand-template-enforcer/metadata.json
@@ -12,8 +12,8 @@
     "documents",
     "presentations"
   ],
-  "author": "Simon Owen",
-  "authorUrl": "https://github.com/SimonOwenDigital",
+  "author": "Doug Bellingeri",
+  "authorUrl": "https://github.com/CATDAB",
   "version": "1.2.0",
   "createdAt": "2026-07-16",
   "updatedAt": "2026-07-18"


### PR DESCRIPTION
Updates the author of the **Brand Template Enforcer** submission.

- `author`: Simon Owen → **Doug Bellingeri**
- `authorUrl`: `github.com/SimonOwenDigital` → **`github.com/CATDAB`**

`authorGithub` (CATDAB) is derived automatically from the GitHub profile URL. Metadata-only change, single submission, no site/infra edits.