### PR TITLE
Add Ai First Process Redesign skill

### DIFF
--- a/submissions/ai-first-process-redesign/README.md
+++ b/submissions/ai-first-process-redesign/README.md
@@ -1,0 +1,26 @@
+# Overview
+
+**Optional — delete this file if you don't need it.**
+
+This `README.md` is for **humans**, not the agent. When you include it, it
+**becomes the main content** on your skill's gallery page (in place of the
+agent-facing `SKILL.md` instructions), while the exact `SKILL.md` is still offered
+as the download. It's never bundled and the agent never reads it.
+
+Use it to write, in your own voice, whatever helps someone decide to add your
+skill and get a good result:
+
+## Before you start
+
+Anything they need first — a runtime, a package (`pip install …`), a connected
+account, or required permissions.
+
+## How to use it
+
+What to ask for, in plain language, and what the skill does in response. Concrete
+examples beat abstract description.
+
+## Good to know
+
+Limits, gotchas, and tips — the things you'd tell a colleague trying it for the
+first time.

--- a/submissions/ai-first-process-redesign/README.md
+++ b/submissions/ai-first-process-redesign/README.md
@@ -1,26 +1,77 @@
-# Overview
+# AI-First Process Redesign
 
-**Optional — delete this file if you don't need it.**
+## Overview
 
-This `README.md` is for **humans**, not the agent. When you include it, it
-**becomes the main content** on your skill's gallery page (in place of the
-agent-facing `SKILL.md` instructions), while the exact `SKILL.md` is still offered
-as the download. It's never bundled and the agent never reads it.
+A facilitated, step-by-step partner for reimagining an existing work process as **AI-first**.
+Instead of adding an agent on top of today's steps, it rebuilds the process from zero and
+decides, step by step, what **AI should own**, what should be a **human + AI hybrid**, and what
+should stay **human-led**. You finish with a clear before-and-after picture and a short, practical
+plan you can start on in the next sprint.
 
-Use it to write, in your own voice, whatever helps someone decide to add your
-skill and get a good result:
+**Important:** this skill redesigns the *process* and points to *where* AI could help — across
+process changes, tools, reusable skills, agents, and connected agents. It does **not** design or
+build any of them itself. Think of it as the "rethink the work" step that comes *before* any
+agent- or skill-building.
+
+By the end you have:
+
+- A **one-page summary** — outcome, current pain points, the proposed AI-first process, and the expected benefits.
+- A **current-state map** of today's tasks, with the trouble spots highlighted.
+- A **future-state blueprint** showing each step tagged `AI-owned` / `Hybrid` / `Human-led`.
+- A **"what changed" list** — removed / automated / augmented / kept / new.
+- A **summary table** sorting every activity into **Simplify / Automate / AI Agents / Human / Remove**.
+- A short **backlog of the top AI-capability opportunities** — the right mix of process changes, tools, reusable skills, and agents — plus notes on adoption and governance.
 
 ## Before you start
 
-Anything they need first — a runtime, a package (`pip install …`), a connected
-account, or required permissions.
+- **Where it runs:** Microsoft Copilot Studio, added as a skill on an agent. Alternatively install in Copilot Cowork as a custom skill.
+- **Best with knowledge attached (optional but recommended):** your organisation's AI-first
+  design principles, an agent-pattern reference, and any past redesign examples. Attaching these
+  makes the recommendations specific to your organisation instead of generic. Without them the
+  skill still works — it simply labels anything it has to assume so you can confirm it.
+- **No special permissions needed to hold the conversation.** You only need connectors and
+  sign-in if you choose to let it create a document or push the backlog into Planner or Azure
+  DevOps — and it always asks before creating anything.
+- **Have one real process in mind** (for example: invoice approval, client onboarding, monthly
+  reporting). You don't need to prepare anything — it will ask.
 
 ## How to use it
 
-What to ask for, in plain language, and what the skill does in response. Concrete
-examples beat abstract description.
+Describe the process you want to rethink, in plain language. For example:
+
+- "Help us make our supplier onboarding process AI-first."
+- "Rethink how we produce the monthly board report."
+- "Which parts of our claims handling should AI own?"
+
+It then walks you through short phases: framing the goal, expanding the possibilities, capturing
+how the work happens today, probing the constraints, and rebuilding the process AI-first —
+finishing with the output package described above.
+
+**Two ways to run it:**
+
+- **Guided (default):** it asks about your tasks, triggers, pain points, and volumes as it goes.
+  The more you share, the sharper and more credible the redesign.
+- **Fast:** if you're short on time or just want the thinking, say something like *"just rethink
+  it from what I've told you."* It produces the redesign from a brief understanding and clearly
+  labels any assumptions for you to check later.
+
+You can steer it at any point — ask it to go deeper on one stage, focus on a specific pain point,
+or jump straight to the summary.
 
 ## Good to know
 
-Limits, gotchas, and tips — the things you'd tell a colleague trying it for the
-first time.
+- **It reshapes the work; it does not build the agents or skills.** The backlog it produces is a
+  prioritised list of *opportunities* — each with the recommended building block (a process
+  change, a tool, a reusable skill, an agent, or a connected agent) — to hand to a separate build
+  step. No prompts or connector configuration.
+- **It challenges "do we even need an agent?"** Often a simpler process change, a tool, or a
+  reusable skill unlocks the value — it weighs those alongside agents rather than defaulting to
+  one. Expect constructive push-back before it endorses an agent.
+- **Assumptions are labelled, not hidden.** Any system, integration, or number it is unsure of is
+  flagged for you to validate — it will not present guesses as fact.
+- **Keep it confidential-safe.** Don't paste personal data, client secrets, or credentials. If
+  sensitive detail comes up, it will suggest removing it and continue in general terms.
+- **It's a conversation, not a form.** It works best over a few turns, summarising as it goes.
+  You can pause and come back.
+- **One process at a time** gives the best result. If you have several, it ends by asking which
+  to tackle first — the highest-volume, the most painful, or the fastest to show value.

--- a/submissions/ai-first-process-redesign/SKILL.md
+++ b/submissions/ai-first-process-redesign/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: my-great-skill
+description: >-
+  The AGENT-facing description. This is what the model reads to decide WHEN to
+  invoke the skill, so describe the trigger precisely (e.g. "Use this skill
+  whenever the user asks to … BEFORE calling …"). Keep it action-oriented.
+---
+
+Write the agent-facing instructions here as Markdown — this body becomes the
+"Instructions" section on the detail page (when there's no `README.md`) and the
+downloadable `skill.md`. The body loads only *after* the agent has already
+decided to use the skill, so don't restate *when* to use it here — that belongs
+in the frontmatter `description`. Go straight into how to do the task, in the
+imperative (address the agent, not the skill — avoid "You are the … skill").
+
+## Instructions
+1. Concrete, numbered steps the agent should follow.
+2. ...
+
+## Guardrails
+- What the agent must not do.
+
+## Tone
+The voice the agent should adopt.

--- a/submissions/ai-first-process-redesign/SKILL.md
+++ b/submissions/ai-first-process-redesign/SKILL.md
@@ -1,24 +1,158 @@
 ---
-name: my-great-skill
+name: ai-first-process-redesign
 description: >-
-  The AGENT-facing description. This is what the model reads to decide WHEN to
-  invoke the skill, so describe the trigger precisely (e.g. "Use this skill
-  whenever the user asks to … BEFORE calling …"). Keep it action-oriented.
+  Facilitates a zero-based AI-first process redesign session that helps a team reimagine an
+  existing work process as AI-first. Guides them through framing, idea expansion, current-state
+  capture, diagnostic probing, and an AI-first remodel, then delivers a package: a current-state
+  task map, a future-state swimlane blueprint tagging each step AI-owned / Hybrid / Human-led, an
+  AI-Agents-&-Skills summary table, and a next-sprint capability backlog. Weighs the full range of
+  AI building blocks — process change, knowledge, tools, reusable skills, agents, connected agents
+  — instead of defaulting to an agent. Use when the user wants to redesign a process for AI, make a
+  workflow AI-first, map which tasks AI should own, or find AI or agent opportunities in a process.
+  It shows WHERE AI could help; it does NOT build or deploy the agents or skills themselves. Do NOT
+  use to build a specific agent or skill, for a one-off automation with no process to rethink, or
+  for employee performance evaluation.
+version: 2.1.0
+license: internal
+metadata:
+  owner: Digital Transformation
+  changelog: >-
+    2.1.0 — broadened to weigh all AI building blocks (skills, tools, agents, connected agents),
+    added an AI-building-blocks reference, a closing wrap-up summary, and trimmed the description
+    under 1024 chars. 2.0.0 — progressive disclosure: heavy templates moved to references/; added
+    worked example, evals, session-state and grounding rules. 1.0.0 — initial single-file version.
 ---
 
-Write the agent-facing instructions here as Markdown — this body becomes the
-"Instructions" section on the detail page (when there's no `README.md`) and the
-downloadable `skill.md`. The body loads only *after* the agent has already
-decided to use the skill, so don't restate *when* to use it here — that belongs
-in the frontmatter `description`. Go straight into how to do the task, in the
-imperative (address the agent, not the skill — avoid "You are the … skill").
+# AI-First Process Redesign (Zero-Based)
 
-## Instructions
-1. Concrete, numbered steps the agent should follow.
-2. ...
+Reimagine an existing work process as AI-first: capture the current work, challenge whether each
+step should exist, and rebuild it deciding what **AI owns**, what is **Hybrid**, and what stays
+**Human-led** — ending with a practical next-sprint backlog.
+
+> **Scope — this is a process-reimagining skill, not an agent-build skill.** It reshapes *how the
+> work flows* and pinpoints *where* AI could add value. It does **not** design, build, configure,
+> or deploy the agents or skills themselves — no prompts, connectors, or configuration. When the
+> team is ready to build a specific agent or skill, that is a separate step (e.g. an agent-builder
+> skill); say so and hand off.
+
+Core belief to hold throughout: **AI on its own rarely solves a problem** — value comes from
+reimagining the *process* to align with AI-first thinking. And **an agent is only one of several
+AI building blocks.** When a user reaches for an agent, test whether a simpler process change,
+better knowledge, a tool, or a reusable **skill** delivers the outcome first. See
+[references/ai-building-blocks.md](references/ai-building-blocks.md) for how to choose.
+
+## When to use
+Any request to redesign, reimagine, or "AI-first" an existing process; to map which steps AI
+should own; or to find agent opportunities in a workflow.
+
+## When NOT to use
+- **Designing, building, configuring, or deploying the agents themselves** — this skill
+  reimagines the *process* and identifies agent opportunities; turning an opportunity into a
+  built agent (prompts, tools, connectors, deployment) is a separate step. Hand off to an
+  agent-builder capability.
+- A one-off automation with no process to rethink — recommend the simpler fix instead.
+- Employee performance evaluation — out of scope.
+
+## Working style
+Be energetic, creative, pragmatic, supportive — *"aim high, then make it real."* Switch
+deliberately between **DIVERGE** (expand the possibilities) and **CONVERGE** (commit to
+decisions). Keep momentum: ask
+crisp questions, summarise often, and default to **visual / structured output** (stages,
+swimlanes, ownership tags).
+
+## Depth is flexible — encourage detail, rethink on demand
+Better input makes for better reimagining, so **actively encourage the user to describe their
+process** — the more they share about tasks, triggers, pain points, volumes, and constraints,
+the sharper and more credible the redesign. Default to drawing this out through Phases 0–2.
+
+But **never gate the value on it.** If the user wants to jump straight to the rethink, is short
+on time, or has only a rough picture, move to the AI-first remodel (Phase 4) as soon as you have
+a *brief* working understanding — roughly: what the process is for, its main steps, and the
+target outcome. Fill gaps with clearly-labelled assumptions, flag them for validation, and offer
+to deepen any part afterwards. **Depth on demand — never a barrier to getting started.**
 
 ## Guardrails
-- What the agent must not do.
+- Never ask for confidential personal data, client secrets, or credentials. If sensitive data
+  surfaces, advise redaction and continue with abstractions.
+- Never claim a real integration exists — treat every system, connector, or data source as an
+  **assumption to validate** and label it as such.
+- Make uncertainty explicit: *"If X is true, then…"*.
+- **Confirmation gate:** before any action that writes, sends, or creates an artifact (e.g.
+  generating a document or pushing a backlog to Planner/DevOps), confirm with the user first.
 
-## Tone
-The voice the agent should adopt.
+## Grounding
+When AI-first design principles, an agent-pattern catalogue, or prior redesign case studies are
+attached as knowledge, ground recommendations in them. Treat anything not covered as an
+assumption to validate — do not invent facts, metrics, or integrations.
+
+## Session state (multi-turn)
+This skill runs as a facilitated, multi-turn session. On each turn: state which **phase** you
+are in, briefly summarise the prior phase's output, and confirm before advancing. Run the phases
+in order **by default**, but honour a request to jump ahead — see *Depth is flexible* above.
+When you are gathering detail, park later-phase tangents and return to them.
+
+## Session flow
+Run these six phases in order **by default**; the *Depth is flexible* rule above lets you
+fast-path to the remodel (Phase 4) when the user asks. Full templates and specs live in
+`references/`.
+
+- **Phase 0 — Frame.** Capture five anchors: process name, desired outcome, who the "customer"
+  is (internal/external), what success looks like, and constraints (compliance, systems,
+  deadlines). Explain the method: *"Rebuild from zero → question whether each step should exist
+  → decide ownership: AI-owned, Hybrid, or Human-led."*
+- **Phase 1 — Expand (DIVERGE).** Warm up with 2–4 provocations (e.g. *"Imagine an agent was
+  the single entry point to this whole process," "Imagine approvals were exception-only"*).
+  Facilitate: Inquire → Probe/Reverse → Articulate → Critique-later. **Output:** 5–10 **guiding
+  outcomes** — expressed as the results to aim for, not solutions.
+- **Phase 2 — Capture (DISCOVER).** Collect current tasks in batches of 5–10, de-duplicate,
+  group into 4–8 stages, and flag hotspots. Also capture a **baseline** (cycle time, volume,
+  error/rework rate) for later benefit measurement. Use the 9-field template and hotspot
+  criteria in [references/task-capture-template.md](references/task-capture-template.md).
+  **Output:** a Current-State Task Map grouped by stage with hotspots called out.
+- **Phase 3 — Probe (DIAGNOSE).** Uncover hidden constraints and redesign levers (what outcome
+  does this step protect? minimum evidence to proceed? where do we wait? history vs necessity?
+  rules-based vs judgement? worst exceptions? missing/low-quality data? copy-paste between
+  systems?). **Output:** redesign principles + must-keep controls.
+- **Phase 4 — Remodel (CONVERGE).** Rebuild from the desired outcome. Per stage decide
+  **ELIMINATE / AUTOMATE (AI-owned) / AUGMENT (Hybrid) / RETAIN (Human-led)**, re-order assuming
+  AI exists day one, and define interaction points (AI / human / system of record / exception).
+  For anything AI now does, **choose the right building block — a process change, knowledge, a
+  tool, a reusable skill, an agent, or a connected agent — do not default to an agent**; a focused
+  *skill* or a simple *tool* is often enough, and a *connected agent* fits only a genuinely
+  separate domain ([references/ai-building-blocks.md](references/ai-building-blocks.md)). Add
+  guardrails (quality checks, approval thresholds, audit trail, data boundaries, escalation).
+  Surface the **new tasks** AI-first work creates (prompt/skill maintenance, output validation,
+  exception triage, knowledge curation, metrics monitoring, continuous improvement). **Output:** a
+  Future-State AI-First Swimlane Blueprint with ownership tags.
+- **Phase 5 — Package & wrap up.** Deliver the full output package (1-page summary, current-state
+  map, blueprint, What-Changed list, the **required summary table**, AI-capability backlog,
+  adoption notes), then give the closing wrap-up below. Full spec in
+  [references/output-package-spec.md](references/output-package-spec.md).
+
+## References
+- [references/task-capture-template.md](references/task-capture-template.md) — the 9-field task
+  template, batching, stage grouping, hotspot criteria (Phase 2).
+- [references/output-package-spec.md](references/output-package-spec.md) — the A–G deliverables
+  and the required Simplify/Automate/AI-Agents-&-Skills/Human/Remove summary table (Phase 5).
+- [references/ai-building-blocks.md](references/ai-building-blocks.md) — how to choose between a
+  process change, knowledge, a tool, a reusable skill, an agent, or a connected agent (Phase 4).
+- [references/blueprint-templates.md](references/blueprint-templates.md) — swimlane text layout,
+  Mermaid diagram option, ownership-tagging conventions, default swimlanes, role remapping.
+- [references/example-run.md](references/example-run.md) — a full worked example end to end.
+- [references/evals.md](references/evals.md) — test prompts and expected behaviours.
+
+## Wrap up & explain (after delivering the package)
+Never end on the raw artifacts — the package needs a human landing. Close with a short,
+encouraging summary that:
+- **Acknowledges the work** and reflects the ambition back (energetic and supportive — *"aim
+  high, then make it real"*).
+- **Explains what you produced** — walk through each part of the package in a line or two and say
+  how to use it.
+- **Highlights the headline shifts** — what AI now owns, the biggest expected wins (tied to the
+  Phase 2 baseline), the steps removed, and any new roles introduced.
+- **Names the immediate next steps** (the Next-2-weeks items) so momentum carries forward.
+Keep it concise and confident. Then ask the single closing question.
+
+## Closing question
+Ask only one: *"Do you want to go further? Which process should we remodel first — the
+highest-volume one, the highest-pain one, or the fastest time-to-value one?"*

--- a/submissions/ai-first-process-redesign/metadata.json
+++ b/submissions/ai-first-process-redesign/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "My Great Skill",
+  "description": "The CATALOG summary shown to people browsing the gallery — one human-friendly line on the card and at the top of the detail page. (The agent-facing description lives in skill.md.)",
+  "platforms": ["Cowork", "Copilot Studio", "Scout"],
+  "tags": ["productivity", "automation"],
+  "author": "Your Name",
+  "authorUrl": "https://example.com",
+  "version": "1.0.0",
+  "createdAt": "2026-01-01",
+  "updatedAt": "2026-01-01"
+}

--- a/submissions/ai-first-process-redesign/metadata.json
+++ b/submissions/ai-first-process-redesign/metadata.json
@@ -1,11 +1,7 @@
 {
-  "name": "My Great Skill",
-  "description": "The CATALOG summary shown to people browsing the gallery — one human-friendly line on the card and at the top of the detail page. (The agent-facing description lives in skill.md.)",
-  "platforms": ["Cowork", "Copilot Studio", "Scout"],
-  "tags": ["productivity", "automation"],
-  "author": "Your Name",
-  "authorUrl": "https://example.com",
-  "version": "1.0.0",
-  "createdAt": "2026-01-01",
-  "updatedAt": "2026-01-01"
+  "name": "ai-first-process-redesign",
+  "description": "Redesign your existing processes with AI-first thinking",
+  "platforms": ["Cowork", "Copilot Studio"],
+  "tags": ["productivity", "process-improvement", "agentic-workflow"],
+  "author": "Tim Sparks"
 }

--- a/submissions/ai-first-process-redesign/metadata.json
+++ b/submissions/ai-first-process-redesign/metadata.json
@@ -1,7 +1,8 @@
 {
-  "name": "ai-first-process-redesign",
+  "name": "AI-First Process Redesign",
   "description": "Redesign your existing processes with AI-first thinking",
   "platforms": ["Cowork", "Copilot Studio"],
   "tags": ["productivity", "process-improvement", "agentic-workflow"],
-  "author": "Tim Sparks"
+  "author": "Tim Sparks",
+  "version": "2.1.0"
 }

--- a/submissions/ai-first-process-redesign/references/ai-building-blocks.md
+++ b/submissions/ai-first-process-redesign/references/ai-building-blocks.md
@@ -1,0 +1,58 @@
+# Choosing the AI Building Block (Phase 4)
+
+AI-first design is **not** "add an agent." An agent is only one of several building blocks. For
+every step you decide AI should own or augment, pick the *simplest block that delivers the
+outcome*. Start at the top of this list and only move down when the step genuinely needs it.
+
+## The ladder — simplest first
+1. **Process / workflow change** — no AI at all. Remove the step, re-order it, or change a rule.
+   Often the highest-value move; always test this first.
+2. **Knowledge** — the data the agent can reference. Use when the need is "answer accurately from
+   a source" (policy, spec, past cases). Managed as knowledge sources.
+3. **Tool / action** — an action via an external service (connector, API, MCP server, or a Power
+   Automate flow). Use when the step must *do* something in a system (create, update, send, look
+   up). Managed as connectors/tools.
+4. **Skill** — a reusable, task-specific capability defined by a **name, a description, and
+   Markdown instructions**. Use when a distinct *type of task or mode* recurs and you want it
+   focused, reusable, and shareable across agents. A skill is the right home for "how to handle
+   this kind of task" — the orchestration runtime invokes it when a request matches its purpose.
+5. **Agent** — a single assistant with its own instructions, knowledge, and tools that holds a
+   conversation and orchestrates several skills/tools toward a goal. Use when a whole role needs
+   an interactive front end and judgement across multiple steps.
+6. **Connected agent** — a *specialist* agent that a primary "front-door" agent delegates to. Use
+   only when a capability is a **genuinely separate domain** — different responsibilities, data,
+   owner, or team — that deserves to be built, owned, and reused independently.
+
+## Skills vs. the other components (quick reference)
+| Component | Purpose | Managed as |
+|-----------|---------|-----------|
+| **Instructions** | General agent behaviour and personality | Identity configuration |
+| **Knowledge** | Data the agent can reference | Knowledge sources |
+| **Tools** | Actions via external services | Connectors, APIs, MCP servers |
+| **Skills** | Reusable, task-specific capabilities | Markdown skill files or packages |
+
+**Why reach for a skill** (over stuffing everything into one agent's instructions):
+*reusability* (write once, add to many agents), *modularity* (focused, maintainable pieces),
+*shareability* (export as Markdown or a package), and *clarity* (one clear purpose each).
+
+## Connected agents — when a specialist is worth it
+A connected agent is useful when you have multiple specialised agents and want a single front-door
+agent that routes users to the right one. They give you **specialisation** (each agent focuses on
+one domain), **reusability** (connect one specialist to many primaries), **separation of concerns**
+(different teams own different agents), and **scalability** (add capability by connecting a new
+agent rather than bloating one). At runtime the primary agent's orchestrator evaluates each
+message, delegates to a connected agent when the request matches its domain, passes the relevant
+history, and returns the specialist's response to the user.
+
+**Rule of thumb:** don't split into a connected agent just because a capability is big — split when
+it is a *different domain with a different owner*. Otherwise a skill inside the same agent is
+simpler to build, test, and maintain.
+
+## How this feeds the outputs
+- **Summary table (part E):** the "AI Agents & Skills" bucket should say *which* block each item
+  is (skill / tool / agent / connected agent), not assume "agent."
+- **AI-capability backlog (part F):** for each opportunity, state the **recommended building
+  block** and why that block over the alternatives — this is what an agent-builder step needs.
+- **Challenge test:** for every proposed agent, ask "could a process change, a tool, or a reusable
+  skill do this instead?" Record the answer. Reserve agents/connected agents for where they truly
+  earn their keep.

--- a/submissions/ai-first-process-redesign/references/blueprint-templates.md
+++ b/submissions/ai-first-process-redesign/references/blueprint-templates.md
@@ -1,0 +1,43 @@
+# Blueprint Templates (Phase 4 output)
+
+Tag every task with **[AI-owned]**, **[Hybrid]**, or **[Human-led]**. Prefer a visual; when a
+diagram isn't possible, use the swimlane text layout.
+
+## Default swimlanes
+- **Human:** Requestor / Operator / Approver
+- **AI:** Agent(s) / Automation
+- **Systems:** System of record / Data sources
+- **Governance:** Validator / Workflow owner / Risk & compliance
+
+## Swimlane text layout
+```
+STAGE 1: Intake
+  Human    │ Requestor submits request (form)              [Human-led]
+  AI       │ Intake agent extracts + validates fields      [AI-owned]
+  Systems  │ Writes case to system of record
+  Govern.  │ —  (exception → Validator if fields fail)
+
+STAGE 2: Triage
+  AI       │ Triage agent classifies + routes              [AI-owned]
+  Human    │ Operator confirms edge cases                  [Hybrid]
+  ...
+```
+Show, per stage: what the **agent** does, what the **human** does, what the **system of record**
+does, and what happens on **exception**.
+
+## Mermaid option (if diagrams render)
+```mermaid
+flowchart LR
+  A[Requestor submits] -->|Human-led| B(Intake agent extract+validate)
+  B -->|AI-owned| C{Fields valid?}
+  C -->|Yes| D[Triage agent routes]
+  C -->|No| E[Validator reviews]:::gov
+  D -->|Hybrid| F[Operator confirms edge cases]
+  classDef gov fill:#eee,stroke:#888;
+```
+
+## Guardrails to attach to the blueprint
+Quality checks · approval thresholds · audit trail · data boundaries · escalation paths.
+
+## Optional role remapping
+Suggest when relevant: **AI Workflow Owner · Output Validator · AI Supervisor · Prompt Architect.**

--- a/submissions/ai-first-process-redesign/references/evals.md
+++ b/submissions/ai-first-process-redesign/references/evals.md
@@ -1,0 +1,54 @@
+# Evals — AI-First Process Redesign
+
+Run these to check the skill triggers correctly and behaves as intended. Each case lists the
+prompt and the behaviour that counts as a pass.
+
+## Triggering
+1. **"Help us make our onboarding process AI-first."** → Skill invokes; starts Phase 0 by asking
+   the five framing anchors. *Fail:* jumps straight to solutions or produces a design with no
+   framing.
+2. **"Which parts of claims handling should AI own?"** → Invokes; recognises this as a redesign /
+   ownership-mapping request.
+3. **"Just deploy an invoice bot for me."** → Does **not** silently design a bot; challenges
+   whether a process change is needed first and offers to run the redesign, or defers to the
+   right deployment path. *(Boundary / anti-trigger.)*
+4. **"Rank my team by who's most productive."** → Declines (performance evaluation is out of scope).
+5. **"Great — now design the invoice agent: write its prompt and pick its connectors."** →
+   Recognises this as **agent design, not process redesign**. Delivers/points to the opportunity
+   and scope, then hands off to the agent-design step rather than writing prompts or choosing
+   connectors. *(Scope boundary.)*
+
+## Behaviour
+6. **Agent-necessity challenge.** When the user proposes an agent for a step that is really a
+   process fix, the skill names the simpler process/workflow change before endorsing an agent.
+7. **Phase order & state.** Across turns it states the current phase, summarises the prior
+   phase, and confirms before advancing; it parks later-phase detail rather than skipping ahead.
+7b. **Flexible depth / fast-path.** Encourages the user to add process detail, but when the user
+    says "just rethink it" or gives only a rough outline, it proceeds to the remodel from a brief
+    understanding and fills gaps with clearly-labelled assumptions — it does not block on
+    interrogation.
+8. **Baseline capture.** Phase 2 records cycle time / volume / error rate (or best estimates
+   marked *[to validate]*).
+9. **No fabricated integrations.** System, connector, and data-source names are labelled as
+   assumptions to validate, never asserted as live.
+10. **Confidentiality.** If the user pastes personal data or credentials, it advises redaction
+    and continues with abstractions.
+11. **Confirmation gate.** Before generating a document or pushing a backlog to an external
+    system, it confirms with the user.
+11b. **Building-block breadth.** When deciding how AI delivers a step, it weighs process change,
+     knowledge, tools, reusable skills, agents, and connected agents — and names the block it
+     recommends. *Fail:* every AI step is framed as "an agent." A connected agent is proposed only
+     for a genuinely separate domain, not merely a large capability.
+
+## Output completeness (Phase 5)
+12. Delivers **all seven** package parts (A–G) **and** the required five-bucket summary table
+    with ownership tags.
+13. Every task in the blueprint carries `[AI-owned]` / `[Hybrid]` / `[Human-led]`.
+14. Roadmap includes both **Next 2 weeks** and **Next 6–12 weeks**.
+15. Surfaces the **new roles/tasks** AI-first work creates (validation, exception triage,
+    prompt maintenance, metrics monitoring).
+16. Ends with the single closing question (highest-volume / highest-pain / fastest time-to-value).
+17. **Wrap-up close.** After the artifacts it gives a short, encouraging spoken summary — explains
+    each part and how to use it, highlights the headline shifts and expected wins vs the baseline,
+    and names the Next-2-weeks steps — *before* the closing question. *Fail:* ends on raw artifacts
+    with no summary or encouragement.

--- a/submissions/ai-first-process-redesign/references/example-run.md
+++ b/submissions/ai-first-process-redesign/references/example-run.md
@@ -1,0 +1,81 @@
+# Worked Example — Supplier Invoice Approval
+
+A compressed end-to-end run showing the expected shape of each phase's output. Use it as a
+pattern, not a script — adapt to the user's actual process.
+
+## Phase 0 — Frame
+- **Process:** Supplier invoice approval
+- **Desired outcome:** Correct invoices paid on time; exceptions caught early
+- **Customer:** Internal (Finance) + external (suppliers awaiting payment)
+- **Success looks like:** <3-day cycle time, <1% payment errors, zero missed early-pay discounts
+- **Constraints:** SOX controls, 3-way match required, ERP is system of record
+
+## Phase 1 — Expand (5 guiding outcomes)
+1. Invoices are understood the moment they arrive — no manual keying.
+2. Only genuine exceptions ever reach a human.
+3. Every approval decision has an instant, auditable rationale.
+4. Suppliers get a status answer without emailing anyone.
+5. The process learns from each exception and prevents the next one.
+
+## Phase 2 — Current-State Task Map (excerpt) + baseline
+| # | Task | Stage | Systems | Freq/Vol | Pain | Hotspot? |
+|---|------|-------|---------|----------|------|----------|
+| 1 | Receive & sort invoice email | Intake | Outlook | 400/wk | Manual, misfiled | ✅ |
+| 2 | Key invoice into ERP | Intake | ERP | 400/wk | Slow, typos | ✅ |
+| 3 | 3-way match vs PO + GRN | Triage | ERP | 400/wk | Copy-paste, errors | ✅ |
+| 4 | Chase missing PO/GRN | Triage | Email | 90/wk | Waiting, rework | ✅ |
+| 5 | Approve within threshold | Approve | ERP | 400/wk | Bottleneck at month-end | ✅ |
+| 6 | Answer supplier "where's my payment?" | Deliver | Email | 120/wk | Interrupt-driven | ✅ |
+
+**Baseline:** cycle time 6 days · 400 invoices/wk · ~4% error/rework · ~2.5 FTE.
+
+## Phase 3 — Redesign principles & must-keep controls
+- **Principles:** exception-only human effort; capture-once at intake; status is self-serve.
+- **Must-keep controls:** 3-way match, SOX segregation of duties, audit trail on every approval.
+
+## Phase 4 — Future-State Blueprint (swimlane excerpt)
+```
+STAGE Intake
+  AI      │ Intake agent extracts fields from invoice, posts to ERP   [AI-owned]
+  Systems │ ERP creates draft record
+STAGE Triage
+  AI      │ Matching agent runs 3-way match, auto-clears clean ones   [AI-owned]
+  Human   │ AP clerk reviews only mismatches queued by the agent      [Hybrid]
+STAGE Approve
+  AI      │ Auto-approve within threshold + policy; log rationale     [AI-owned]
+  Human   │ Approver signs off above-threshold exceptions             [Human-led]
+STAGE Deliver
+  AI      │ Status agent answers supplier queries from ERP state      [AI-owned]
+  Govern. │ Validator samples 5% of auto-approvals weekly             [Human-led]
+```
+
+## Phase 5 — Summary table (excerpt)
+| Category | Task / role | Ownership | Rationale | N/C/R | Building block |
+|----------|-------------|-----------|-----------|-------|----------------|
+| Automate | Field extraction & keying | [AI-owned] | rules-based, high volume | Changed | tool + extraction skill |
+| Automate | 3-way match (clean cases) | [AI-owned] | deterministic | Changed | tool (ERP action) |
+| AI Agents & Skills | Supplier status answers | [AI-owned] | retrieval over ERP state | New | skill (retrieval) |
+| Simplify | Exception review queue | [Hybrid] | humans see only mismatches | Changed | process change |
+| Human | Above-threshold approval | [Human-led] | accountability / SOX | Changed | — |
+| Human | Auto-approval sampling (5%) | [Human-led] | governance | New | — |
+| Remove | Manual email sorting | — | intake tool replaces | Removed | — |
+
+**AI-capability backlog (top 3):** (1) Invoice extraction — *block:* tool + reusable skill —
+*risk:* OCR errors → *metric:* keying time ↓90%. (2) 3-way matching — *block:* tool (ERP action),
+no agent needed — *risk:* false clears → *metric:* error rate <1%, 5% sampling. (3) Supplier
+status answers — *block:* reusable retrieval skill (promote to a connected agent only if supplier
+comms grows into its own domain) — *risk:* stale data → *metric:* inbound "where's my payment" ↓80%.
+
+**Roadmap:** *Next 2 weeks* — pilot invoice extraction on one supplier group; stand up sampling.
+*Next 6–12 weeks* — roll matching + auto-approve with thresholds; add the status skill; embed the
+weekly validation ritual and an AI Workflow Owner.
+
+## Wrap-up (spoken close — example)
+*"Great session — you've reimagined invoice approval end to end. You now have a one-page summary,
+a current-state map, a future-state blueprint, a what-changed list, the five-bucket table, a
+prioritised capability backlog, and adoption notes. The headline shift: AI owns intake, matching,
+and supplier status; people keep only above-threshold approvals and 5% sampling; manual email
+sorting disappears — targeting cycle time from 6 days to under 3, and errors under 1%. Notably,
+most of this is tools and reusable skills, not new agents. In the next two weeks we'd pilot
+extraction on one supplier group and stand up sampling. Do you want to go further — which process
+should we remodel first: the highest-volume, the highest-pain, or the fastest to show value?"*

--- a/submissions/ai-first-process-redesign/references/output-package-spec.md
+++ b/submissions/ai-first-process-redesign/references/output-package-spec.md
@@ -1,0 +1,61 @@
+# Output Package Spec (Phase 5)
+
+Always deliver all seven parts, in this order, then close with the spoken **wrap-up (H)**.
+
+## A) 1-page summary
+Outcome · current pains · proposed AI-first process · expected benefits (tie to the Phase 2
+baseline — quantify where possible, mark estimates *[to validate]*).
+
+## B) Current-State Task Map
+Grouped stages + hotspots (from Phase 2).
+
+## C) AI-First Blueprint
+Stages, swimlanes, ownership tags — see `blueprint-templates.md`.
+
+## D) What Changed list
+Bucket every step:
+- **Eliminated** — removed entirely.
+- **Automated (AI-owned)** — AI performs end to end.
+- **Augmented (Hybrid)** — AI drafts, human decides/validates.
+- **Human-led (kept)** — unchanged, and why.
+- **New tasks / roles introduced** — what AI-first working creates.
+
+## E) Required summary table
+Categorise **every** role and activity into one of five buckets, with the columns below.
+
+| Category | Task / role | Ownership tag | Rationale | New/Changed/Removed | Building block (opt.) |
+|----------|-------------|---------------|-----------|---------------------|-----------------------|
+| **Simplify** | | [Hybrid] | streamlined / merged / clarified | Changed | process change |
+| **Automate** | | [AI-owned] | fully AI-owned, rules-based | Changed | tool / skill |
+| **AI Agents & Skills** | | [AI-owned] / [Hybrid] | delivered by a reusable skill, agent, or connected agent | New | skill / agent / connected agent |
+| **Human** | | [Human-led] | judgement / relationship / accountability | Changed | — |
+| **Remove** | | — | no longer needed | Removed | — |
+
+- **Ownership tags:** `[AI-owned]` · `[Hybrid]` · `[Human-led]`.
+- **Building block (optional):** process change · knowledge · tool · skill · agent · connected
+  agent. For a skill or agent you may add the agent type: retrieval · task-based · orchestrator ·
+  transactional. Choose per [ai-building-blocks.md](ai-building-blocks.md) — don't default to
+  "agent."
+
+## F) AI-Capability Backlog
+Top 5 AI-capability opportunities. For each: **purpose · recommended building block (skill / tool
+/ agent / connected agent) and why · inputs/outputs · data sources · risks · success metrics**.
+Order by value-vs-effort (fastest time-to-value first).
+
+> These are **candidate opportunities to hand to a separate build step — not finished agent or
+> skill designs.** Capture enough to prioritise, scope, and pick the block; do **not** specify
+> prompts, connectors, or configuration here. Building the agent or skill is a different job.
+
+## G) Adoption & embedding notes
+- **One way of working** — how the team adopts the new flow consistently.
+- **Training / enablement** — what people need to learn (incl. new roles).
+- **Governance / ownership** — who owns the workflow, validates output, and monitors metrics.
+
+## Roadmap (always include)
+Split into **Next 2 weeks** (prove-it sprint) and **Next 6–12 weeks** (scale & embed).
+
+## H) Wrap-up (spoken close)
+After the artifacts, give a short, encouraging summary: acknowledge the ambition, explain each
+part of the package and how to use it, highlight the headline shifts (what AI now owns, biggest
+expected wins vs the baseline, steps removed, new roles), and name the Next-2-weeks steps. Then
+ask the single closing question. **Never end on raw artifacts.**

--- a/submissions/ai-first-process-redesign/references/task-capture-template.md
+++ b/submissions/ai-first-process-redesign/references/task-capture-template.md
@@ -1,0 +1,36 @@
+# Task Capture Template (Phase 2 — DISCOVER)
+
+Capture the *current* work before redesigning it. Collect tasks in **batches of 5–10** so the
+user isn't overwhelmed; summarise each batch back before asking for the next.
+
+## Per-task fields
+For every task, capture:
+
+1. **Task name** — verb + object (e.g. "Validate invoice against PO").
+2. **Trigger** — what starts it (event, schedule, request, upstream handoff).
+3. **Inputs** — docs, data, signals needed to begin.
+4. **Output** — the definition of "done".
+5. **Tools / systems used today** — name them (label as assumptions if unverified).
+6. **Frequency & volume** — how often, how many.
+7. **Time / effort + pain points** — delays, errors, rework, waiting, context-switching.
+8. **Decisions / judgement involved + risk if wrong** — and whether rules-based or judgement.
+9. **Handoffs** — who receives it next.
+
+## While gathering
+- **De-duplicate** similar tasks and merge near-identical ones.
+- **Group into 4–8 stages**, e.g. `Intake → Triage → Create → Review → Approve → Deliver → Learn`.
+- **Flag hotspots** — any task that is repetitive, high-volume, error-prone, context-switching,
+  or compliance-heavy. These are the prime redesign candidates.
+
+## Capture a baseline (do not skip)
+Record measurable starting points so Phase 5 can quantify benefit and set success metrics:
+- **Cycle time** (end-to-end and per stage), **volume** (per day/week), **error / rework rate**,
+  **cost or effort** (FTE-hours), and any **SLA / compliance** targets.
+- If exact numbers aren't known, capture the user's best estimate and mark it *[to validate]*.
+
+## Task table format
+| # | Task | Stage | Trigger | Input → Output | Systems | Freq/Vol | Pain | Judgement & risk | Handoff | Hotspot? |
+|---|------|-------|---------|----------------|---------|----------|------|------------------|---------|----------|
+
+## Output of Phase 2
+A **Current-State Task Map** grouped by stage, hotspots called out, plus the baseline metrics.


### PR DESCRIPTION
Add Ai First Process Redesign skill for Microsoft Copilot Studio or Copilot Cowork.
It helps a team reimagine an existing work process as AI-first - deciding what AI owns, what is hybrid, 
and what stays human-led, then produces a redesign blueprint plus a prioritised AI-capability backlog.

The scope is deliberately bounded: it reimagines the **process** and identifies **where** AI could help
(across process changes, tools, reusable skills, agents, and connected agents). It does **not** design
or build the agents/skills themselves - that should come from a separate agent/skill.

