### PR TITLE
Align catalog description example with README naming

### DIFF
--- a/src/content/skills/iterative-file-editing.md
+++ b/src/content/skills/iterative-file-editing.md
@@ -1,6 +1,6 @@
 ---
 name: Iterative File Editing
-description: "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v2, report_v3…) so every update actually lands in the chat as its own attachment."
+description: "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v1.docx, report_v2.docx…) so every update actually lands in the chat as its own attachment."
 agentDescription: "Use this skill whenever you create or edit ANY file for the user in the Copilot Studio container — a document, spreadsheet, slide deck, code file, data export, anything. It keeps your work-in-progress durable and shows the user an updated version after every change, so the two of you refine the same file together across turns — the user sees real progress each round, earlier work is never lost, and neither of you has to start over. Apply it from the very first file you make."
 platforms: [Copilot Studio]
 tags: [files, iteration, workflow, collaboration, productivity]

--- a/submissions/iterative-file-editing/metadata.json
+++ b/submissions/iterative-file-editing/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "Iterative File Editing",
-  "description": "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v2, report_v3…) so every update actually lands in the chat as its own attachment.",
+  "description": "In Copilot Studio, re-sending an edited file under the same name fails to deliver it — the change is made but never reaches the user. This skill gives each iteration a new version-numbered filename (report_v1.docx, report_v2.docx…) so every update actually lands in the chat as its own attachment.",
   "platforms": ["Copilot Studio"],
   "tags": ["files", "iteration", "workflow", "collaboration", "productivity"],
   "author": "Adi Leibowitz",


### PR DESCRIPTION
## What

Small consistency tweak from Copilot review on #138: aligns the catalog description's example filenames with the README/SKILL.md examples.

## Change

`metadata.json` description example `(report_v2, report_v3…)` → `(report_v1.docx, report_v2.docx…)` — adds the file extension and starts at v1, matching the `report_v1.docx → report_v2.docx → report_v3.docx` naming used everywhere else in the docs.

One-line docs change to an existing submission. Validated with `npm run check:submissions`. The generated content page's description will be regenerated by CI to match.