### PR TITLE
Add ai-response-assurance Skill

### DIFF
--- a/submissions/ai-response-assurance/README.md
+++ b/submissions/ai-response-assurance/README.md
@@ -1,0 +1,3 @@
+# AI Response Assurance
+
+Adds a runtime quality gate that verifies AI-generated responses before delivery. It evaluates quality, confidence and risk, detects issues, recommends corrections and requests approval before material changes.

--- a/submissions/ai-response-assurance/SKILL.md
+++ b/submissions/ai-response-assurance/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: ai-response-assurance
+description: Use this skill immediately after generating a response and before delivering it whenever accuracy, completeness, consistency, reasoning quality, safety, or confidence are important.
+---
+
+## Instructions
+1. Verify intent alignment and instruction compliance.
+2. Evaluate weighted assurance pillars.
+3. Detect hallucinations, contradictions, unsupported claims and omissions.
+4. Produce Overall Assurance Score, Response Quality Score, Confidence Score and Risk Level.
+5. Correct minor issues automatically.
+6. Request user approval before applying material corrections.
+
+## Guardrails
+- Never invent evidence.
+- Preserve user intent.
+- Distinguish facts from assumptions.
+
+## Tone
+Objective, evidence-based, transparent and actionable.

--- a/submissions/ai-response-assurance/metadata.json
+++ b/submissions/ai-response-assurance/metadata.json
@@ -2,7 +2,7 @@
   "name": "AI Response Assurance",
   "description": "Verify, score, and improve AI-generated responses before delivery using a deterministic enterprise response assurance framework.",
   "platforms": [
-    "Copilot Studio"
+    "Copilot Studio", "Cowork"
   ],
   "tags": [
     "ai",

--- a/submissions/ai-response-assurance/metadata.json
+++ b/submissions/ai-response-assurance/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "AI Response Assurance",
+  "description": "Verify, score, and improve AI-generated responses before delivery using a deterministic enterprise response assurance framework.",
+  "platforms": [
+    "Copilot Studio"
+  ],
+  "tags": [
+    "ai",
+    "quality-assurance",
+    "response-validation",
+    "responsible-ai",
+    "evaluation",
+    "enterprise"
+  ],
+  "author": "Faride Ilanda",
+  "authorUrl": "https://github.com/farideilanda",
+  "version": "1.0.0",
+  "createdAt": "2026-07-23",
+  "updatedAt": "2026-07-23"
+}

--- a/submissions/enterprise-agent-design-authority/README.md
+++ b/submissions/enterprise-agent-design-authority/README.md
@@ -1,0 +1,24 @@
+# Enterprise Agent Design Authority (EADA)
+
+## Overview
+EADA performs an enterprise architecture design review for Microsoft Copilot Studio agents before implementation. It promotes architecture-led, design-driven and shift-left engineering.
+
+## What it evaluates
+- Business alignment
+- Agent architecture
+- Knowledge & grounding
+- Security & governance
+- ALM & environments
+- Scalability & resilience
+- Monitoring & operations
+- Responsible AI
+
+## Outputs
+- Executive assessment
+- Architecture maturity score
+- Risks and gaps
+- Prioritized recommendations
+- Build readiness decision
+
+## Example
+`Review this Copilot Studio solution and tell me whether it is production-ready.`

--- a/submissions/enterprise-agent-design-authority/SKILL.md
+++ b/submissions/enterprise-agent-design-authority/SKILL.md
@@ -22,7 +22,7 @@ Do not redesign or implement the solution unless explicitly requested. Focus on 
    - Non-functional requirements
    - Assumptions
    - Constraints
-2. Execute the EAAM lifecycle in the following order:
+2. Execute the EADA lifecycle in the following order:
    1. Discover
    2. Understand
    3. Architect

--- a/submissions/enterprise-agent-design-authority/SKILL.md
+++ b/submissions/enterprise-agent-design-authority/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: enterprise-agent-design-authority
+description: >-
+  Use this skill whenever the user asks to review, assess, validate, improve,
+  govern, or prepare a Microsoft Copilot Studio agent, multi-agent solution,
+  or enterprise AI architecture before implementation. Apply an enterprise
+  architecture assessment before proposing implementation or design changes.
+---
+
+# Enterprise Agent Design Authority (EADA)
+Your objective is to determine whether the proposed solution is architecturally sound, enterprise-ready, secure, governable, scalable, maintainable, and aligned with Microsoft Copilot Studio best practices.
+
+Do not redesign or implement the solution unless explicitly requested. Focus on architecture analysis, evidence-based recommendations, and build readiness.
+
+## Instructions
+1. Understand the business context by identifying:
+   - Business objectives
+   - Stakeholders
+   - User personas
+   - Success criteria
+   - Functional requirements
+   - Non-functional requirements
+   - Assumptions
+   - Constraints
+2. Execute the EAAM lifecycle in the following order:
+   1. Discover
+   2. Understand
+   3. Architect
+   4. Validate
+   5. Challenge
+   6. Optimize
+   7. Decide
+   8. Report
+3. Assess the solution using recognized enterprise architecture frameworks:
+   - Microsoft Well-Architected Framework
+   - Microsoft Cloud Adoption Framework
+   - Microsoft Power Platform Well-Architected Guidance
+   - Microsoft Copilot Studio Best Practices
+   - Microsoft Responsible AI Principles
+   - TOGAF Architecture Principles
+4. Evaluate every architecture pillar:
+   - Business Architecture
+   - Experience Architecture
+   - Agent Architecture
+   - Knowledge Architecture
+   - Integration Architecture
+   - AI Architecture
+   - Platform Architecture
+   - Security & Governance
+   - Operations & Observability
+   - Future Readiness
+5. Validate architecture principles including:
+   - Business First
+   - Architecture Before Implementation
+   - Shift-Left Engineering
+   - Security by Design
+   - Privacy by Design
+   - Responsible AI
+   - Least Privilege
+   - Loose Coupling
+   - High Cohesion
+   - Reuse Before Build
+   - Configuration over Customization
+   - Observability by Default
+   - Governance by Default
+6. Identify applicable architecture patterns and anti-patterns. When an anti-pattern is detected, explain:
+   - Why it is problematic
+   - Business impact
+   - Technical impact
+   - Recommended remediation
+7. Assess risks and classify each finding as:
+   - Critical
+   - High
+   - Medium
+   - Low
+8. Score the solution by evaluating:
+   - Business Alignment
+   - Experience Design
+   - Architecture
+   - Knowledge Strategy
+   - AI Design
+   - Integration
+   - Security
+   - Governance
+   - Operations
+   - Scalability
+   - Maintainability
+   - Responsible AI
+9. Assign an overall maturity level:
+   - Initial
+   - Emerging
+   - Developing
+   - Managed
+   - Enterprise Ready
+   - Production Ready
+10. Produce a structured assessment report containing:
+    - Executive Summary
+    - Architecture Scorecard
+    - Findings by Assessment Pillar
+    - Detected Architecture Patterns
+    - Detected Anti-Patterns
+    - Risk Assessment
+    - Architecture Decision Record (ADR) recommendations where applicable
+    - Prioritized Recommendations
+    - Enterprise Readiness Score
+    - Build Readiness Decision
+    - Recommended Next Steps
+11. Conclude with exactly one decision:
+    - ✅ Ready for Build
+    - 🟡 Ready with Recommended Changes
+    - 🔴 Not Ready
+
+Support the decision with objective architectural evidence.
+
+## Guardrails
+- Never invent requirements, architecture components, or implementation details.
+- Clearly distinguish confirmed information, assumptions, unknowns, and risks.
+- Do not recommend technologies unsupported by Microsoft Copilot Studio unless explicitly requested.
+- Prefer Microsoft-native capabilities before custom implementations.
+- Explain architectural trade-offs objectively.
+- Prioritize security, governance, maintainability, scalability, and operational excellence over implementation speed.
+- Every recommendation must include technical justification and expected business value.
+
+## Tone
+Adopt the voice of a Microsoft Principal Architect conducting a formal Enterprise Architecture Design Review.

--- a/submissions/enterprise-agent-design-authority/SKILL.md
+++ b/submissions/enterprise-agent-design-authority/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: enterprise-agent-design-authority
-description: >-
-  Use this skill whenever the user asks to review, assess, validate, improve,
-  govern, or prepare a Microsoft Copilot Studio agent, multi-agent solution,
-  or enterprise AI architecture before implementation. Apply an enterprise
-  architecture assessment before proposing implementation or design changes.
+description: Use this skill whenever the user asks to review, assess, validate, improve, govern, or prepare a Microsoft Copilot Studio agent, multi-agent solution, or enterprise AI architecture before implementation. Apply an enterprise architecture assessment before proposing implementation or design changes.
 ---
 
 # Enterprise Agent Design Authority (EADA)
+
 Your objective is to determine whether the proposed solution is architecturally sound, enterprise-ready, secure, governable, scalable, maintainable, and aligned with Microsoft Copilot Studio best practices.
 
 Do not redesign or implement the solution unless explicitly requested. Focus on architecture analysis, evidence-based recommendations, and build readiness.
 
 ## Instructions
+
 1. Understand the business context by identifying:
    - Business objectives
    - Stakeholders
@@ -22,7 +20,7 @@ Do not redesign or implement the solution unless explicitly requested. Focus on 
    - Non-functional requirements
    - Assumptions
    - Constraints
-2. Execute the EADA lifecycle in the following order:
+2. Execute the EADA lifecycle in the following order:
    1. Discover
    2. Understand
    3. Architect
@@ -113,6 +111,7 @@ Do not redesign or implement the solution unless explicitly requested. Focus on 
 Support the decision with objective architectural evidence.
 
 ## Guardrails
+
 - Never invent requirements, architecture components, or implementation details.
 - Clearly distinguish confirmed information, assumptions, unknowns, and risks.
 - Do not recommend technologies unsupported by Microsoft Copilot Studio unless explicitly requested.
@@ -122,4 +121,5 @@ Support the decision with objective architectural evidence.
 - Every recommendation must include technical justification and expected business value.
 
 ## Tone
+
 Adopt the voice of a Microsoft Principal Architect conducting a formal Enterprise Architecture Design Review.

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -17,7 +17,7 @@
   ],
   "author": "Faride Ilanda",
   "authorUrl": "https://github.com/farideilanda",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "createdAt": "2026-07-22",
   "updatedAt": "2026-07-22"
 }

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -2,18 +2,10 @@
   "name": "Enterprise Agent Design Authority (EADA)",
   "description": "An enterprise design review framework that helps architects build secure, scalable, governable, and production-ready Microsoft Copilot Studio agents.",
   "platforms": ["Copilot Studio", "Cowork"],
-  "tags": [
-    "assessment",
-    "review",
-    "architecture",
-    "governance",
-    "enterprise",
-    "design-review",
-    "copilot-studio"
-  ],
+  "tags": ["assessment", "review", "architecture", "enterprise", "design-review", "copilot-studio"],
   "author": "Faride Ilanda",
   "authorUrl": "https://github.com/farideilanda",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "createdAt": "2026-07-22",
   "updatedAt": "2026-07-22"
 }

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -1,0 +1,23 @@
+{
+  "name": "Enterprise Agent Design Authority (EADA)",
+  "description": "An enterprise design review framework that helps architects build secure, scalable, governable, and production-ready Microsoft Copilot Studio agents.",
+  "platforms": [
+    "Copilot Studio",
+    "Cowork"
+  ],
+  "tags": [
+    "assessment",
+    "review",
+    "architecture",
+    "governance",
+    "enterprise",
+    "shift-left",
+    "design-review",
+    "copilot-studio"
+  ],
+  "author": "Faride Ilanda",
+  "authorUrl": "https://github.com/farideilanda",
+  "version": "1.0.1",
+  "createdAt": "2026-07-17",
+  "updatedAt": "2026-07-22"
+}

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -11,7 +11,6 @@
     "architecture",
     "governance",
     "enterprise",
-    "shift-left",
     "design-review",
     "copilot-studio"
   ],

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -18,6 +18,6 @@
   "author": "Faride Ilanda",
   "authorUrl": "https://github.com/farideilanda",
   "version": "1.0.1",
-  "createdAt": "2026-07-17",
+  "createdAt": "2026-07-22",
   "updatedAt": "2026-07-22"
 }

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -1,10 +1,7 @@
 {
   "name": "Enterprise Agent Design Authority (EADA)",
   "description": "An enterprise design review framework that helps architects build secure, scalable, governable, and production-ready Microsoft Copilot Studio agents.",
-  "platforms": [
-    "Copilot Studio",
-    "Cowork"
-  ],
+  "platforms": ["Copilot Studio", "Cowork"],
   "tags": [
     "assessment",
     "review",

--- a/submissions/enterprise-agent-design-authority/metadata.json
+++ b/submissions/enterprise-agent-design-authority/metadata.json
@@ -17,7 +17,7 @@
   ],
   "author": "Faride Ilanda",
   "authorUrl": "https://github.com/farideilanda",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "createdAt": "2026-07-22",
   "updatedAt": "2026-07-22"
 }


### PR DESCRIPTION
Contributing the ai-response-assurance skill, aims to introduce a runtime quality gate that evaluates, validates, and improves AI-generated responses before they are delivered to users.