### PR TITLE
Fix gallery cards stuck at one batch when switching to a larger filter

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -407,11 +407,32 @@ const popularTags = allTags.slice(0, 8);
     emptyEl.classList.toggle("hidden", matched.length > 0);
   }
 
+  // The infinite-scroll IntersectionObserver below only reacts to *changes* in
+  // the sentinel's visibility. After a filter reset shrinks `shown` back to
+  // BATCH, a sentinel that was already parked in view stays in view and never
+  // re-fires — so `shown` would stay stuck at 12 even when many more cards
+  // match (e.g. switching from a small tag to a larger one, which showed the
+  // right "(N)" count but only the first 12 cards). Top up manually until the
+  // sentinel is pushed past the preload zone, or everything is shown.
+  const PRELOAD = 400;
+  function sentinelInView() {
+    const rect = sentinel.getBoundingClientRect();
+    return rect.top <= window.innerHeight + PRELOAD && rect.bottom >= -PRELOAD;
+  }
+  function fill() {
+    let guard = 0;
+    while (shown < matched.length && sentinelInView() && guard++ < 500) {
+      shown = Math.min(shown + BATCH, matched.length);
+      render();
+    }
+  }
+
   function refilter() {
     matched = applySort(computeMatched());
     shown = BATCH;
     reorderDom();
     render();
+    fill();
   }
 
   // Search (debounced)
@@ -594,7 +615,7 @@ const popularTags = allTags.slice(0, 8);
         render();
       }
     },
-    { rootMargin: "400px" }
+    { rootMargin: `${PRELOAD}px` }
   );
   io.observe(sentinel);
 


### PR DESCRIPTION
## Problem

On the skills gallery (`src/pages/index.astro`), cards are revealed in batches of 12 via an `IntersectionObserver` watching `#scroll-sentinel`. That observer only fires when the sentinel's visibility **changes**. `refilter()` resets `shown` back to `BATCH` (12) on every filter change, so when you switch from a filter with **few** results to one with **more** (e.g. a small tag → All), the sentinel was already parked in view and *stays* in view — the observer never re-fires.

Result: the `(N)` count updates correctly (e.g. "Skills (40)") but only the first **12 cards** render, with the footer immediately below. On desktop it's unrecoverable — the short page never moves the sentinel out and back into view, so even scrolling doesn't help.

Repro: full page → apply a filter → filter to fewer items → filter to more items.

## Fix

Add a `fill()` pass after `refilter()` that keeps revealing batches until the sentinel is pushed past the preload zone (or everything is shown), covering the "already in view, no change event" gap the observer misses. The `rootMargin` and the new `PRELOAD` constant are kept in sync.

## Verification

Tested with Playwright against the built site (`astro preview`):

| Step | Buggy (fix reverted) | Fixed |
|---|---|---|
| back to All (repro point) | 12/40, sentinel still in view ❌ | 24/40, sentinel pushed out ✅ |
| after scrolling | 12/40, still stuck ❌ | 40/40 ✅ |

- **Desktop** (multi-column): reproduced the stuck-at-12 bug on the reverted fix; fixed version reveals correctly and scroll shows all 40.
- **Mobile** (390×844, single-column): tested both the inline tag pill and the "More tags" bottom-sheet paths — 12 → all 40 on scroll. The single-column layout pushes the sentinel out even at 12 cards, so this bug is desktop-specific; the fix causes no mobile regression.

`npm run build` passes.