### PR TITLE
rich-html-presentation: make generated decks work in embedded preview panes

### DIFF
--- a/submissions/rich-html-presentation/SKILL.md
+++ b/submissions/rich-html-presentation/SKILL.md
@@ -60,7 +60,7 @@ If missing, re-create/re-attach — never report success unverified.
 ### Step 5a — Verify it survives a preview pane
 Before saying it's ready, check the finished HTML against the constraints in Step 2a. These are cheap text checks — do them on the file you actually produced:
 
-1. **Every `<script>` under ~1700 characters.** Measure them. If one is over, split it into smaller self-contained blocks — never leave a single large engine script.
+1. **Every `<script>` under ~1700 characters.** Measure them — but **strip HTML comments first**. The template's own `<head>` comment contains the literal text `<script>` as documentation, so a naive `<script>…</script>` regex matches from inside the comment and reports one enormous block that doesn't exist. If a real block is over, split it into smaller self-contained blocks — never leave a single large engine script.
 2. **No cross-block state.** No block may read a variable or `window.*` property that a different block created.
 3. **Counter total matches the real slide count** in the markup, not `01`.
 4. **`justify-content:safe center`** is still on `.slide`, and the two `@media (max-height: …)` blocks are present.

--- a/submissions/rich-html-presentation/SKILL.md
+++ b/submissions/rich-html-presentation/SKILL.md
@@ -15,14 +15,30 @@ description: >-
 If the deck is grounded in the user's world (a meeting/transcript, documents, a project, a product), retrieve it with the right tools (`SearchM365`, `ListCalendarView` + meeting-transcript tools, `ReadFileContent`, `web_search`) before authoring. Use clearly-marked placeholders (e.g. `[Add Q3 number]`) for anything you can't find — never invent names, numbers, quotes, or dates.
 
 ### Step 2 — Start from the template
-Read `references/template.html` and `references/components.md` from this skill folder. The template is the source of truth for the design system. **Copy its `<style>` block and `<script>` block verbatim** — do not restyle or rewrite the navigation/theme engine. Only the slide content, `<title>`, and `.brand` label change.
+Read `references/template.html` and `references/components.md` from this skill folder. The template is the source of truth for the design system. **Copy its `<style>` block and all four `<script>` blocks verbatim** — do not restyle or rewrite the navigation/theme engine. Only the slide content, `<title>`, and `.brand` label change.
+
+**The engine ships as four separate small scripts on purpose. Never merge them into one, and never make one depend on a variable from another** — see "Preview-surface constraints" below.
+
+### Step 2a — Preview-surface constraints (why the engine looks the way it does)
+Decks get shared, and most recipients open them in an **embedded preview** — the Teams file-preview pane, Outlook's reading pane, a SharePoint preview — not a real browser tab. Those hosts rewrite the document before rendering, and they impose three limits that are easy to violate by accident:
+
+1. **Inline scripts over ~2000 characters are silently never executed.** (The Teams preview injects its own guard carrying `LIMIT=2000`.) Keep every `<script>` under **~1700 characters** to leave headroom.
+2. **Each inline script is wrapped, so top-level `const`/`let` does not reach a shared global scope.** A `const` declared in one block is invisible to the next.
+3. **Each inline script may get its own global object.** Even an explicit `window.myThing = {}` in one block can be `undefined` in the next. There is no reliable cross-block channel.
+
+So every block must be **self-contained**: re-read what you need from the DOM, and if one block must trigger another, dispatch a DOM event rather than calling a function. The template's swipe handler does exactly this — it dispatches an `ArrowRight`/`ArrowLeft` `keydown` instead of calling the navigation code.
+
+These failures are **silent and deceptive**: CSS still applies, so the deck looks styled and intentional while navigation is dead. That is why the template hardcodes the real slide total into the counter — a deck stuck on slide 1 reading `01 / 12` reports "navigation is broken", whereas `01 / 01` looks like a deliberate one-slide deck and gets shipped that way.
+
+These limits are **observed behavior, not documented vendor contract** — they may change. Treat them as the reason for the structure, and re-verify with the checks in Step 5 rather than assuming.
 
 ### Step 3 — Structure the deck
 - One idea per slide; pace ~1.5–2 minutes per slide (state the slide count against the target length).
 - Typical arc: title → context/why → 4–8 concept slides → any "options/comparison" slide → a numbered feature/asset run → a call-to-action step list → a timeline/closing with links.
 - Compose each slide from the catalog (`.card` grids, `.callout`, `.chips`, `.steps`, the animated `.tf` spine timeline by default (static `.timeline` only as a deliberate quiet fallback), `.bars` bar chart for any numbers/ranking/comparison, `.flow-panel`/`.loop`, `.asset-num`, `.plat` color columns). Reuse the CSS variables and `cN` accent classes so both themes stay correct — avoid hard-coded light-on-dark hex.
 - **Use the full visual portfolio.** Aim for variety — don't build a deck of near-identical card grids. Across a typical deck reach for a spread of distinct components: a spine timeline, a bar chart wherever there are figures to compare, a color-accented `.plat` slide, a `.callout` for the one line to remember, a numbered `.asset-num` run, and `.steps` for a call to action. If the content contains any quantities (sales, counts, growth, rankings), render at least one `.bars` chart rather than listing the numbers as text — the user should not have to ask for a chart. Vary the layout from slide to slide so no two consecutive slides look the same.
-- First slide keeps `class="slide title-slide active"`; every other slide is `class="slide"`. The counter total is computed automatically.
+- First slide keeps `class="slide title-slide active"`; every other slide is `class="slide"`. **Set `<span id="tot">` to the real slide count** — the nav script sets it too, but hardcoding the truth means a deck whose script was blocked reports broken navigation instead of pretending to be a one-slide deck.
+- **Keep slides short enough to fit a short viewport.** A preview pane is roughly `1200×672` — much shorter than a browser window. The template's height media queries shrink the type scale, but they can't rescue a slide with eight dense cards. Prefer 4–6 cards; if a slide needs more, split it.
 
 ### Step 4 — Detect the channel, then write the file
 First determine which delivery surface is available — the tools differ by host, so pick the matching path:
@@ -41,6 +57,16 @@ Confirm the `.html` file actually reached the user before claiming done:
 - Non-artifact hosts: confirm the file is attached to the current turn's response.
 If missing, re-create/re-attach — never report success unverified.
 
+### Step 5a — Verify it survives a preview pane
+Before saying it's ready, check the finished HTML against the constraints in Step 2a. These are cheap text checks — do them on the file you actually produced:
+
+1. **Every `<script>` under ~1700 characters.** Measure them. If one is over, split it into smaller self-contained blocks — never leave a single large engine script.
+2. **No cross-block state.** No block may read a variable or `window.*` property that a different block created.
+3. **Counter total matches the real slide count** in the markup, not `01`.
+4. **`justify-content:safe center`** is still on `.slide`, and the two `@media (max-height: …)` blocks are present.
+
+If you can render the file, also load it at **1200×672** and confirm no slide overflows (`scrollHeight > clientHeight`) and that → advances past slide 1. Report the slide count and that the preview checks passed.
+
 ## Output
 - A single self-contained `.html` file (inline CSS + JS, no external dependencies), delivered on the host's output surface — `output/` on artifact hosts, an attached file on Copilot Studio and similar.
 - Dark theme by default, follows the OS setting on load, with a working light/dark toggle.
@@ -49,7 +75,8 @@ If missing, re-create/re-attach — never report success unverified.
 
 ## Guardrails
 - **Never fabricate facts** — look up the user's real data first; use visible `[placeholders]` for gaps.
-- **Preserve the design system** — keep the template `<style>`/`<script>` intact so every deck matches; don't hand-roll a different look.
+- **Preserve the design system** — keep the template `<style>` and all four `<script>` blocks intact so every deck matches; don't hand-roll a different look.
+- **Never consolidate the engine scripts** — they are split so embedded previews (Teams, Outlook, SharePoint) will execute them, and each is self-contained because those hosts may isolate every script's global scope. Merging them, or introducing a shared global between them, silently kills navigation for anyone who opens the deck in a preview pane.
 - **Self-contained only** — inline everything; no CDN links or external image URLs (embed or omit). This keeps the deck portable and offline-safe.
 - **Verify before claiming done** — confirm the file reached the user (artifact present in `output/`, or file attached to this turn) before saying it's ready.
 - **Match the delivery to the channel** — use artifact tools on Cowork; on Copilot Studio and other attachment-only hosts, return the file on the current turn and increment the file name (`-v2`, `-v3`, …) on every edit so the user always gets the fresh version.

--- a/submissions/rich-html-presentation/metadata.json
+++ b/submissions/rich-html-presentation/metadata.json
@@ -6,7 +6,7 @@
   "author": "Henry Jammes",
   "authorUrl": "https://www.linkedin.com/in/henryjammes/",
   "authorGithub": "HenryJammes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "createdAt": "2026-07-21",
-  "updatedAt": "2026-07-21"
+  "updatedAt": "2026-08-03"
 }

--- a/submissions/rich-html-presentation/references/components.md
+++ b/submissions/rich-html-presentation/references/components.md
@@ -1,6 +1,6 @@
 # Component Catalog
 
-Every component below is already styled in `template.html`. Build slides by composing these — do not invent new CSS unless a slide genuinely needs it. Keep the `<style>` and `<script>` blocks verbatim.
+Every component below is already styled in `template.html`. Build slides by composing these — do not invent new CSS unless a slide genuinely needs it. Keep the `<style>` block and all four `<script>` blocks verbatim, and keep the scripts split (see the note at the top of `template.html`).
 
 ## Slide shell
 ```html
@@ -92,7 +92,7 @@ CSS-only horizontal bars that grow from zero on slide entry — no libraries. Us
 - `.link` — monospace pill anchor (auto arrow prefix). Group several in `.recap` for a resources footer.
 
 ## Chrome (do not remove)
-`.bg-glow` (ambient), `.progress` (top bar), `.brand` (top-left label — edit its text), `.counter` (auto), `.nav` (‹ ›), `.theme-btn` (☀/☾). The slide count is computed from the number of `.slide` elements.
+`.bg-glow` (ambient), `.progress` (top bar), `.brand` (top-left label — edit its text), `.counter`, `.nav` (‹ ›), `.theme-btn` (☀/☾). The nav script computes the slide count from the number of `.slide` elements — but also **hardcode the real total into `<span id="tot">`**, so a deck whose script was blocked by a preview surface shows broken navigation rather than looking like a one-slide deck.
 
 ## Theme
 Dark by default; follows the OS `prefers-color-scheme` on load; toggled via the top-right button or `T`. Everything reads from CSS variables (`--bg --ink --muted --line --card --grad --blue --violet --pink`), so custom colors should reuse those variables (or the `cN` accent classes) to stay theme-correct. Avoid hard-coded light-on-dark hex in inline styles.

--- a/submissions/rich-html-presentation/references/template.html
+++ b/submissions/rich-html-presentation/references/template.html
@@ -8,14 +8,25 @@
   KEYNOTE-STYLE HTML PRESENTATION TEMPLATE
   ----------------------------------------
   HOW TO USE:
-  1. Keep the <style> block and the <script> block VERBATIM — that is the design system
+  1. Keep the <style> block and ALL FOUR <script> blocks VERBATIM — that is the design system
      and the navigation/theme engine. Do not restyle from scratch.
   2. Replace ONLY the <section class="slide">…</section> blocks in the deck with your content.
      Each <section class="slide"> is one slide. The first slide must keep class="slide title-slide active".
      Every OTHER slide is just class="slide" (no "active").
   3. Update <title> and the .brand text.
-  4. The slide counter total is computed automatically from the number of .slide elements — no need to edit it.
+  4. Set <span id="tot"> to your real slide count. The nav script sets it too, but hardcoding
+     the truth means a deck whose script was blocked shows broken navigation rather than
+     looking like a deliberate one-slide deck.
   5. One idea per slide. Aim ~1.5–2 min per slide (a 25-min talk ≈ 15–20 slides).
+
+  WHY THE ENGINE IS SPLIT INTO FOUR SCRIPTS — do not merge them:
+  Embedded preview surfaces (Teams / Outlook / SharePoint file preview) rewrite the page
+  before rendering. They (a) silently skip any inline script over ~2000 chars, and (b) give
+  each script its own global object, so neither top-level const/let nor window.foo crosses
+  a block boundary. Each block is therefore under ~1500 chars and fully self-contained;
+  the swipe block signals the nav block with a synthetic key event rather than a call.
+  Merging them, or adding a shared global, kills navigation for anyone using a preview —
+  and does it silently, because the CSS still renders perfectly.
   Controls: ← / → (or PageUp/Down, Space) navigate · Home/End jump · F fullscreen · T theme.
   Theme: dark by default, follows the OS setting on load, toggle top-right.
   See components.md for the full component catalog.
@@ -66,7 +77,7 @@
   @keyframes drift2{50%{transform:translate(-5vw,-4vh) scale(1.12)}}
 
   .deck{position:relative;z-index:1;height:100vh;width:100vw}
-  .slide{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;padding:7vh 8vw;
+  .slide{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:safe center;padding:7vh 8vw;
     opacity:0;visibility:hidden;transform:translateY(22px) scale(.995);
     transition:opacity .55s ease,transform .55s ease,visibility .55s;overflow:auto}
   .slide.active{opacity:1;visibility:visible;transform:none}
@@ -239,6 +250,35 @@
     .tf-row{grid-template-columns:1fr}
     .bar-row{grid-template-columns:120px 1fr}
   }
+  /* ===== short-viewport fit =====
+     The type scale above is width-based (h1 6vw, h2 4.4vw), so a wide but
+     SHORT viewport - an embedded Teams/Outlook preview pane, a small laptop,
+     a projector at 4:3 - renders huge text with no vertical room. These
+     queries step the scale down by height. Keep them. */
+  @media (max-height:860px){
+    .slide{padding:4.5vh 7vw}
+    h1{font-size:clamp(2rem,4.2vw,3.4rem)}
+    h2{font-size:clamp(1.5rem,3.1vw,2.35rem);margin-bottom:1rem}
+    .eyebrow{font-size:.72rem;margin-bottom:.85rem}
+    .lead{font-size:clamp(.95rem,1.35vw,1.14rem)}
+    .grid,.timeline,.bars,.tf,.steps{margin-top:1.15rem;gap:.85rem}
+    .card{padding:1rem 1.1rem;border-radius:13px}
+    .card h3{font-size:1rem}
+    .card p{font-size:.87rem;line-height:1.4}
+    .callout{padding:1rem 1.2rem}
+  }
+  @media (max-height:700px){
+    .slide{padding:3.2vh 6vw}
+    h1{font-size:clamp(1.7rem,3.4vw,2.6rem)}
+    h2{font-size:clamp(1.25rem,2.5vw,1.85rem);margin-bottom:.75rem}
+    .eyebrow{margin-bottom:.6rem}
+    .lead{font-size:.95rem;line-height:1.42}
+    .grid,.timeline,.bars,.tf,.steps{margin-top:.85rem;gap:.7rem}
+    .card{padding:.8rem .9rem;border-radius:11px}
+    .card h3{font-size:.94rem}
+    .card p{font-size:.82rem;line-height:1.35}
+  }
+  /* ===== end short-viewport fit ===== */
 </style>
 </head>
 <body>
@@ -386,77 +426,120 @@
 </div>
 
 <button class="theme-btn" id="theme" aria-label="Toggle theme" title="Toggle light/dark (T)">☀</button>
-<div class="counter"><b id="cur">01</b> / <span id="tot">01</span></div>
+<!-- Set the total below to the REAL slide count. The nav script also
+     sets it, but hardcoding the truth means a deck whose script was
+     blocked shows "01 / 08" (obviously broken navigation) instead of
+     "01 / 01" (which looks like a deliberate one-slide deck). -->
+<div class="counter"><b id="cur">01</b> / <span id="tot">08</span></div>
 <div class="nav">
   <button id="prev" aria-label="Previous slide">‹</button>
   <button id="next" aria-label="Next slide">›</button>
 </div>
 
+<!--
+  NAVIGATION / THEME ENGINE - keep VERBATIM, and keep it SPLIT.
+
+  These four blocks are deliberately separate and deliberately self-contained.
+  Embedded preview surfaces (Teams / Outlook file preview) skip any inline
+  script over ~2000 characters AND give each script its own global object, so
+  a single large block never runs and shared state never crosses a boundary.
+  Each block re-reads what it needs from the DOM; the swipe block talks to the
+  nav block by dispatching a key event, not by calling a function.
+
+  If you extend this engine: add another SMALL, self-contained block. Do not
+  merge these back together, and do not introduce a shared global.
+-->
 <script>
-  const slides = Array.from(document.querySelectorAll('.slide'));
-  const total = slides.length;
-  let i = 0;
-  const prog = document.getElementById('progress');
-  const cur = document.getElementById('cur');
-  const tot = document.getElementById('tot');
-  const prevBtn = document.getElementById('prev');
-  const nextBtn = document.getElementById('next');
-  const pad = n => String(n).padStart(2,'0');
-  tot.textContent = pad(total);
-
-  const root = document.documentElement;
-  const themeBtn = document.getElementById('theme');
-  const mql = window.matchMedia ? window.matchMedia('(prefers-color-scheme: light)') : null;
-  let userSet = false;
-  function applyTheme(t){
+(function(){
+  var root = document.documentElement, btn = document.getElementById('theme');
+  var mql = window.matchMedia ? window.matchMedia('(prefers-color-scheme: light)') : null;
+  var userSet = false;
+  function apply(t){
     root.setAttribute('data-theme', t);
-    themeBtn.textContent = t==='dark' ? '☀' : '☾';
-    themeBtn.setAttribute('aria-label', t==='dark' ? 'Switch to light theme' : 'Switch to dark theme');
+    btn.textContent = t === 'dark' ? '\u2600' : '\u263e';
+    btn.setAttribute('aria-label',
+      t === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
   }
-  applyTheme(mql && mql.matches ? 'light' : 'dark');
-  themeBtn.addEventListener('click', ()=>{ userSet=true; applyTheme(root.getAttribute('data-theme')==='dark'?'light':'dark'); });
-  if(mql && mql.addEventListener){ mql.addEventListener('change', e=>{ if(!userSet) applyTheme(e.matches?'light':'dark'); }); }
-
+  function toggle(){
+    userSet = true;
+    apply(root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  }
+  apply(mql && mql.matches ? 'light' : 'dark');
+  btn.addEventListener('click', toggle);
+  if (mql && mql.addEventListener) {
+    mql.addEventListener('change', function(e){
+      if (!userSet) apply(e.matches ? 'light' : 'dark');
+    });
+  }
+  document.addEventListener('keydown', function(e){
+    if (e.key === 't' || e.key === 'T') toggle();
+  });
+})();
+</script>
+<script>
+(function(){
+  var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+  var total = slides.length, i = 0;
+  var prog = document.getElementById('progress');
+  var cur = document.getElementById('cur'), tot = document.getElementById('tot');
+  var pb = document.getElementById('prev'), nb = document.getElementById('next');
+  function pad(n){ return ('0' + n).slice(-2); }
+  tot.textContent = pad(total);
   function show(n, push){
-    i = Math.max(0, Math.min(total-1, n));
-    slides.forEach((s,idx)=>s.classList.toggle('active', idx===i));
-    prog.style.width = ((i+1)/total*100) + '%';
-    cur.textContent = pad(i+1);
-    prevBtn.disabled = i===0;
-    nextBtn.disabled = i===total-1;
-    if(push!==false){ try{ history.replaceState(null,'','#'+(i+1)); }catch(e){} }
+    i = Math.max(0, Math.min(total - 1, n));
+    for (var k = 0; k < total; k++) slides[k].classList.toggle('active', k === i);
+    prog.style.width = ((i + 1) / total * 100) + '%';
+    cur.textContent = pad(i + 1);
+    pb.disabled = i === 0;
+    nb.disabled = i === total - 1;
+    if (push !== false) {
+      try { history.replaceState(null, '', '#' + (i + 1)); } catch (e) {}
+    }
   }
-  const next = ()=>show(i+1);
-  const prev = ()=>show(i-1);
-
-  document.addEventListener('keydown', e=>{
-    switch(e.key){
+  nb.addEventListener('click', function(){ show(i + 1); });
+  pb.addEventListener('click', function(){ show(i - 1); });
+  document.addEventListener('keydown', function(e){
+    switch (e.key) {
       case 'ArrowRight': case 'PageDown': case ' ': case 'Spacebar':
-        e.preventDefault(); next(); break;
+        e.preventDefault(); show(i + 1); break;
       case 'ArrowLeft': case 'PageUp':
-        e.preventDefault(); prev(); break;
+        e.preventDefault(); show(i - 1); break;
       case 'Home': e.preventDefault(); show(0); break;
-      case 'End': e.preventDefault(); show(total-1); break;
-      case 'f': case 'F':
-        if(!document.fullscreenElement){ document.documentElement.requestFullscreen && document.documentElement.requestFullscreen(); }
-        else { document.exitFullscreen && document.exitFullscreen(); }
-        break;
-      case 't': case 'T':
-        userSet=true; applyTheme(root.getAttribute('data-theme')==='dark'?'light':'dark'); break;
+      case 'End': e.preventDefault(); show(total - 1); break;
     }
   });
-  nextBtn.addEventListener('click', next);
-  prevBtn.addEventListener('click', prev);
-
-  let tx=0;
-  addEventListener('touchstart', e=>{ tx = e.changedTouches[0].clientX; }, {passive:true});
-  addEventListener('touchend', e=>{
-    const dx = e.changedTouches[0].clientX - tx;
-    if(Math.abs(dx) > 50){ dx < 0 ? next() : prev(); }
+  var s = parseInt((location.hash || '').replace('#', ''), 10);
+  show(isFinite(s) && s >= 1 ? s - 1 : 0, false);
+})();
+</script>
+<script>
+(function(){
+  document.addEventListener('keydown', function(e){
+    if (e.key !== 'f' && e.key !== 'F') return;
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen &&
+        document.documentElement.requestFullscreen();
+    } else {
+      document.exitFullscreen && document.exitFullscreen();
+    }
+  });
+})();
+</script>
+<script>
+(function(){
+  var tx = 0;
+  window.addEventListener('touchstart', function(e){
+    tx = e.changedTouches[0].clientX;
   }, {passive:true});
-
-  const start = parseInt((location.hash||'').replace('#',''),10);
-  show(Number.isFinite(start) && start>=1 ? start-1 : 0, false);
+  window.addEventListener('touchend', function(e){
+    var dx = e.changedTouches[0].clientX - tx;
+    if (Math.abs(dx) > 50) {
+      document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: dx < 0 ? 'ArrowRight' : 'ArrowLeft', bubbles: true
+      }));
+    }
+  }, {passive:true});
+})();
 </script>
 </body>
 </html>

--- a/submissions/rich-html-presentation/references/template.html
+++ b/submissions/rich-html-presentation/references/template.html
@@ -77,7 +77,7 @@
   @keyframes drift2{50%{transform:translate(-5vw,-4vh) scale(1.12)}}
 
   .deck{position:relative;z-index:1;height:100vh;width:100vw}
-  .slide{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:safe center;padding:7vh 8vw;
+  .slide{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;justify-content:safe center;padding:7vh 8vw;
     opacity:0;visibility:hidden;transform:translateY(22px) scale(.995);
     transition:opacity .55s ease,transform .55s ease,visibility .55s;overflow:auto}
   .slide.active{opacity:1;visibility:visible;transform:none}
@@ -483,7 +483,7 @@
   var prog = document.getElementById('progress');
   var cur = document.getElementById('cur'), tot = document.getElementById('tot');
   var pb = document.getElementById('prev'), nb = document.getElementById('next');
-  function pad(n){ return ('0' + n).slice(-2); }
+  function pad(n){ return n < 10 ? '0' + n : '' + n; }
   tot.textContent = pad(total);
   function show(n, push){
     i = Math.max(0, Math.min(total - 1, n));


### PR DESCRIPTION
## Problem

Decks generated by `rich-html-presentation` render correctly but are **unnavigable** in the Microsoft Teams, Outlook, and SharePoint file-preview panes — which is where most recipients open a deck that was shared with them.

The failure is silent and looks deliberate. CSS still applies, so the deck appears fully styled and intentional while stuck on slide 1 showing `01 / 01`. Nobody files a bug; they just assume the deck is one slide long.

This affects **every deck the skill produces**, not just large ones — the template's engine script was already over the limit before any content was added.

## Root causes

Found by instrumenting a generated deck with an error trap and a script-tag dump, then reading the result in the Teams preview pane.

1. **Inline scripts over ~2000 characters are never executed.** The preview host injects its own guard carrying `LIMIT=2000`. The template shipped a single ~2900-char engine, so navigation was dead on arrival.

2. **Each inline script is wrapped *and* given its own global object.** Splitting alone does not fix it: neither top-level `const`/`let` nor an explicit `window.foo = {}` survives into the next block. An intermediate attempt that split the engine into three blocks sharing a `window.__deck` namespace still failed, with `Cannot set properties of undefined (setting 'show')`.

3. **The counter was hardcoded `01 / 01`** in markup and only corrected by script — converting a visible failure into an invisible one.

4. **The type scale is width-based** (`h1` is `6vw`, `h2` is `4.4vw`), so a wide-but-short preview pane produced oversized text that overflowed; with `justify-content:center` the overflow was unreachable at both ends rather than merely scrolled.

## Changes

**`references/template.html`**
- Split the engine into **four self-contained blocks** — theme / nav / fullscreen / touch — at 913, 1485, 350 and 437 chars. They share **no JavaScript state**; each re-reads what it needs from the DOM. The swipe block signals the nav block by dispatching a `keydown` rather than calling a function.
- Hardcode the real slide total in the counter markup, so a deck whose script was blocked reports *broken navigation* instead of masquerading as a short deck.
- Add `@media (max-height: 860px)` and `(max-height: 700px)` steps for type, padding and card density; switch `.slide` to `justify-content: safe center`.
- Expand the in-file header comment to explain why the scripts are split, so a future edit doesn't helpfully merge them back.

**`SKILL.md`**
- New **Step 2a — Preview-surface constraints**, stating the three limits and why the engine is shaped this way.
- New **Step 5a — Verify it survives a preview pane**: check script sizes, absence of cross-block state, counter honesty, and the CSS guards; render at `1200x672` if possible.
- Guardrail against re-merging the engine scripts or introducing a shared global.
- Slide-authoring guidance to keep slides short enough for a preview-pane viewport.

**`references/components.md`** — updated the two stale references to "the `<script>` block" and the "auto" counter.

**`metadata.json`** — version 1.0.0 → 1.1.0, `updatedAt` refreshed.

## Verification

The updated template, checked directly:

| Check | Result |
|---|---|
| Script blocks | 913 / 1485 / 350 / 437 — max **1485**, all under budget |
| Renders + navigates at 1920x1080 | pass |
| Renders + navigates at 1200x672 | pass |
| Slides overflowing at 1200x672 | **0 of 8** |
| Nav, theme, deep-link under a simulation giving every script an **isolated global** | pass |

**Blind end-to-end test.** A sub-agent was given only the updated skill folder at a neutral path plus a content brief — no knowledge of this problem, no mention of previews, script size, or scope isolation. It produced a 12-slide deck that independently verified as:

- script blocks 913 / 1485 / 350 / 437, max 1485
- **zero** `window.*` assignments in any block
- `<span id="tot">12</span>` matching its 12 slides
- `safe center` and both height queries present
- no external dependencies
- **0 of 12** slides overflowing at 1200x672
- navigation and theme working under the isolated-globals simulation

It also followed Step 5a unprompted, which was the real test of whether the instructions carry without context.

That blind run surfaced one genuine documentation defect, fixed in the second commit: the template's `<head>` comment contains the literal text `<script>`, so a naive size-check regex matches from inside the comment and reports one enormous phantom block. Step 5a now says to strip HTML comments before measuring.

## Notes for reviewers

- The **~2000-char limit is observed behavior, not a documented vendor contract.** `SKILL.md` records it as such, along with how to re-verify it, rather than asserting it as fact.
- Existing decks are unaffected — this changes the template, not anything already generated.
- No visual change at normal presentation sizes; the height queries only engage below 860px tall.
- Speaker-notes support is deliberately **not** included here. It doesn't exist upstream today, and adding a feature alongside a bug fix would widen the review. Happy to follow up separately.
