### PR TITLE
Add Out-of-Office Assistant skill

### DIFF
--- a/submissions/ooo-assistant/README.md
+++ b/submissions/ooo-assistant/README.md
@@ -1,0 +1,56 @@
+# Out-of-Office Assistant
+
+Going away for a day or a week? This skill stands up **temporary OOO coverage**
+across your Microsoft 365 signals: it auto-replies to direct messages and
+@mentions, flags anything urgent straight to you, watches meetings for mentions
+of your name, and drops an end-of-day digest so you can catch up in minutes when
+you're back.
+
+Every auto-reply carries a clear **AI-generated disclosure footer**, so nobody
+is ever misled into thinking you personally replied.
+
+## Before you start
+
+- **A connected Microsoft 365 account** — the skill reads chats, mentions,
+  meetings, and mail, and sends replies/notifications through the agent's
+  `m365_*`-style tools.
+- **A host that can schedule recurring tasks** (e.g. Scout automations). The
+  monitor runs on a half-hourly cadence during work hours; the digest runs once
+  a day. On hosts without scheduling, you can still run the monitor on demand.
+- Tool names vary by host — the skill describes the *capability* (list chats,
+  reply, remember, schedule, send-Teams-message). Map them to whatever your
+  environment exposes.
+
+## How to use it
+
+Invoke it when you're heading out, e.g.:
+
+- *"I'm OOO Thursday and Friday — set up coverage, back Monday."*
+- *"/ooo-assistant"*
+- *"Turn on out-of-office monitoring until the 15th."*
+
+The skill will ask for your OOO dates, return date, any custom urgency keywords,
+where to save digests, and the name to sign auto-replies with. Then it creates
+two automations:
+
+1. **OOO Monitor** (half-hourly, work hours) — auto-replies to new 1:1s and
+   @mentions, flags urgent items, and watches recent meeting transcripts for
+   mentions of you.
+2. **OOO Digest** (6:30pm) — compiles the day's messages, mentions, urgent
+   flags, and meeting notes into a saved markdown digest and a Teams summary.
+
+When you're back, say *"I'm back"* or *"/ooo-assistant off"* and it tears the
+automations down and sends a final wrap-up.
+
+## Good to know
+
+- **Auto-replies are always disclosed.** The footer makes it explicit the reply
+  was machine-generated on your behalf — this is non-negotiable in the skill.
+- **No double-replies.** Replied chat/message IDs are tracked in memory, so a
+  chat only gets one OOO reply per absence.
+- **System noise is ignored.** Bots, calendar notifications, and system messages
+  never get a reply.
+- **Digests are privacy-aware.** Customer names are anonymized and confidential
+  details are omitted; the full digest is saved to your chosen folder.
+- **Urgent means urgent.** Messages matching your urgency keywords are pushed to
+  you immediately rather than waiting for the digest.

--- a/submissions/ooo-assistant/SKILL.md
+++ b/submissions/ooo-assistant/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: ooo-assistant
+description: Activate enhanced out-of-office monitoring — auto-reply to 1:1 chats and @mentions, monitor meetings for name mentions, flag urgent items via Teams, and generate an end-of-day digest. Use this skill whenever the user says they are going out of office, asks to set up OOO coverage, or invokes "/ooo-assistant".
+---
+
+# Out-of-Office Assistant
+
+Set up enhanced OOO coverage: while the user is away, auto-reply to direct
+messages and @mentions, watch meetings for mentions of the user, flag urgent
+items, and produce a daily digest.
+
+Gather these parameters first (ask if not provided):
+
+1. **OOO date(s)** — which day(s) the user will be out.
+2. **Return date** — when they're back (used in the auto-reply text).
+3. **Urgency keywords** — optional custom keywords to flag as urgent
+   (defaults: "urgent", "ASAP", "critical", "blocker", "emergency").
+4. **Digest folder** — where to save the daily digest
+   (default: `Documents/daily-digests/`).
+5. **Signature name** — the name to sign auto-replies with (defaults to the
+   user's first name from their profile).
+
+> **Tool names.** This skill refers to Microsoft 365 tools as `m365_*`, the
+> scheduling tool as an automation-create tool, memory as a remember/recall
+> tool, and the outbound status ping as a Teams-message tool. If your host
+> exposes these under different names, map them to the equivalent capability —
+> the workflow is identical.
+
+---
+
+## Setup phase
+
+Create these **recurring monitoring automations** (leave them enabled; they are
+disabled/removed in the teardown phase when the user returns).
+
+### 1. OOO Monitor — every 30 min during work hours (8am–6pm)
+
+**Name:** `OOO Monitor — <date>`
+**Schedule:** every weekday at 8am, 8:30am, 9am, … through 6pm (half-hourly).
+
+**Prompt tasks:**
+
+1. **1:1 chat replies:**
+   - List recent chats and filter to 1:1 chats.
+   - For each, check the last message — if it's from someone else AND newer than
+     the last check, send the OOO reply (below).
+   - Track replied chat IDs in memory to avoid duplicate replies.
+
+2. **@mention replies in group chats/channels:**
+   - Scan active group chats and channels for @mentions of the user since the
+     last check.
+   - Reply to that specific thread with the same OOO message.
+   - Track replied message IDs.
+
+3. **Urgent item flagging:**
+   - Scan new emails and chat messages for the urgency keywords.
+   - If found, immediately send a Teams message to the user with context.
+
+4. **Meeting mention monitoring:**
+   - List meetings that ended in the last hour.
+   - Attempt to fetch each transcript.
+   - Search the transcript for mentions of the user's name.
+   - If mentioned, summarize the context and stage it for the digest.
+
+### 2. OOO End-of-Day Digest — 6:30 PM
+
+**Name:** `OOO Digest — <date>`
+**Schedule:** every OOO day at 6:30pm.
+
+**Prompt tasks:**
+
+1. Compile the day's activity:
+   - All 1:1 messages received (with OOO replies sent)
+   - All @mentions in groups/channels (with replies sent)
+   - Urgent items flagged
+   - Meeting summaries (especially those mentioning the user)
+   - Emails received (subjects, senders, urgency flags)
+2. Generate a markdown digest and save it to
+   `<digest folder>/<YYYY-MM-DD>-ooo-digest.md`.
+3. Send a Teams summary to the user with the key highlights.
+
+---
+
+## The OOO auto-reply
+
+```
+👋 Hi! I'm currently out of office and will be back on <return date>.
+
+If this is urgent, I'll try to respond — otherwise I'll catch up when I return.
+
+---
+This message was sent automatically by <signature name>'s AI assistant,
+monitoring on their behalf while they're away.
+```
+
+Use this same disclosure footer on **every** auto-reply so recipients always
+know the reply was machine-generated on the user's behalf. Never impersonate the
+user without the disclosure line.
+
+---
+
+## Teardown phase
+
+When the user says "I'm back", invokes "/ooo-assistant off", or the return date
+is reached:
+
+1. Disable/delete the OOO monitoring automations.
+2. Send a final summary of the OOO period.
+3. Clear the tracking memories.
+
+---
+
+## Hard rules
+
+- NEVER reply to automated/system messages, calendar notifications, or bot
+  messages.
+- NEVER reply to the same message twice (track replied IDs in memory).
+- ALWAYS include the AI-generated disclosure footer on auto-replies.
+- NEVER include sensitive content in digests — anonymize customer names and omit
+  confidential details.
+- DO send urgent alerts to the user immediately.
+- DO save every digest to the specified folder.

--- a/submissions/ooo-assistant/metadata.json
+++ b/submissions/ooo-assistant/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Out-of-Office Assistant",
+  "description": "While you're out of office, auto-replies to 1:1 chats and @mentions (clearly marked AI-generated), flags urgent items to you, watches meetings for mentions of your name, and produces an end-of-day digest.",
+  "platforms": ["Cowork", "Scout"],
+  "tags": ["out-of-office", "teams", "automation", "email", "meetings", "productivity"],
+  "author": "Srinivas Varukala",
+  "authorUrl": "https://github.com/svarukala",
+  "version": "1.0.0",
+  "createdAt": "2026-07-26",
+  "updatedAt": "2026-07-26"
+}


### PR DESCRIPTION
## Summary
Adds the **Out-of-Office Assistant** skill (`submissions/ooo-assistant/`).

While you're out of office, it auto-replies to 1:1 chats and @mentions (clearly
marked as AI-generated), flags genuinely urgent items for your attention, watches
meetings for mentions of your name, and posts an end-of-day digest of what you
missed so re-entry is painless.

- **Platforms:** Cowork, Scout
- **Tags:** out-of-office, teams, automation, email, meetings, productivity

## Submission checklist
- [x] `metadata.json` with name, description, platforms, tags, author, authorUrl
- [x] `SKILL.md` with frontmatter `name` matching the folder slug (`ooo-assistant`)
- [x] Gallery `README.md`
- [x] Genericized — no personal identity, product branding, hardcoded paths, or internal tool/codenames; tool references abstracted for portability
- [x] AI-generated replies explicitly disclosed to recipients

## Notes
Adapted from a personal Scout skill. Single submission; no changes outside
`submissions/ooo-assistant/`.