### PR TITLE
feat: add Agent Evaluation Designer skill

### DIFF
--- a/submissions/agent-evaluation-designer/README.md
+++ b/submissions/agent-evaluation-designer/README.md
@@ -1,0 +1,44 @@
+# Agent Evaluation Designer
+
+Most agent "testing" fails for the same reason: nobody defined what *good* meant
+before running the tests, then graded long, nuanced answers with brittle
+exact-match rules and declared victory on activity rather than outcomes. This
+skill fixes that.
+
+**Agent Evaluation Designer** turns an agent into a disciplined evaluation
+partner. It walks you through five stages:
+
+1. **Define what "good" means** - the decision the evaluation supports, the
+   scenarios that matter, and a one-line success bar per quality dimension.
+2. **Choose the grading method per scenario** - a decision table that steers you
+   to the cheapest method that actually measures what you care about (and away
+   from exact/verbatim matching for long generative answers).
+3. **Build the test set** - coverage over volume, short rubric-style reference
+   answers, edge cases and paraphrases, no secrets baked in.
+4. **Run and interpret** - read aggregate *and* per-case results, cluster
+   failures by root cause, and know when to fix the test instead of the agent.
+5. **Decide go / no-go** - a short, defensible readiness summary you can own.
+
+## Built for Copilot Studio
+
+This skill targets **Microsoft Copilot Studio**, which has a native agent
+evaluation feature with exactly these grading methods, test sets, and quotas. The
+skill pulls in `references/copilot-studio-evaluation.md`, which pins down the
+native test-method names and the real field limits and quotas (the ~1,000-character
+expected-response cap, 100 cases per set, one run at a time, the ~20-runs-per-24h
+throttle, and 89-day retention) so your test design fits what the product actually
+enforces. The underlying five-stage methodology is general enough to guide
+evaluation of any agent, but the concrete method names and limits are Copilot
+Studio's.
+
+## When it triggers
+
+The agent invokes this skill whenever you want to evaluate, test, or validate an
+agent, decide whether one is ready to ship or go live, pick how to grade its
+answers, design a test set, or interpret evaluation results into a decision.
+
+## A note on scope
+
+Evaluation here measures **correctness and quality**. It does not replace
+responsible-AI, safety, or content-policy review - treat those as a separate
+gate. The skill will remind you of that when it matters.

--- a/submissions/agent-evaluation-designer/SKILL.md
+++ b/submissions/agent-evaluation-designer/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: agent-evaluation-designer
+description: Use this skill whenever the user wants to evaluate, test, or validate an AI agent, decide whether an agent is ready to ship or go live, choose how to grade an agent's answers (exact match, similarity, meaning, keywords, quality, or custom), design a test set of questions and expected answers, or interpret evaluation results into a go/no-go decision. Invoke it before the user hand-builds tests or declares an agent "done."
+---
+
+# Agent Evaluation Designer
+
+You help the user design and run a **rigorous, defensible evaluation** of an AI
+agent and turn the results into a clear **go / no-go** decision. Evaluation is a
+product discipline, not a technical formality: your job is to make the user
+define what "good" means *before* testing, pick the right way to measure it, and
+stay accountable to the result.
+
+Work through the five stages below in order. Do not skip stage 1 - most bad
+evaluations fail because "good" was never defined. Ask concise questions when you
+lack the information a stage needs; otherwise proceed and state your assumptions.
+
+## Stage 1 - Define what "good" means
+
+Establish the evaluation's purpose before writing a single test.
+
+1. Ask what decision the evaluation must support (ship / don't ship, compare two
+   versions, catch regressions, satisfy a stakeholder or compliance gate).
+2. Ask who the agent serves and the top real-world tasks it must get right.
+3. For each task, define the **quality dimensions** that matter, choosing from:
+   - **Correctness / groundedness** - is the answer factually right and grounded
+     in the agent's sources?
+   - **Completeness** - does it cover the required points?
+   - **Relevance** - does it answer what was asked?
+   - **Tone / format / compliance** - does it meet wording, safety, or policy rules?
+   - **Tool / action use** - did it call the right capability or resource?
+4. Write a one-line **success bar** per dimension (e.g. "names the correct return
+   window and the required proof of purchase, in a friendly tone").
+
+Output of this stage: a short list of prioritized scenarios, each with the
+dimensions and success bar that define a pass.
+
+## Stage 2 - Choose the grading method per scenario
+
+Pick the *cheapest method that actually measures the dimension you care about*.
+Never default to exact/verbatim matching for long generative answers - it fails
+good answers for trivial wording differences. Use this decision guide:
+
+| If you need to check… | Use | Needs an expected answer? |
+| --- | --- | --- |
+| Overall quality with no reference answer | **General quality** (LLM judge on relevance/groundedness/completeness) | No |
+| The answer *means* the same as a reference | **Compare meaning** (semantic) | Short reference answer |
+| Specific required facts/phrases are present | **Keyword match** | Keywords/phrases only |
+| The right tool/capability/resource was used | **Tool use** | Expected capabilities |
+| Close textual match to a canonical answer | **Text similarity** | Full reference answer |
+| An exact, deterministic string (IDs, codes, short canned replies) | **Exact match** | Exact answer |
+| A bespoke pass/fail rule you define | **Custom** (your criteria + labels) | Your instructions |
+
+Rules of thumb:
+- **Long, free-form responses → Compare meaning, Keyword match, General quality,
+  or Custom.** Not Exact match or Text similarity.
+- You can combine methods on one test set (e.g. Keyword match for required facts
+  + General quality for tone).
+- Reserve Exact match for short, deterministic outputs only.
+
+## Stage 3 - Build the test set
+
+1. Aim for coverage over volume: start with 5-30 high-impact cases for fast
+   iteration; grow to 50-200+ for regression/coverage once the agent stabilizes.
+2. Include **happy paths, edge cases, paraphrases, and known failure modes**.
+3. For methods that need a reference, write the **shortest reference that still
+   captures the required meaning or keywords** - a rubric ("must mention X, Y, Z"),
+   not a full essay. This keeps cases robust and avoids fragile verbatim matching.
+4. Never bake secrets, personal data, or environment-specific paths into cases.
+5. Note the user profile / auth context each case needs, if the agent behaves
+   differently per user.
+
+## Stage 4 - Run and interpret
+
+1. Run the test set; if the platform limits concurrency, run one at a time and
+   plan batches so you don't hit daily throttles (see the platform reference).
+2. Read results at two levels: the **aggregate score** (are we broadly good?) and
+   **individual failures** (what exactly broke, and why?).
+3. Cluster failures by root cause: missing knowledge, wrong tool call, poor
+   grounding, tone/format, or an over-strict expected answer (fix the test, not
+   the agent, when the answer was actually fine).
+4. Prioritize fixes by user impact × frequency.
+
+## Stage 5 - Decide go / no-go
+
+Produce a short, defensible readiness summary:
+- **Verdict:** Go / Go-with-caveats / No-go.
+- **Evidence:** pass rate per priority scenario against the success bars from
+  stage 1.
+- **Top risks** still open, and what would clear them.
+- **Recommended next actions**, ordered.
+
+State the verdict plainly and own it. Evaluation measures correctness and
+quality - it does **not** replace responsible-AI, safety, or content-policy
+review, so call those out as a separate gate when relevant.
+
+## Copilot Studio specifics
+
+This skill targets **Microsoft Copilot Studio**, whose built-in agent evaluation
+provides these grading methods, test sets, and quotas natively. Read
+`references/copilot-studio-evaluation.md` for the exact native test-method names,
+field limits, and quotas so your recommendations fit what the product enforces
+(for example, the ~1,000-character expected-response cap and the per-agent daily
+evaluation throttle). The five-stage methodology itself is sound for evaluating
+any agent, but the concrete method names and limits here are Copilot Studio's.

--- a/submissions/agent-evaluation-designer/metadata.json
+++ b/submissions/agent-evaluation-designer/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Agent Evaluation Designer",
+  "description": "Design a rigorous, platform-aware evaluation for an AI agent - define what good looks like, pick the right grading method, build a test set, and turn results into a defensible go/no-go decision.",
+  "platforms": ["Copilot Studio"],
+  "tags": ["evaluation", "testing", "quality-assurance", "go-live", "decision-making"],
+  "author": "James Papadimitriou",
+  "authorUrl": "https://github.com/jpapadimitriou",
+  "version": "1.0.0",
+  "createdAt": "2026-07-23",
+  "updatedAt": "2026-07-23"
+}

--- a/submissions/agent-evaluation-designer/references/copilot-studio-evaluation.md
+++ b/submissions/agent-evaluation-designer/references/copilot-studio-evaluation.md
@@ -1,0 +1,60 @@
+# Copilot Studio agent evaluation - platform specifics
+
+Use these facts when the user evaluates a **Microsoft Copilot Studio** agent, so
+your recommendations match what the product actually enforces. The general
+methodology in `SKILL.md` still applies; this only pins down the native names,
+limits, and quotas.
+
+## Native test (grading) methods
+
+Copilot Studio's built-in agent evaluation supports these methods. Map the
+generic guidance in the skill to these exact names:
+
+| Native method | Measures | Needs |
+| --- | --- | --- |
+| **General quality** | Response quality on set qualities (relevance, groundedness, completeness). Scored /100. | No expected answer |
+| **Compare meaning** | Whether the answer matches the *meaning* of the expected answer. Scored /100. | Pass score + expected answer |
+| **Text similarity** | Textual closeness to the expected answer. Scored /100. | Pass score + expected answer |
+| **Exact match** | Answer matches the expected answer exactly. Pass/fail. | Expected answer |
+| **Keyword match** | Answer contains all/any expected keywords or phrases. Pass/fail. | Expected keywords/phrases |
+| **Tool use** | Whether the expected tools/capabilities were used. Pass/fail. | Expected capabilities |
+| **Custom** | Meets criteria you define. Pass/fail against your labels. | Name + evaluation instructions + labels |
+
+Guidance:
+- For **long, free-form responses, do not use Exact match or Text
+  similarity** - they compare against the full verbatim answer and fail on
+  trivial wording differences. Use **Compare meaning**, **Keyword match**,
+  **Custom**, or **General quality** (no reference needed) instead.
+- A single test set can apply **multiple methods** at once.
+- **All methods except General quality require an expected response or keywords.**
+
+## Field limits and quotas (as observed / documented)
+
+- **~1,000-character limit on both the question and the expected-response
+  fields** of a test case. Cases that exceed it are dropped on import (the UI
+  warns "Some cases weren't imported"). This applies to manual entry and
+  spreadsheet/CSV import. It is enforced by the product; there is **no documented
+  self-service setting to raise it**. Work around it by using Compare
+  meaning / Keyword match / Custom with a **short reference (a rubric of required
+  facts), not the full verbatim answer**.
+- **Up to 100 test cases per test set.**
+- **One evaluation runs at a time** per agent.
+- **Rolling 24-hour throttle of ~20 evaluation runs per agent** ("The agent has
+  been evaluated more than 20 times in the last 24 hours"). Not in the published
+  quota docs but enforced; plan batches to stay under it. No documented way to
+  raise it.
+- **Results retained for 89 days**; export to CSV for longer retention.
+- Test-case generation from knowledge/topics accepts source files up to **5 MB**.
+
+## Environment notes
+
+- In **Government Community Cloud (GCC)**: the **Text similarity** method is not
+  available (all other methods are), and makers cannot attach a user profile to a
+  test set.
+- Evaluations can also be driven via the **Power Platform REST API** or
+  connectors/flows for CI/CD, as an alternative to the Copilot Studio UI - useful
+  when volume or automation matters.
+
+> These limits reflect the current (preview-era) product and may change. When a
+> value is critical to the user, advise them to confirm against the current
+> Microsoft Learn "agent evaluation" docs.


### PR DESCRIPTION
# Add skill: Agent Evaluation Designer

## What this adds

A new skill, **Agent Evaluation Designer**, under `submissions/agent-evaluation-designer/`.

It turns an agent into a disciplined evaluation partner that walks the user
through five stages: (1) define what "good" means, (2) choose the right grading
method per scenario, (3) build a test set, (4) run and interpret results, and
(5) make a defensible go / no-go decision. It deliberately steers users away from
brittle exact/verbatim matching for long generative answers.

## Platforms

`Copilot Studio`.

The skill targets Copilot Studio, whose native agent evaluation feature provides
exactly these grading methods, test sets, and quotas. It reads
`references/copilot-studio-evaluation.md` for the native test-method names and the
current field limits/quotas (e.g. the ~1,000-character expected-response cap, 100
cases per set, one run at a time, the ~20-runs-per-24h throttle, and 89-day
retention), so its recommendations fit what the product enforces. The underlying
five-stage methodology is general enough to guide evaluation of any agent, but the
concrete method names and limits are Copilot Studio's.

## Contents

```
submissions/agent-evaluation-designer/
├── metadata.json                          # catalog sidecar
├── README.md                              # detail-page overview
├── SKILL.md                               # name + agent description + instructions
└── references/
    └── copilot-studio-evaluation.md       # Copilot Studio specifics (read on demand)
```

## Testing

Smoke-tested in Copilot Studio's new (modern agent) experience by uploading the
skill as a `.zip` bundle (SKILL.md + references) and verifying:

- The skill self-triggers from its frontmatter description (no manual "use the skill" prompt needed).
- It defines success criteria before writing tests.
- It recommends meaning/keyword/quality/custom grading and avoids exact/text-similarity for long answers.
- It surfaces the Copilot Studio limits from the bundled reference when the agent is identified as Copilot Studio.
- It produces a clear go / no-go decision with evidence, risks, and next actions.

## License

By contributing, I agree the skill is shared under the repository's MIT license.
