### PR TITLE
Reframe iterative-file-editing README around the delivery problem

### DIFF
--- a/src/content/skills/iterative-file-editing.md
+++ b/src/content/skills/iterative-file-editing.md
@@ -1,6 +1,6 @@
 ---
 name: Iterative File Editing
-description: "Build files with the user through natural back-and-forth — keep a durable working copy and re-share an updated version after every change, so you refine it together without losing work."
+description: "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v2, report_v3…) so every update actually lands in the chat as its own attachment."
 agentDescription: "Use this skill whenever you create or edit ANY file for the user in the Copilot Studio container — a document, spreadsheet, slide deck, code file, data export, anything. It keeps your work-in-progress durable and shows the user an updated version after every change, so the two of you refine the same file together across turns — the user sees real progress each round, earlier work is never lost, and neither of you has to start over. Apply it from the very first file you make."
 platforms: [Copilot Studio]
 tags: [files, iteration, workflow, collaboration, productivity]

--- a/submissions/iterative-file-editing/README.md
+++ b/submissions/iterative-file-editing/README.md
@@ -1,32 +1,45 @@
 # Iterative File Editing
 
-Turns file creation in a Copilot Studio agent into a genuine back-and-forth.
-Instead of generating a file once and calling it done, the agent keeps a durable
-working copy and re-shares an updated version every time you have feedback — so
-you and the agent shape the file together, turn after turn, without ever losing
-earlier work.
+In Copilot Studio today, editing a file that's already been sent to you
+fails to reach you. You ask the agent to tweak a document it delivered a moment
+ago; it makes the change and tells you it's done — but no new file shows up in the
+chat. That's because re-sending a file under a name the chat has already received
+doesn't fire Copilot Studio's file-delivery event, so the updated version never
+actually leaves the agent. You're left looking at the old attachment, told it was
+updated.
+
+This skill fixes that. It has the agent give each new version of a file a fresh,
+incremented filename — `report_v1.docx`, `report_v2.docx`, `report_v3.docx` — so
+every round of edits carries a name the chat hasn't seen before and actually gets
+delivered. You receive each iteration as its own attachment, and the version trail
+comes for free.
+
+## Why it matters
+
+Without it, iterating on a file in Copilot Studio breaks: the agent keeps
+"making changes" you never receive, and you have no signal that the send didn't
+happen. A version-numbered filename is what turns "I updated it" into a file you
+can actually open — it's the difference between a real back-and-forth over a
+document and a one-shot export you can never refine.
 
 ## How it works
 
-The agent keeps a single file and refines it in place as you give feedback. Each
-time there's something new to see, it hands you the current version as a
-downloadable attachment — numbered `_v1`, `_v2`, `_v3`, and so on — so you can
-watch the file evolve without the agent ever rebuilding it from scratch or dropping
-something you'd already settled on. When you're happy, the latest version is your
-final file.
+Whenever the agent has an updated version to hand you, it bumps the version number
+in the filename before sending. Because the name is new, Copilot Studio delivers it
+as a fresh attachment. The highest number is always your current file, and every
+earlier version stays in the chat so you can scroll back.
 
 ## How to use it
 
-Just ask for a file the way you normally would — "draft a proposal", "build me a
-spreadsheet", "write this script" — and give feedback as it comes back. Say things
-like "change the intro" or "add a column" to keep refining, and "looks good" or
-"that's the one" when you're happy. The latest version in your attachments is the
-final deliverable.
+Ask for a file the way you normally would — "draft a proposal", "build me a
+spreadsheet", "write this script" — and give feedback as it comes back. Say
+"change the intro" or "add a column" to keep refining. Each reply brings a new
+numbered attachment; the highest-numbered one is your latest file.
 
 ## A quick walkthrough
 
-Here's a short session — notice how each attachment comes back with the next
-version number as the file evolves:
+Here's a short session — each attachment comes back with the next version number,
+which is exactly what lets every edit land in the chat:
 
 > **You:** create a simple text file that says "hi"
 >
@@ -43,17 +56,16 @@ version number as the file evolves:
 > **Agent:** All set — `hi_v3.txt` now has your "hi", the poem, and an ASCII
 > rose 🌹. Anything else?  📎 `hi_v3.txt`
 
-Each round you get a new numbered attachment (`hi_v1.txt` → `hi_v2.txt` →
-`hi_v3.txt`), so you can always open the latest and still scroll back to earlier
-versions.
+Without the version bump, that "add a poem" step would look like it worked, but
+`hi.txt` would never re-appear in your chat — you'd be stuck on the original. The
+climbing number (`hi_v1.txt` → `hi_v2.txt` → `hi_v3.txt`) is precisely what gets
+each update delivered, and it doubles as a history you can scroll back through.
 
 ## Good to know
 
 - It applies to any file type — documents, spreadsheets, decks, code, data
   exports.
-- You'll get a fresh, numbered attachment each round; that's intentional, so you
-  can always see the current state and trace the history.
-- When you say you're done, the agent treats that as closing the loop — it won't
-  keep revising the file unless you ask for something new, so "done" means done.
+- The version number climbing each round isn't clutter — it's the mechanism that
+  makes each update reach you, and it happens to give you a clean version history.
 - It's built for the Copilot Studio container specifically, because it relies on
   how that container delivers files to you.

--- a/submissions/iterative-file-editing/metadata.json
+++ b/submissions/iterative-file-editing/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Iterative File Editing",
-  "description": "Build files with the user through natural back-and-forth — keep a durable working copy and re-share an updated version after every change, so you refine it together without losing work.",
+  "description": "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v2, report_v3…) so every update actually lands in the chat as its own attachment.",
   "platforms": ["Copilot Studio"],
   "tags": ["files", "iteration", "workflow", "collaboration", "productivity"],
   "author": "Adi Leibowitz",


### PR DESCRIPTION
## What

Reframes the `iterative-file-editing` skill's human-facing docs to lead with the actual value proposition, and tightens the catalog description to match.

## Why

The previous README framed the skill as a generic "durable working copy / refine without losing work" back-and-forth — which both buried the value and mis-stated the mechanism. The real reason the skill exists is a concrete Copilot Studio behavior:

> If you ask an agent to change a file it has **already sent you**, it makes the change and reports success — but the updated file never arrives, because re-sending under the same filename doesn't fire Copilot Studio's file-delivery event.

The skill fixes this by giving each iteration a new version-numbered filename (`report_v2.docx`, `report_v3.docx`, …) so every update is a name the chat hasn't seen and actually gets delivered.

## Changes

- `README.md` — opens with the delivery problem, adds a "Why it matters" section, ties the `hi_v1/v2/v3` walkthrough back to the problem, and drops the misleading "durable working copy" framing.
- `metadata.json` — catalog description rewritten to convey the same value.

Docs-only change to an existing submission; no `SKILL.md` behavior change. Validated with `npm run check:submissions`.