### PR TITLE
fix: prevent metadata.json from overwriting SKILL.md agentDescription

### DIFF
--- a/scripts/import-submissions.ts
+++ b/scripts/import-submissions.ts
@@ -416,7 +416,12 @@ function processSubmission(sub: Submission): ImportProblem | null {
   // Merge into the canonical frontmatter. The gallery `name` is the human display
   // name from metadata; the slug (SKILL.md `name`) is the file id used for the
   // route and the downloadable SKILL.md. The agent description gets its own key.
-  const { name: displayName, description: catalogDescription, ...catalogRest } = catalog;
+  const {
+    name: displayName,
+    description: catalogDescription,
+    agentDescription: _catalogAgentDescription,
+    ...catalogRest
+  } = catalog;
   const meta: Record<string, unknown> = {
     name: displayName,
     description: catalogDescription,


### PR DESCRIPTION
## What changed

In `scripts/import-submissions.ts`, the `processSubmission` function merges `metadata.json` catalog data with the `SKILL.md` frontmatter to produce the canonical skill content file. The `agentDescription` field — which comes from `SKILL.md`'s frontmatter `description` — was not being excluded from the `...catalogRest` spread. This means `agentDescription` in the `metadata.json` would silently overwrite the agent-facing trigger description from `SKILL.md`.

The other processors (`processPlugin`, `processAutomation`, `processAutomationInstaller`) already explicitly strip their canonical/protected fields before spreading catalog metadata. `processSubmission` was the only one that missed this step for `agentDescription`.

## The fix

Explicitly destructure `agentDescription` out of `catalog` so it never leaks into `...catalogRest`:

```typescript
const {
  name: displayName,
  description: catalogDescription,
  agentDescription: _catalogAgentDescription,
  ...catalogRest
} = catalog;
```

## Reference
CONTRIBUTING.md: — SKILL.md description is the agent-facing trigger; metadata.json description is the catalog summary
docs/authoring-skills.md: — explicit table separating agent description from catalog description
scripts/import-submissions.ts:— inline comment: "The agent description gets its own key"
