### PR TITLE
rich-html-presentation: add optional speaker-notes tray

### DIFF
--- a/submissions/rich-html-presentation/SKILL.md
+++ b/submissions/rich-html-presentation/SKILL.md
@@ -15,9 +15,9 @@ description: >-
 If the deck is grounded in the user's world (a meeting/transcript, documents, a project, a product), retrieve it with the right tools (`SearchM365`, `ListCalendarView` + meeting-transcript tools, `ReadFileContent`, `web_search`) before authoring. Use clearly-marked placeholders (e.g. `[Add Q3 number]`) for anything you can't find — never invent names, numbers, quotes, or dates.
 
 ### Step 2 — Start from the template
-Read `references/template.html` and `references/components.md` from this skill folder. The template is the source of truth for the design system. **Copy its `<style>` block and all four `<script>` blocks verbatim** — do not restyle or rewrite the navigation/theme engine. Only the slide content, `<title>`, and `.brand` label change.
+Read `references/template.html` and `references/components.md` from this skill folder. The template is the source of truth for the design system. **Copy its `<style>` block and all five `<script>` blocks verbatim** — do not restyle or rewrite the navigation/theme engine. Only the slide content, `<title>`, and `.brand` label change.
 
-**The engine ships as four separate small scripts on purpose. Never merge them into one, and never make one depend on a variable from another** — see "Preview-surface constraints" below.
+**The engine ships as five separate small scripts on purpose. Never merge them into one, and never make one depend on a variable from another** — see "Preview-surface constraints" below. (The fifth is the optional speaker-notes tray; delete it wholesale if the deck has no notes.)
 
 ### Step 2a — Preview-surface constraints (why the engine looks the way it does)
 Decks get shared, and most recipients open them in an **embedded preview** — the Teams file-preview pane, Outlook's reading pane, a SharePoint preview — not a real browser tab. Those hosts rewrite the document before rendering, and they impose three limits that are easy to violate by accident:
@@ -39,6 +39,14 @@ These limits are **observed behavior, not documented vendor contract** — they 
 - **Use the full visual portfolio.** Aim for variety — don't build a deck of near-identical card grids. Across a typical deck reach for a spread of distinct components: a spine timeline, a bar chart wherever there are figures to compare, a color-accented `.plat` slide, a `.callout` for the one line to remember, a numbered `.asset-num` run, and `.steps` for a call to action. If the content contains any quantities (sales, counts, growth, rankings), render at least one `.bars` chart rather than listing the numbers as text — the user should not have to ask for a chart. Vary the layout from slide to slide so no two consecutive slides look the same.
 - First slide keeps `class="slide title-slide active"`; every other slide is `class="slide"`. **Set `<span id="tot">` to the real slide count** — the nav script sets it too, but hardcoding the truth means a deck whose script was blocked reports broken navigation instead of pretending to be a one-slide deck.
 - **Keep slides short enough to fit a short viewport.** A preview pane is roughly `1200×672` — much shorter than a browser window. The template's height media queries shrink the type scale, but they can't rescue a slide with eight dense cards. Prefer 4–6 cards; if a slide needs more, split it.
+
+### Step 3a — Speaker notes (optional)
+The template ships a collapsible notes tray. Author a slide's notes as a `<div class="spk">…</div>` **inside** its `<section class="slide">`; they never render on the slide itself, and the tray shows the note for whichever slide is active.
+
+- **N** toggles the tray, **Esc** collapses it, and a **Hide** link on the collapsed bar removes it from the screen entirely for presenting (**N** brings it back).
+- Add notes when the user asks for them, or when the deck will be presented by someone who wasn't in the room. Write what the presenter should *say* and watch for — not a re-reading of the slide.
+- **If a deck carries no notes, delete the tray** — its markup, its CSS block, and its script block. An empty tray is worse than no tray.
+- **Notes are not private.** They ship inside the same file and are one "view source" away. Never put anything in them you wouldn't hand to the recipient. For a deck going outside your organization, strip the `.spk` blocks from the file rather than relying on the tray being collapsed.
 
 ### Step 4 — Detect the channel, then write the file
 First determine which delivery surface is available — the tools differ by host, so pick the matching path:
@@ -71,11 +79,12 @@ If you can render the file, also load it at **1200×672** and confirm no slide o
 - A single self-contained `.html` file (inline CSS + JS, no external dependencies), delivered on the host's output surface — `output/` on artifact hosts, an attached file on Copilot Studio and similar.
 - Dark theme by default, follows the OS setting on load, with a working light/dark toggle.
 - Navigation: ← / → (also PageUp/Down, Space), Home/End, on-screen ‹ ›, F fullscreen, T theme, touch swipe.
+- Optional speaker-notes tray: N toggles, Esc collapses, and a Hide link removes the bar for presenting.
 - Tell the user the filename, the slide count, and the controls.
 
 ## Guardrails
 - **Never fabricate facts** — look up the user's real data first; use visible `[placeholders]` for gaps.
-- **Preserve the design system** — keep the template `<style>` and all four `<script>` blocks intact so every deck matches; don't hand-roll a different look.
+- **Preserve the design system** — keep the template `<style>` and all five `<script>` blocks intact so every deck matches; don't hand-roll a different look.
 - **Never consolidate the engine scripts** — they are split so embedded previews (Teams, Outlook, SharePoint) will execute them, and each is self-contained because those hosts may isolate every script's global scope. Merging them, or introducing a shared global between them, silently kills navigation for anyone who opens the deck in a preview pane.
 - **Self-contained only** — inline everything; no CDN links or external image URLs (embed or omit). This keeps the deck portable and offline-safe.
 - **Verify before claiming done** — confirm the file reached the user (artifact present in `output/`, or file attached to this turn) before saying it's ready.

--- a/submissions/rich-html-presentation/SKILL.md
+++ b/submissions/rich-html-presentation/SKILL.md
@@ -38,7 +38,7 @@ These limits are **observed behavior, not documented vendor contract** — they 
 - Compose each slide from the catalog (`.card` grids, `.callout`, `.chips`, `.steps`, the animated `.tf` spine timeline by default (static `.timeline` only as a deliberate quiet fallback), `.bars` bar chart for any numbers/ranking/comparison, `.flow-panel`/`.loop`, `.asset-num`, `.plat` color columns). Reuse the CSS variables and `cN` accent classes so both themes stay correct — avoid hard-coded light-on-dark hex.
 - **Use the full visual portfolio.** Aim for variety — don't build a deck of near-identical card grids. Across a typical deck reach for a spread of distinct components: a spine timeline, a bar chart wherever there are figures to compare, a color-accented `.plat` slide, a `.callout` for the one line to remember, a numbered `.asset-num` run, and `.steps` for a call to action. If the content contains any quantities (sales, counts, growth, rankings), render at least one `.bars` chart rather than listing the numbers as text — the user should not have to ask for a chart. Vary the layout from slide to slide so no two consecutive slides look the same.
 - First slide keeps `class="slide title-slide active"`; every other slide is `class="slide"`. **Set `<span id="tot">` to the real slide count** — the nav script sets it too, but hardcoding the truth means a deck whose script was blocked reports broken navigation instead of pretending to be a one-slide deck.
-- **Keep slides short enough to fit a short viewport.** A preview pane is roughly `1200×672` — much shorter than a browser window. The template's height media queries shrink the type scale, but they can't rescue a slide with eight dense cards. Prefer 4–6 cards; if a slide needs more, split it.
+- **Keep slides short enough to fit a short viewport.** A preview pane is roughly `1200×672` — much shorter than a browser window, and shorter still when the notes tray reserves space. The template's height media queries shrink the type scale, but they can't rescue a slide with eight dense cards. Prefer 4–6 cards; if a slide needs more, split it. A slide that fills the full height will collide with the fixed brand label at the top or the counter and nav at the bottom.
 
 ### Step 3a — Speaker notes (optional)
 The template ships a collapsible notes tray. Author a slide's notes as a `<div class="spk">…</div>` **inside** its `<section class="slide">`; they never render on the slide itself, and the tray shows the note for whichever slide is active.
@@ -66,14 +66,21 @@ Confirm the `.html` file actually reached the user before claiming done:
 If missing, re-create/re-attach — never report success unverified.
 
 ### Step 5a — Verify it survives a preview pane
-Before saying it's ready, check the finished HTML against the constraints in Step 2a. These are cheap text checks — do them on the file you actually produced:
+Before saying it's ready, check the finished HTML against the constraints in Step 2a. These are cheap text checks — do them on the file you actually produced.
 
-1. **Every `<script>` under ~1700 characters.** Measure them on the file as written — but **strip HTML *and* CSS comments first**. Both the `<head>` comment and a comment inside `<style>` contain the literal text `<script>` and `<section class="slide">` as documentation, so a naive regex matches from inside a comment and reports phantom blocks (or a wildly wrong slide count). Note that CRLF line endings add ~1 byte per line, so a block measured at 1500 with LF can read ~1560 with CRLF — measure the actual output file. If a real block is over, split it into smaller self-contained blocks — never leave a single large engine script.
+> **Strip HTML *and* CSS comments before counting anything.** The `<head>` comment and a comment inside `<style>` both quote the literal strings `<script>`, `<section class="slide">` and `<div class="spk">` as documentation. A regex that only strips `<!-- … -->` will report a phantom script block, an inflated slide count, or a phantom speaker note. This has produced a wrong answer on every one of those three counts — strip `/* … */` too, every time.
+
+1. **Every `<script>` under ~1700 characters**, measured on the file as written. CRLF line endings add ~1 byte per line, so a block that measures 1500 with LF reads ~1560 with CRLF. If a real block is over, split it into smaller self-contained blocks — never leave a single large engine script.
 2. **No cross-block state.** No block may read a variable or `window.*` property that a different block created.
-3. **Counter total matches the real slide count** in the markup, not `01`. Count `<section class="slide">` elements *after* stripping comments — the documentation comments contain that literal string too.
+3. **Counter total matches the real slide count** in the markup, not `01`.
 4. **`justify-content:safe center`** is still on `.slide` (with the plain `center` fallback declared before it), and the two `@media (max-height: …)` blocks are present.
 
-If you can render the file, also load it at **1200×672** and confirm no slide overflows (`scrollHeight > clientHeight`) and that → advances past slide 1. Report the slide count and that the preview checks passed.
+If you can render the file, load it at **1200×672** and check two different things:
+
+- **Overflow** — no slide has `scrollHeight > clientHeight`.
+- **Chrome collision** — the fixed `.brand` (top-left), `.counter` (bottom-left) and `.nav` (bottom-right) float *above* the slide, so a slide can pass the overflow check and still have its first or last line sitting underneath them. Compare the bounding box of the slide's first and last visible content against those three. Measure the text, not the block: `.content` children are full-width, so a naive box-intersection test reports a collision on almost every slide.
+
+Report the slide count and that the preview checks passed.
 
 ## Output
 - A single self-contained `.html` file (inline CSS + JS, no external dependencies), delivered on the host's output surface — `output/` on artifact hosts, an attached file on Copilot Studio and similar.

--- a/submissions/rich-html-presentation/SKILL.md
+++ b/submissions/rich-html-presentation/SKILL.md
@@ -68,10 +68,10 @@ If missing, re-create/re-attach — never report success unverified.
 ### Step 5a — Verify it survives a preview pane
 Before saying it's ready, check the finished HTML against the constraints in Step 2a. These are cheap text checks — do them on the file you actually produced:
 
-1. **Every `<script>` under ~1700 characters.** Measure them — but **strip HTML comments first**. The template's own `<head>` comment contains the literal text `<script>` as documentation, so a naive `<script>…</script>` regex matches from inside the comment and reports one enormous block that doesn't exist. If a real block is over, split it into smaller self-contained blocks — never leave a single large engine script.
+1. **Every `<script>` under ~1700 characters.** Measure them on the file as written — but **strip HTML *and* CSS comments first**. Both the `<head>` comment and a comment inside `<style>` contain the literal text `<script>` and `<section class="slide">` as documentation, so a naive regex matches from inside a comment and reports phantom blocks (or a wildly wrong slide count). Note that CRLF line endings add ~1 byte per line, so a block measured at 1500 with LF can read ~1560 with CRLF — measure the actual output file. If a real block is over, split it into smaller self-contained blocks — never leave a single large engine script.
 2. **No cross-block state.** No block may read a variable or `window.*` property that a different block created.
-3. **Counter total matches the real slide count** in the markup, not `01`.
-4. **`justify-content:safe center`** is still on `.slide`, and the two `@media (max-height: …)` blocks are present.
+3. **Counter total matches the real slide count** in the markup, not `01`. Count `<section class="slide">` elements *after* stripping comments — the documentation comments contain that literal string too.
+4. **`justify-content:safe center`** is still on `.slide` (with the plain `center` fallback declared before it), and the two `@media (max-height: …)` blocks are present.
 
 If you can render the file, also load it at **1200×672** and confirm no slide overflows (`scrollHeight > clientHeight`) and that → advances past slide 1. Report the slide count and that the preview checks passed.
 

--- a/submissions/rich-html-presentation/metadata.json
+++ b/submissions/rich-html-presentation/metadata.json
@@ -6,7 +6,7 @@
   "author": "Henry Jammes",
   "authorUrl": "https://www.linkedin.com/in/henryjammes/",
   "authorGithub": "HenryJammes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "createdAt": "2026-07-21",
   "updatedAt": "2026-08-03"
 }

--- a/submissions/rich-html-presentation/references/components.md
+++ b/submissions/rich-html-presentation/references/components.md
@@ -1,6 +1,6 @@
 # Component Catalog
 
-Every component below is already styled in `template.html`. Build slides by composing these — do not invent new CSS unless a slide genuinely needs it. Keep the `<style>` block and all four `<script>` blocks verbatim, and keep the scripts split (see the note at the top of `template.html`).
+Every component below is already styled in `template.html`. Build slides by composing these — do not invent new CSS unless a slide genuinely needs it. Keep the `<style>` block and all five `<script>` blocks verbatim, and keep the scripts split (see the note at the top of `template.html`).
 
 ## Slide shell
 ```html
@@ -93,6 +93,21 @@ CSS-only horizontal bars that grow from zero on slide entry — no libraries. Us
 
 ## Chrome (do not remove)
 `.bg-glow` (ambient), `.progress` (top bar), `.brand` (top-left label — edit its text), `.counter`, `.nav` (‹ ›), `.theme-btn` (☀/☾). The nav script computes the slide count from the number of `.slide` elements — but also **hardcode the real total into `<span id="tot">`**, so a deck whose script was blocked by a preview surface shows broken navigation rather than looking like a one-slide deck.
+
+## Speaker notes (optional)
+
+```html
+<section class="slide">
+  <div class="content"> … slide content … </div>
+  <div class="spk">
+    <p><b>What to say here.</b> Notes never render on the slide.</p>
+  </div>
+</section>
+```
+
+`.spk` blocks are pulled into the `.tray` at the bottom of the screen for whichever slide is active. **N** toggles, **Esc** collapses, and the **Hide** link on the collapsed bar clears it off screen for presenting (**N** restores it).
+
+Delete the `.tray` markup, its CSS block and its script block for a deck with no notes. Notes travel inside the file and are readable in source — strip them before sharing a deck whose notes aren't for the recipient.
 
 ## Theme
 Dark by default; follows the OS `prefers-color-scheme` on load; toggled via the top-right button or `T`. Everything reads from CSS variables (`--bg --ink --muted --line --card --grad --blue --violet --pink`), so custom colors should reuse those variables (or the `cN` accent classes) to stay theme-correct. Avoid hard-coded light-on-dark hex in inline styles.

--- a/submissions/rich-html-presentation/references/template.html
+++ b/submissions/rich-html-presentation/references/template.html
@@ -296,7 +296,7 @@
   .tray{position:fixed;left:0;right:0;bottom:0;z-index:30;background:var(--bg);
     border-top:1px solid var(--line-hi);box-shadow:0 -18px 44px rgba(0,0,0,.34);
     transform:translateY(calc(100% - 42px));transition:transform .34s cubic-bezier(.22,1,.36,1);
-    max-height:46vh;display:flex;flex-direction:column}
+    height:34vh;display:flex;flex-direction:column}
   .tray.open{transform:translateY(0)}
   .tray.gone{transform:translateY(100%)}
   .tray-bar{height:42px;flex:0 0 42px;display:flex;align-items:center;gap:.7rem;padding:0 1.2rem;
@@ -310,18 +310,20 @@
     text-decoration:underline;text-underline-offset:3px;cursor:pointer;padding:.2rem .1rem}
   .tray-bar .hide:hover{color:var(--ink)}
   .tray.open .tray-bar .hide{display:none}
-  .tray-body{overflow-y:auto;padding:.2rem 1.4rem 1.4rem;border-top:1px solid var(--line)}
+  .tray-body{flex:1 1 auto;overflow-y:auto;padding:.2rem 1.4rem 1.4rem;border-top:1px solid var(--line)}
   .tray-body p{color:var(--muted);font-size:.92rem;line-height:1.55;margin-bottom:.6rem;max-width:82ch}
   .tray-body b{color:var(--ink)}
   .tray-body i{color:var(--ink);font-style:italic}
   .tray-body .none{color:var(--faint);font-style:italic}
-  /* lift the counter/nav clear of the collapsed bar, and drop them back
-     when the bar is hidden */
-  .counter{bottom:3.7rem}
-  .nav{bottom:3.5rem}
-  body.tray-open .counter,body.tray-open .nav{display:none}
-  body.tray-gone .counter{bottom:1.5rem}
-  body.tray-gone .nav{bottom:1.5rem}
+  /* The tray reserves vertical space rather than covering the deck, so the
+     counter and nav stay visible in every state. --tray-h is the single
+     source of truth for how much room the tray occupies. */
+  :root{--tray-h:42px}
+  body.tray-open{--tray-h:34vh}
+  body.tray-gone{--tray-h:0px}
+  .deck{height:calc(100vh - var(--tray-h))}
+  .counter{bottom:calc(var(--tray-h) + 1.2rem)}
+  .nav{bottom:calc(var(--tray-h) + 1rem)}
   @media print{.tray{display:none}}
   /* ===== end speaker notes tray ===== */
 </style>

--- a/submissions/rich-html-presentation/references/template.html
+++ b/submissions/rich-html-presentation/references/template.html
@@ -8,7 +8,7 @@
   KEYNOTE-STYLE HTML PRESENTATION TEMPLATE
   ----------------------------------------
   HOW TO USE:
-  1. Keep the <style> block and ALL FOUR <script> blocks VERBATIM — that is the design system
+  1. Keep the <style> block and ALL FIVE <script> blocks VERBATIM — that is the design system
      and the navigation/theme engine. Do not restyle from scratch.
   2. Replace ONLY the <section class="slide">…</section> blocks in the deck with your content.
      Each <section class="slide"> is one slide. The first slide must keep class="slide title-slide active".
@@ -19,14 +19,22 @@
      looking like a deliberate one-slide deck.
   5. One idea per slide. Aim ~1.5–2 min per slide (a 25-min talk ≈ 15–20 slides).
 
-  WHY THE ENGINE IS SPLIT INTO FOUR SCRIPTS — do not merge them:
+  WHY THE ENGINE IS SPLIT INTO FIVE SCRIPTS — do not merge them:
   Embedded preview surfaces (Teams / Outlook / SharePoint file preview) rewrite the page
   before rendering. They (a) silently skip any inline script over ~2000 chars, and (b) give
   each script its own global object, so neither top-level const/let nor window.foo crosses
-  a block boundary. Each block is therefore under ~1500 chars and fully self-contained;
+  a block boundary. Each block is therefore under ~1600 chars and fully self-contained;
   the swipe block signals the nav block with a synthetic key event rather than a call.
   Merging them, or adding a shared global, kills navigation for anyone using a preview —
   and does it silently, because the CSS still renders perfectly.
+
+  SPEAKER NOTES (the fifth block) are OPTIONAL. Author a slide's notes as
+  <div class="spk">…</div> inside its <section class="slide">; the tray shows the note for
+  whichever slide is active. N toggles, Esc collapses, and the Hide link on the collapsed
+  bar clears it off screen for presenting (N brings it back). For a deck with no notes,
+  delete the .tray markup, the speaker-notes CSS block, and the fifth script block.
+  Notes ship inside the file and are readable in source — strip them before sharing a deck
+  whose notes are not for the recipient.
   Controls: ← / → (or PageUp/Down, Space) navigate · Home/End jump · F fullscreen · T theme.
   Theme: dark by default, follows the OS setting on load, toggle top-right.
   See components.md for the full component catalog.
@@ -279,6 +287,43 @@
     .card p{font-size:.82rem;line-height:1.35}
   }
   /* ===== end short-viewport fit ===== */
+  /* ===== speaker notes tray =====
+     Optional. Author notes for a slide as <div class="spk">...</div> inside
+     the <section class="slide">. They never render inline - the tray pulls
+     them in for whichever slide is active. Delete this block and the .tray
+     markup if a deck should carry no notes at all. */
+  .spk{display:none}
+  .tray{position:fixed;left:0;right:0;bottom:0;z-index:30;background:var(--bg);
+    border-top:1px solid var(--line-hi);box-shadow:0 -18px 44px rgba(0,0,0,.34);
+    transform:translateY(calc(100% - 42px));transition:transform .34s cubic-bezier(.22,1,.36,1);
+    max-height:46vh;display:flex;flex-direction:column}
+  .tray.open{transform:translateY(0)}
+  .tray.gone{transform:translateY(100%)}
+  .tray-bar{height:42px;flex:0 0 42px;display:flex;align-items:center;gap:.7rem;padding:0 1.2rem;
+    cursor:pointer;user-select:none;font-size:.76rem;letter-spacing:.14em;text-transform:uppercase;
+    color:var(--faint);font-weight:600}
+  .tray-bar:hover{color:var(--ink)}
+  .tray-bar .chev{transition:transform .34s;font-size:.9rem;color:var(--violet)}
+  .tray.open .tray-bar .chev{transform:rotate(180deg)}
+  .tray-bar .sp{margin-left:auto;font-size:.7rem;letter-spacing:.08em;color:var(--faint);text-transform:none}
+  .tray-bar .hide{font-size:.7rem;letter-spacing:.08em;text-transform:none;color:var(--faint);
+    text-decoration:underline;text-underline-offset:3px;cursor:pointer;padding:.2rem .1rem}
+  .tray-bar .hide:hover{color:var(--ink)}
+  .tray.open .tray-bar .hide{display:none}
+  .tray-body{overflow-y:auto;padding:.2rem 1.4rem 1.4rem;border-top:1px solid var(--line)}
+  .tray-body p{color:var(--muted);font-size:.92rem;line-height:1.55;margin-bottom:.6rem;max-width:82ch}
+  .tray-body b{color:var(--ink)}
+  .tray-body i{color:var(--ink);font-style:italic}
+  .tray-body .none{color:var(--faint);font-style:italic}
+  /* lift the counter/nav clear of the collapsed bar, and drop them back
+     when the bar is hidden */
+  .counter{bottom:3.7rem}
+  .nav{bottom:3.5rem}
+  body.tray-open .counter,body.tray-open .nav{display:none}
+  body.tray-gone .counter{bottom:1.5rem}
+  body.tray-gone .nav{bottom:1.5rem}
+  @media print{.tray{display:none}}
+  /* ===== end speaker notes tray ===== */
 </style>
 </head>
 <body>
@@ -313,6 +358,13 @@
         <div class="card"><div class="stat-num">Text</div><h3>Label</h3><p>One supporting sentence.</p></div>
       </div>
       <p class="lead" style="margin-top:1.8rem">A closing takeaway line for the slide.</p>
+    </div>
+      <div class="spk">
+      <p><b>Example speaker note.</b> Notes live inside the slide as
+      <i>div class="spk"</i> and never render on the slide itself - the tray
+      shows the note for whichever slide is active.</p>
+      <p>Delete the tray entirely if a deck shouldn't carry notes, and strip
+      these blocks before sharing a deck whose notes are internal-only.</p>
     </div>
   </section>
 
@@ -423,6 +475,18 @@
     </div>
   </section>
 
+</div>
+
+<!-- Speaker notes tray. Delete this block (and the matching CSS + script)
+     for a deck that carries no notes. -->
+<div class="tray" id="tray">
+  <div class="tray-bar" id="trayBar">
+    <span class="chev">&#9650;</span><span>Speaker notes</span>
+    <span class="sp">N to toggle</span>
+    <span class="hide" id="trayHide" role="button" tabindex="0"
+          title="Hide the notes bar - press N to bring it back">Hide</span>
+  </div>
+  <div class="tray-body" id="trayBody"></div>
 </div>
 
 <button class="theme-btn" id="theme" aria-label="Toggle theme" title="Toggle light/dark (T)">☀</button>
@@ -539,6 +603,49 @@
       }));
     }
   }, {passive:true});
+})();
+</script>
+<script>
+(function(){
+  var tray = document.getElementById('tray');
+  if (!tray) return;
+  var bar = document.getElementById('trayBar');
+  var hideBtn = document.getElementById('trayHide');
+  var body = document.getElementById('trayBody');
+  var B = document.body;
+  function render(){
+    var s = document.querySelector('.slide.active');
+    var n = s ? s.querySelector('.spk') : null;
+    body.innerHTML = n ? n.innerHTML : '<p class="none">No notes for this slide.</p>';
+    body.scrollTop = 0;
+  }
+  function setOpen(v){
+    tray.classList.toggle('open', v);
+    B.classList.toggle('tray-open', v);
+  }
+  function setGone(v){
+    tray.classList.toggle('gone', v);
+    B.classList.toggle('tray-gone', v);
+    if (v) setOpen(false);
+  }
+  bar.addEventListener('click', function(){
+    setOpen(!tray.classList.contains('open'));
+  });
+  function doHide(e){ e.stopPropagation(); e.preventDefault(); setGone(true); }
+  hideBtn.addEventListener('click', doHide);
+  hideBtn.addEventListener('keydown', function(e){
+    if (e.key === 'Enter' || e.key === ' ') doHide(e);
+  });
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'n' || e.key === 'N') {
+      e.preventDefault();
+      if (tray.classList.contains('gone')) { setGone(false); setOpen(true); }
+      else setOpen(!tray.classList.contains('open'));
+    } else if (e.key === 'Escape') setOpen(false);
+  });
+  new MutationObserver(render).observe(document.getElementById('deck'),
+    {subtree:true, attributes:true, attributeFilter:['class']});
+  render();
 })();
 </script>
 </body>


### PR DESCRIPTION
> **Stacked on #250.** This branch contains that PR's commits as well — review or merge #250 first, and this diff will reduce to the speaker-notes work alone.

## What this adds

Optional per-slide speaker notes. The skill has no notes support today, so a deck presented by someone who didn't write it has nothing to carry the argument.

Notes are authored inside a slide and never render on it:

```html
<section class="slide">
  <div class="content"> … slide content … </div>
  <div class="spk">
    <p><b>What to say here.</b> Notes never appear on the slide.</p>
  </div>
</section>
```

A bottom tray shows the note for whichever slide is active:

| Control | Action |
|---|---|
| **N** | toggle the tray |
| **Esc** | collapse it |
| **Hide** | link on the collapsed bar — clears it off screen for presenting |
| **N** | brings it back after hiding |

The **Hide** link exists because even a collapsed "SPEAKER NOTES" strip is visible to a room. Presenting shouldn't require reloading the file to get rid of it.

## The tray reserves space rather than covering the deck

A single `--tray-h` custom property drives both the deck height and the counter/nav offset, so they can't drift apart:

```
collapsed   --tray-h: 42px    deck 100vh - 42px
open        --tray-h: 34vh    deck 66vh
hidden      --tray-h: 0       deck 100vh
```

The measured gap between the bottom of the deck and the top of the tray is **0** in all three states, and the slide counter and prev/next buttons stay visible throughout.

Two earlier approaches were wrong and are worth recording:

- **Hiding the counter/nav when the tray opened.** That's a workaround, not a fix — it removes the page number exactly when a presenter most wants it.
- **Letting the tray size to its content while reserving 46vh.** That left ~234px of dead space between deck and tray. The tray now has an explicit 34vh height, with the transform controlling how much of it shows.

## Preview-surface constraints

The tray ships as a **fifth** inline `<script>` (1529 chars) rather than being folded into an existing block, and is fully self-contained — it reads the DOM and shares no JavaScript state with any other block.

That isn't theoretical. In the failure that motivated #250, an earlier deck's notes tray was the **only** script that kept working inside the Teams preview pane, precisely because it never depended on another block. Everything that reached across a block boundary died silently.

## Documentation

- **SKILL.md** gains a Step 3a: when to add notes, to delete the tray wholesale when a deck has none, and that **notes are not private** — they ship inside the file and are one "view source" away, so a deck going outside the organization needs its `.spk` blocks stripped, not merely collapsed.
- **components.md** gains the `.spk` markup example.
- The template header comment explains the fifth block and how to remove it.

## Verification

Direct checks on the template: 5 blocks at 913 / 1491 / 350 / 437 / 1529, all under the ~1700 budget; notes render for the active slide and re-render on navigation; the full N / Esc / Hide / N cycle works; gap 0 and counter/nav visible in all three tray states, measured with real interaction after transitions settle; tray excluded from print; and the whole thing still works under a simulation that gives every inline script an isolated global.

**Blind end-to-end test.** A sub-agent was given only the updated skill folder at a neutral path plus a content brief for an unrelated domain — no knowledge of this work, and no mention of speaker notes. It discovered the feature from `SKILL.md`, produced an 11-slide deck with notes on **every** slide written as presenter guidance rather than slide re-reads, and independently verified as: 5 blocks under budget, zero cross-block state, counter total matching the real slide count, no external dependencies, and **0 of 11 slides overflowing** at 1200×672.

It was also candid about what it couldn't do — it declined to claim the browser render check passed, having no browser available. That check was run separately and passed.

## Two documentation gaps that blind test found

Both are fixed here:

1. **Step 5a said to strip HTML comments** before counting scripts and slides. The CSS comment inside `<style>` *also* contains the literal text `<section class="slide">`, which inflated the agent's slide count from 11 to 15. Now says to strip HTML **and** CSS comments. (This same class of trap produced a false result three separate times while developing these changes — it's worth the explicit warning.)
2. **CRLF line endings** push the largest block from 1529 to 1571 chars — roughly 1 byte per line. Step 5a now says to measure the budget on the file as written.

## Notes for reviewers

- Existing decks are unaffected; this changes the template only.
- The tray is opt-out: delete its markup, CSS block and script block for a deck with no notes. `SKILL.md` says to do exactly that rather than ship an empty tray.
- No visual change when the tray is absent.
