### PR TITLE
Fix rating pill tooltip to say "Rate & discuss"

### DIFF
--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -230,7 +230,7 @@ const authorProfileUrl =
           <a
             href="#rate"
             class="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-fg hover:border-accent/50 hover:text-fg transition-colors"
-            title={`Rate this ${noun}`}
+            title={`Rate & discuss this ${noun}`}
           >
             <span aria-hidden="true">👍</span>
             <span>{rating}</span>


### PR DESCRIPTION
## What

The rating pill on each skill's detail page (`src/pages/skills/[slug].astro`) links to the `#rate` section, which is titled **"Rate & discuss this {skill/plugin/automation}"**. But its hover tooltip only said **"Rate this {noun}"**, under-describing where the action goes.

This aligns the tooltip with the section it scrolls to.

## Change

- `title={`Rate this ${noun}`}` → `title={`Rate & discuss this ${noun}`}`

One-line, site-only change; no submission content touched.