### PR TITLE
Add skill: Grab My Files (Copilot Studio)

### DIFF
--- a/submissions/grab-my-files/README.md
+++ b/submissions/grab-my-files/README.md
@@ -1,0 +1,108 @@
+# Grab My Files
+
+**Collect everything your Copilot Studio agent produced in a session into one
+downloadable zip — on demand, in a single step.**
+
+Grab My Files gathers every file the agent generated during a session, packages
+them into one timestamped `.zip`, and hands it back as a download. It's a deliberately
+lightweight utility: no bundled script, nothing to wire up — import the `SKILL.md` and
+it works.
+
+---
+
+## The gap it closes
+
+Modern Copilot Studio is a genuinely strong **file generator**. In a single session an
+agent can populate a Word doc, spin up a PDF, build an Excel sheet, produce an
+interactive HTML report, and more — and a busy session often produces several of them as
+it works.
+
+Handed back inline as they're made, those files are easy to use in the moment. But across
+a **long session** that's harder than it sounds: revisions happen, new sets of content
+get generated, and the files just live in the chat history. That infographic the agent
+made early on is easy to lose track of ten tasks later — you know it exists, you just
+can't find where it landed.
+
+This skill removes the hunt. At any point you ask for everything the agent made, and you
+get **one zip** — every produced file, in a single output, without scrolling back through
+the conversation to collect them one at a time.
+
+## What it does
+
+- **Reads from `/app/created/`** — the sandbox directory where Copilot Studio writes
+  generated files — **recursively**, so nested outputs (e.g. `charts/adoption.png`) are
+  included, not just top-level files.
+- **Filters out noise** — any earlier export (`all_files_produced_*.zip`) and hidden /
+  system junk (`.DS_Store`, `Thumbs.db`, `*.tmp`, dotfiles) are skipped.
+- **Packages one archive** named `all_files_produced_<YYYYMMDD_HHMMSS>.zip` (a sortable
+  UTC timestamp), preserving the session's folder structure inside.
+- **Cleans up safely** — the new archive is built *first*, then older exports are pruned,
+  so a failed run never destroys your previous bundle.
+- **Handles a subset** — ask for "just the PDFs" and it zips only the matching files.
+- **Delivers the file** — returns the finished `.zip` as a download, not just a "done"
+  message. If nothing qualifies, it says so plainly instead of shipping an empty zip.
+
+## What it looks like
+
+You ask, at any point in the session:
+
+> **"Zip up everything you've made and give it to me."**
+
+The agent packages the session's outputs and hands back a single download:
+
+```
+all_files_produced_20260724_223104.zip
+├── onboarding_overview.pdf
+├── q3_headcount.xlsx
+├── launch_brief.docx
+└── charts/
+    └── adoption_curve.png
+```
+
+> I've packaged **4 files** into `all_files_produced_20260724_223104.zip`
+> (`onboarding_overview.pdf`, `q3_headcount.xlsx`, `launch_brief.docx`,
+> `charts/adoption_curve.png`). It's attached and ready to download.
+
+## Runs when you ask
+
+The skill triggers on natural "give me my files" phrasings, for example:
+
+- "Export all the files you produced in this session"
+- "Zip up my files so I can download them"
+- "Package everything you made into one download"
+- "Just zip the PDFs you created and send them over"
+
+It deliberately **does not** fire for adjacent-but-different asks — downloading a single
+named file, creating or converting a file, or persisting files to SharePoint / OneDrive /
+Dataverse — so it stays out of the way of those flows.
+
+## Where it fits
+
+| You want to… | Grab My Files gives you… |
+| --- | --- |
+| **Grab everything at the end of a session** | One zip of every file produced, in a single step. |
+| **Find a file that scrolled out of view** | All outputs collected in one place — no hunting the chat. |
+| **Hand off a session's deliverables** | A single, cleanly named archive with the folder layout preserved. |
+| **Pull just one kind of output** | A filtered zip (e.g. only the PDFs). |
+
+## How it works
+
+1. **Inventories `/app/created/`** recursively and selects the produced files, excluding
+   prior exports and system junk.
+2. **Builds the archive** — a UTC-timestamped `.zip` that preserves relative folder
+   structure — then prunes older exports only after it's safely written.
+3. **Returns `all_files_produced_<timestamp>.zip`** to the user as a downloadable file.
+
+## Honest boundaries
+
+This is a **convenience utility, not a storage or backup system.**
+
+- Files in `/app/created/` are **ephemeral** — Copilot Studio's sandbox is cleared when
+  the session ends. The zip is a way to walk away with a session's outputs, not a place
+  they persist. For durable storage, route files to SharePoint, OneDrive, or Dataverse
+  with a flow instead.
+- It assumes generated files land in **`/app/created/`**.
+
+## Files
+
+- `SKILL.md` — the agent-facing trigger and packaging instructions.

--- a/submissions/grab-my-files/SKILL.md
+++ b/submissions/grab-my-files/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: grab-my-files
+description: Bundle every file the agent produced in this session into a single timestamped .zip and hand it back as a download. Use when the user asks to "export all produced files", "zip my files", "package everything you made", "bundle my files", "give me all the files", or similar. Files are read from /app/created/. Do NOT use to fetch a single named file the user can already download on its own, to create or convert a file, or to save/persist files to SharePoint, OneDrive, or Dataverse — those are separate flows, not a local zip-and-download.
+---
+
+# Grab My Files
+
+## Overview
+
+Copilot Studio writes the files it generates during a session to **`/app/created/`**.
+This skill packages everything currently in that folder into one timestamped `.zip`
+and returns it to the user as a downloadable attachment — a one-tap way to grab all
+of a session's outputs at once instead of downloading them one by one.
+
+There is **no bundled script**. You perform the export yourself with the tools you
+already have (e.g. the code interpreter). Work against whatever is actually present
+in `/app/created/` at the moment the user asks — do not assume a fixed set of files.
+
+## When to use
+
+Invoke when the user says anything like:
+- "export all produced files" / "package everything"
+- "zip up my files" / "bundle my files"
+- "give me everything you made" / "download all the outputs"
+
+If the user names a subset ("just the PDFs", "only the report"), honor that and zip
+only the matching files, but still follow the rules below.
+
+## How to export
+
+1. **Inspect the folder.** List `/app/created/` **recursively** so nested outputs
+   (e.g. `/app/created/charts/foo.png`) are included, not just top-level files.
+2. **Decide what goes in.** Include every produced file **except**:
+   - any previous export archive (files named `all_files_produced_*.zip`), and
+   - hidden/system junk (`.DS_Store`, `Thumbs.db`, `*.tmp`, dotfiles).
+3. **Prune old exports *after* the new one is written.** Build the new archive
+   first, then delete any *other* `all_files_produced_*.zip` in `/app/created/`.
+   Doing it in this order means a failed build never destroys the user's previous
+   bundle, and no old export gets nested inside the new one.
+4. **Handle the empty case.** If nothing qualifies, tell the user there are no
+   produced files to export and stop — do not create an empty zip.
+5. **Name the archive** `all_files_produced_<YYYYMMDD_HHMMSS>.zip` — a sortable,
+   UTC timestamp — and write it to `/app/created/`.
+6. **Preserve structure.** Keep the relative folder layout inside the zip so files
+   restore to the same subfolders they came from.
+7. **Deliver it.** Return the finished `.zip` to the user as a download — don't just
+   report that it was created. In Copilot Studio, writing the file to `/app/created/`
+   surfaces it as a downloadable attachment; make sure the user gets that link.
+
+## Confirm to the user
+
+After the zip is written, reply with:
+- the archive name (including its timestamp),
+- the count and list of files packaged inside, and
+- a note that the zip is attached and ready to download.
+
+> I've packaged **3 file(s)** into **`all_files_produced_20260724_215812.zip`**:
+> - `onboarding_overview.pdf`
+> - `onboarding_overview.docx`
+> - `charts/headcount.png`
+>
+> It's attached above and ready to download. 📦

--- a/submissions/grab-my-files/SKILL.md
+++ b/submissions/grab-my-files/SKILL.md
@@ -40,7 +40,7 @@ only the matching files, but still follow the rules below.
 
 After the zip is written, reply with:
 - the archive name (including its timestamp),
-- the count and list of files packaged inside, and
+- the total count of files packaged, plus a list of up to 50 packaged paths (sorted). If there are more than 50, list the first 50 and say how many additional files were included, and
 - a note that the zip is attached and ready to download.
 
 > I've packaged **3 file(s)** into **`all_files_produced_20260724_215812.zip`**:

--- a/submissions/grab-my-files/SKILL.md
+++ b/submissions/grab-my-files/SKILL.md
@@ -5,17 +5,6 @@ description: Bundle every file the agent produced in this session into a single 
 
 # Grab My Files
 
-## Overview
-
-Copilot Studio writes the files it generates during a session to **`/app/created/`**.
-This skill packages everything currently in that folder into one timestamped `.zip`
-and returns it to the user as a downloadable attachment — a one-tap way to grab all
-of a session's outputs at once instead of downloading them one by one.
-
-There is **no bundled script**. You perform the export yourself with the tools you
-already have (e.g. the code interpreter). Work against whatever is actually present
-in `/app/created/` at the moment the user asks — do not assume a fixed set of files.
-
 ## When to use
 
 Invoke when the user says anything like:

--- a/submissions/grab-my-files/metadata.json
+++ b/submissions/grab-my-files/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Grab My Files",
+  "description": "One-tap way to bundle every file your Copilot Studio agent produced in a session into a single timestamped .zip and hand it back as a download.",
+  "platforms": ["Copilot Studio"],
+  "tags": ["files", "export", "zip", "download", "productivity"],
+  "author": "Rafael Alcaraz",
+  "authorUrl": "https://github.com/rafalcaraz",
+  "version": "1.0.0",
+  "createdAt": "2026-07-24",
+  "updatedAt": "2026-07-24"
+}


### PR DESCRIPTION
Adds **Grab My Files**, a lightweight Copilot Studio skill that bundles every file the agent produced in a session into one timestamped .zip and returns it as a download. Instruction-only (no bundled script).