### PR TITLE
fix(ci): commit generated src/content/guides alongside skills and bundles in PR workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Commit extracted skills
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          if [ -n "$(git status --porcelain src/content/skills public/bundles)" ]; then
+          if [ -n "$(git status --porcelain src/content/skills src/content/guides public/bundles)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add src/content/skills public/bundles
+            git add src/content/skills src/content/guides public/bundles
             git commit -m "chore: extract skill submissions"
             git push
           else


### PR DESCRIPTION
## What changed
CI's "Commit extracted skills" step was missing `src/content/guides` from both the porcelain check and `git add`, even though `import:submissions` generates `src/content/guides/<slug>.md` from each submission's `README.md`.

### The result
 If a contributor’s PR added or updated a README.md, npm run import:submissions would write the guide file into the CI workspace, astro build would use it successfully, but the file was never committed to the PR branch. On main, src/content/guides/ does not exist at all, which means the repo state has never tracked guides — every deploy has to regenerate them from scratch in deploy.yml.

## Refernce
The workflow itself documents guides as a generated artifact in three places:

.github/workflows/ci.yml:— scope guard comment: "Generated artifacts that CI itself commits back to the branch (src/content/skills, src/content/guides, public/bundles, src/data/ratings.json) are ignored"
.github/workflows/ci.yml: — scope guard grep exclusion: grep -vE '^src/content/guides/'
.github/workflows/deploy.yml: — deploy step re-runs `npm run import:submissions` before build, confirming guides are expected to be persisted artifacts

The importer produces them consistently:

scripts/import-submissions.ts: — writeGuide() writes src/content/guides/<slug>.md from the submission’s README.md
scripts/import-submissions.ts — called in every processor path (processSubmission, processPlugin, processAutomation, processAutomationInstaller)
The commit step simply never included the path.

## The fix
Added `src/content/guides` to both lines in `.github/workflows/ci.yml`:

```yaml
if [ -n "$(git status --porcelain src/content/skills src/content/guides public/bundles)" ]; then
  git add src/content/skills src/content/guides public/bundles
```
