### PR TITLE
feat: Add root-cause-analysis skill

### DIFF
--- a/submissions/root-cause-analysis/README.md
+++ b/submissions/root-cause-analysis/README.md
@@ -1,0 +1,38 @@
+# Root Cause Analysis
+
+Use this skill when you need to understand why something failed — not just what went wrong, but the underlying cause you can act on.
+
+## What it does
+
+Root Cause Analysis (RCA) turns incident symptoms into a clear diagnosis using structured techniques:
+
+- **5 Whys** — keep asking "why" until you reach a fixable origin.
+- **Fishbone diagram** — map causes across six categories: People, Process, Technology, Data, Environment, Management.
+
+The skill distinguishes between a **root cause** (the fundamental origin) and **contributing factors** (things that made the problem worse). That distinction changes what you fix and whether the problem stays fixed.
+
+## When to use it
+
+- An incident, defect, or outage happened and you need to know why.
+- You are preparing a post-mortem or incident review.
+- A process keeps failing in the same place and surface fixes are not working.
+- You want to separate "what happened" from "what actually caused it."
+
+## What you get
+
+- A clear root cause statement.
+- The evidence chain behind it.
+- A list of contributing factors.
+- Recommended actions, ordered by whether they address the root cause or only contributing factors.
+
+## What you need
+
+- A clear symptom or failure to investigate.
+- Access to the person or system that observed the problem.
+- Any available logs, timelines, or context that show what happened.
+
+## Tips
+
+- Start with a precise problem statement. "The service went down" is a symptom; "the payment API returned 503 for 12 minutes during the 9 AM traffic spike" is a problem statement.
+- Keep asking "why" at least three levels before proposing causes.
+- Contributing factors are still useful to document — they reduce recurrence even if they are not the root cause.

--- a/submissions/root-cause-analysis/SKILL.md
+++ b/submissions/root-cause-analysis/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: root-cause-analysis
+description: Use this skill whenever the user asks to diagnose why something failed, find the root cause of an incident, conduct a post-mortem, analyze a problem or defect, distinguish symptoms from causes, or apply 5 Whys or Fishbone analysis. Trigger on phrases like "why did this happen", "root cause", "post-mortem", "5 whys", "fishbone", "what caused this", "diagnose the failure", "why did it fail", "underlying cause". Do NOT trigger for general problem solving (use business-os), refining existing plans (use idea-refiner), or content quality audits (use content-quality-auditor).
+---
+
+# Root Cause Analysis
+
+Guide the user through structured problem diagnosis to move from observed symptoms to the true underlying cause, using repeatable techniques that prevent guessing or stopping at surface-level fixes.
+
+## Instructions
+
+1. **Lock the problem statement**
+   - State the exact symptom or failure in one sentence.
+   - Capture when it occurred, where, and who or what was affected.
+   - Do not allow vague wording like "it broke" or "performance is bad."
+
+2. **Map the symptom chain**
+   - List every observed symptom as a fact, not a hypothesis.
+   - For each symptom, ask: "What could produce this?"
+   - Keep asking "why" at least three levels deep before proposing any cause.
+
+3. **Apply 5 Whys**
+   - Start from the problem statement.
+   - Ask "why" repeatedly, recording each answer.
+   - Stop when you reach a cause that, if fixed, would prevent the symptom from recurring.
+   - If you reach a cause that is a contributing factor rather than a fixable origin, keep going.
+   - Load `references/rca-methods.md` if the problem is complex or the user asks for a specific technique.
+
+4. **Build a Fishbone diagram**
+   - Categorize potential causes across: People, Process, Technology, Data, Environment, Management.
+   - For each category, list specific contributing factors backed by evidence the user can confirm.
+   - Do not invent facts; if a factor is uncertain, mark it as unverified.
+   - Use `assets/fishbone-template.html` to structure the diagram. Open the template, replace the placeholder text in each category branch with the contributing factors identified above, and return the filled-in HTML so the user can save and open it.
+   - Do NOT build a new diagram from scratch. Do NOT generate matplotlib, code-generated plots, or any output that is not based on the provided template. Editing and returning the provided HTML template is the correct output.
+
+5. **Separate root cause from contributing factors**
+   - Root cause: the fundamental origin that, if eliminated, prevents recurrence.
+   - Contributing factor: made the problem more likely or more severe, but is not the origin.
+   - Present both clearly; fixing only contributing factors will not fully resolve the issue.
+
+6. **Output the diagnosis**
+   - Root cause: one precise sentence.
+   - Evidence: the "why" chain or diagram nodes that support it.
+   - Contributing factors: bullet list with severity or likelihood.
+   - Recommended actions: ordered by whether they address the root cause or only contributing factors.
+
+## Guardrails
+
+- Never skip the "why" chain. Symptoms are not causes.
+- Do not propose fixes before the root cause is stated.
+- Separate factual evidence from assumptions; label anything unverified.
+- If evidence is missing, say so explicitly rather than inferring.
+- Do not assign blame. Describe mechanisms and conditions, not people.
+- Stop at actionable causes. Do not drift into speculation or philosophy.

--- a/submissions/root-cause-analysis/SKILL.md
+++ b/submissions/root-cause-analysis/SKILL.md
@@ -26,23 +26,42 @@ Guide the user through structured problem diagnosis to move from observed sympto
    - If you reach a cause that is a contributing factor rather than a fixable origin, keep going.
    - Load `references/rca-methods.md` if the problem is complex or the user asks for a specific technique.
 
-4. **Build a Fishbone diagram**
-   - Categorize potential causes across: People, Process, Technology, Data, Environment, Management.
-   - For each category, list specific contributing factors backed by evidence the user can confirm.
-   - Do not invent facts; if a factor is uncertain, mark it as unverified.
-   - Use `assets/fishbone-template.html` to structure the diagram. Open the template, replace the placeholder text in each category branch with the contributing factors identified above, and return the filled-in HTML so the user can save and open it.
-   - Do NOT build a new diagram from scratch. Do NOT generate matplotlib, code-generated plots, or any output that is not based on the provided template. Editing and returning the provided HTML template is the correct output.
+ 4. **Build a Fishbone diagram**
+    - Categorize potential causes across: People, Process, Technology, Data, Environment, Management.
+    - For each category, list specific contributing factors backed by evidence the user can confirm.
+    - Do not invent facts; if a factor is uncertain, mark it as unverified.
+    - Use `assets/fishbone-template.html` to structure the diagram. Open the template, replace the placeholder text in each category branch with the contributing factors identified above, and return the filled-in HTML so the user can save and open it.
+    - Do NOT build a new diagram from scratch. Do NOT generate matplotlib, code-generated plots, or any output that is not based on the provided template. Editing and returning the provided HTML template is the correct output.
+    - Classify every factor as **CONFIRMED**, **UNVERIFIED**, or **DISPROVEN** using the rules in the Evidence classification section below. In particular: only facts stated verbatim or by direct paraphrase in the user's input may be CONFIRMED. If a claim is built on the absence of information — for example, inferring a missing control because no one mentioned it — it must be UNVERIFIED, not CONFIRMED.
 
-5. **Separate root cause from contributing factors**
-   - Root cause: the fundamental origin that, if eliminated, prevents recurrence.
-   - Contributing factor: made the problem more likely or more severe, but is not the origin.
-   - Present both clearly; fixing only contributing factors will not fully resolve the issue.
+ 5. **Separate root cause from contributing factors**
+    - Root cause: the fundamental origin that, if eliminated, prevents recurrence.
+    - Contributing factor: made the problem more likely or more severe, but is not the origin.
+    - Present both clearly; fixing only contributing factors will not fully resolve the issue.
 
-6. **Output the diagnosis**
-   - Root cause: one precise sentence.
-   - Evidence: the "why" chain or diagram nodes that support it.
-   - Contributing factors: bullet list with severity or likelihood.
-   - Recommended actions: ordered by whether they address the root cause or only contributing factors.
+ 6. **Output the diagnosis**
+    - Root cause: one precise sentence.
+    - Evidence: the "why" chain or diagram nodes that support it.
+    - Contributing factors: bullet list with severity or likelihood.
+    - Recommended actions: ordered by whether they address the root cause or only contributing factors.
+
+## Evidence classification
+
+Classify every factor in the fishbone as **CONFIRMED**, **UNVERIFIED**, or **DISPROVEN**.
+
+- **CONFIRMED** — the fact is stated verbatim in the user's input, or is a direct paraphrase with no added detail.
+- **UNVERIFIED** — the fact is an inference, an assumption, or any detail not explicitly provided by the user. This also includes claims built on the absence of information (for example, inferring a missing control from the fact that no one mentioned it).
+- **DISPROVEN** — the user's input directly contradicts the claim.
+
+**Rule:** Only facts present verbatim or by direct paraphrase in the user's input may be tagged CONFIRMED. Every added detail, inference, or absence of a piece of information that leads you to think the opposite is true, must be UNVERIFIED.
+
+**Positive example (CONFIRMED):**
+- User says: "The deploy failed because the config file was missing."
+- Factor: "Config file was missing at deploy time." → **CONFIRMED** (verbatim)
+
+**Negative example (UNVERIFIED):**
+- User says: "The deploy failed and no one remembered checking the config."
+- Factor: "The team did not have a checklist for config validation." → **UNVERIFIED** (inference from absence of information — the user never said a checklist existed or was missing)
 
 ## Guardrails
 

--- a/submissions/root-cause-analysis/assets/fishbone-template.html
+++ b/submissions/root-cause-analysis/assets/fishbone-template.html
@@ -5,51 +5,130 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Fishbone Diagram Template</title>
 <style>
-  body { font-family: sans-serif; margin: 2rem; background: #f8f9fa; color: #212529; }
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 2rem; background: #f8f9fa; color: #212529; max-width: 960px; }
   h1 { font-size: 1.25rem; margin-bottom: 1rem; }
-  .problem { font-weight: bold; text-align: center; margin-bottom: 2rem; padding: 0.5rem; border: 2px solid #333; display: inline-block; }
-  .diagram { position: relative; height: 420px; margin-bottom: 2rem; }
-  .spine { position: absolute; top: 210px; left: 4%; right: 4%; height: 4px; background: #333; }
-  .head { position: absolute; right: 2%; top: 210px; transform: translateY(-50%); width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 20px solid transparent; border-left: 30px solid #333; }
-  .category { position: absolute; width: 110px; text-align: center; }
-  .category .label { font-weight: bold; font-size: 0.85rem; margin-bottom: 0.25rem; }
-  .category .causes { font-size: 0.75rem; color: #495057; }
-  .cat-top { top: 40px; }
-  .cat-bottom { top: 310px; }
-  .c1 { left: 10%; } .c2 { left: 30%; } .c3 { left: 50%; } .c4 { left: 10%; } .c5 { left: 30%; } .c6 { left: 50%; }
-  .bone { position: absolute; height: 2px; background: #666; transform-origin: left center; }
-  .bone-top { top: 115px; width: 140px; transform: rotate(35deg); }
-  .bone-bottom { top: 275px; width: 140px; transform: rotate(-35deg); }
-  .notes { margin-top: 1rem; }
-  .notes textarea { width: 100%; min-height: 120px; border: 1px solid #ced4da; border-radius: 0.25rem; padding: 0.5rem; }
+  .problem { font-weight: bold; text-align: center; margin-bottom: 1.5rem; padding: 0.5rem 1.5rem; border: 2px solid #333; display: inline-block; cursor: text; }
+  .diagram { position: relative; margin-bottom: 2rem; }
+  .diagram svg.overlay { position: absolute; top: 0; left: 0; pointer-events: none; z-index: 0; }
+  .row { display: flex; justify-content: space-around; gap: 1rem; padding: 0.5rem 0; position: relative; z-index: 1; }
+  .category { min-width: 0; flex: 1 1 0; max-width: 220px; border: 1px solid #ced4da; border-radius: 6px; padding: 0.75rem; background: white; word-wrap: break-word; overflow-wrap: break-word; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+  .category .label { font-weight: 600; font-size: 0.8rem; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.03em; color: #495057; }
+  .category .causes { font-size: 0.85rem; color: #212529; min-height: 1.2em; line-height: 1.4; }
+  .spine-area { position: relative; height: 50px; display: flex; align-items: center; margin: 0.5rem 0; }
+  .spine-line { flex: 1; height: 3px; background: #333; }
+  .head { position: absolute; right: 0; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 12px solid transparent; border-bottom: 12px solid transparent; border-left: 20px solid #333; }
+  .notes { margin-top: 1.5rem; }
+  .notes label { display: block; font-weight: 600; margin-bottom: 0.25rem; }
+  .notes textarea { width: 100%; min-height: 120px; border: 1px solid #ced4da; border-radius: 4px; padding: 0.75rem; font-family: inherit; }
 </style>
 </head>
 <body>
   <h1>Fishbone Diagram Template</h1>
   <div class="problem" contenteditable="true">PROBLEM STATEMENT</div>
 
-  <div class="diagram">
-    <div class="spine"></div>
-    <div class="head"></div>
+  <div class="diagram" id="diagram">
+    <svg class="overlay" id="overlay"></svg>
 
-    <div class="bone bone-top" style="left: 10%;"></div>
-    <div class="bone bone-top" style="left: 30%;"></div>
-    <div class="bone bone-top" style="left: 50%;"></div>
-    <div class="bone bone-bottom" style="left: 10%;"></div>
-    <div class="bone bone-bottom" style="left: 30%;"></div>
-    <div class="bone bone-bottom" style="left: 50%;"></div>
+    <div class="row top" id="topRow">
+      <div class="category"><div class="label">People</div><div class="causes" contenteditable="true">skills, training, staffing</div></div>
+      <div class="category"><div class="label">Process</div><div class="causes" contenteditable="true">steps, policies, approvals</div></div>
+      <div class="category"><div class="label">Technology</div><div class="causes" contenteditable="true">tools, infra, config</div></div>
+    </div>
 
-    <div class="category c1 cat-top"><div class="label">People</div><div class="causes" contenteditable="true">skills, training, staffing</div></div>
-    <div class="category c2 cat-top"><div class="label">Process</div><div class="causes" contenteditable="true">steps, policies, approvals</div></div>
-    <div class="category c3 cat-top"><div class="label">Technology</div><div class="causes" contenteditable="true">tools, infra, config</div></div>
-    <div class="category c4 cat-bottom"><div class="label">Data</div><div class="causes" contenteditable="true">quality, completeness</div></div>
-    <div class="category c5 cat-bottom"><div class="label">Environment</div><div class="causes" contenteditable="true">external conditions</div></div>
-    <div class="category c6 cat-bottom"><div class="label">Management</div><div class="causes" contenteditable="true">priorities, resources</div></div>
+    <div class="spine-area" id="spineArea">
+      <div class="spine-line"></div>
+      <div class="head"></div>
+    </div>
+
+    <div class="row bottom" id="bottomRow">
+      <div class="category"><div class="label">Data</div><div class="causes" contenteditable="true">quality, completeness</div></div>
+      <div class="category"><div class="label">Environment</div><div class="causes" contenteditable="true">external conditions</div></div>
+      <div class="category"><div class="label">Management</div><div class="causes" contenteditable="true">priorities, resources</div></div>
+    </div>
   </div>
 
   <div class="notes">
     <label><strong>Notes / Evidence:</strong></label><br>
     <textarea placeholder="Add supporting facts, timestamps, logs, or observations for each category..."></textarea>
   </div>
+
+  <script>
+    function drawBones() {
+      const diagram = document.getElementById('diagram');
+      const overlay = document.getElementById('overlay');
+      const spineArea = document.getElementById('spineArea');
+      const diagramRect = diagram.getBoundingClientRect();
+      const spineRect = spineArea.getBoundingClientRect();
+
+      if (diagramRect.width === 0 || diagramRect.height === 0) return;
+
+      const svgNS = 'http://www.w3.org/2000/svg';
+      overlay.setAttribute('viewBox', `0 0 ${diagramRect.width} ${diagramRect.height}`);
+      overlay.setAttribute('width', diagramRect.width);
+      overlay.setAttribute('height', diagramRect.height);
+      overlay.innerHTML = '';
+
+      const spineY = spineRect.top + spineRect.height / 2 - diagramRect.top;
+      const spineStartX = 20;
+      const spineEndX = spineRect.right - diagramRect.left - 30;
+      const spineCenterX = (spineStartX + spineEndX) / 2;
+
+      const spine = document.createElementNS(svgNS, 'line');
+      spine.setAttribute('x1', spineStartX);
+      spine.setAttribute('y1', spineY);
+      spine.setAttribute('x2', spineEndX);
+      spine.setAttribute('y2', spineY);
+      spine.setAttribute('stroke', '#333');
+      spine.setAttribute('stroke-width', '3');
+      overlay.appendChild(spine);
+
+      const head = document.createElementNS(svgNS, 'polygon');
+      const headX = spineEndX;
+      const headSize = 12;
+      head.setAttribute('points', `${headX},${spineY} ${headX - 20},${spineY - headSize} ${headX - 20},${spineY + headSize}`);
+      head.setAttribute('fill', '#333');
+      overlay.appendChild(head);
+
+      document.querySelectorAll('.category').forEach(cat => {
+        const catRect = cat.getBoundingClientRect();
+        const isTop = cat.closest('.top') !== null;
+
+        // Connect from the category edge closest to the spine center
+        const catCenterX = catRect.left + catRect.width / 2 - diagramRect.left;
+        const useLeftEdge = catCenterX > spineCenterX;
+
+        const startY = isTop ? catRect.bottom - diagramRect.top : catRect.top - diagramRect.top;
+        const startX = useLeftEdge ? catRect.left - diagramRect.left : catRect.right - diagramRect.left;
+
+        // End at the point on the spine closest to the start X
+        const endY = spineY;
+        const endX = Math.max(spineStartX, Math.min(spineEndX, startX));
+
+        const line = document.createElementNS(svgNS, 'line');
+        line.setAttribute('x1', startX);
+        line.setAttribute('y1', startY);
+        line.setAttribute('x2', endX);
+        line.setAttribute('y2', endY);
+        line.setAttribute('stroke', '#666');
+        line.setAttribute('stroke-width', '2');
+        overlay.appendChild(line);
+      });
+    }
+
+    function init() {
+      drawBones();
+      window.addEventListener('resize', drawBones);
+      document.querySelectorAll('[contenteditable="true"]').forEach(el => {
+        el.addEventListener('input', drawBones);
+      });
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', init);
+    } else {
+      init();
+    }
+  </script>
 </body>
 </html>

--- a/submissions/root-cause-analysis/assets/fishbone-template.html
+++ b/submissions/root-cause-analysis/assets/fishbone-template.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fishbone Diagram Template</title>
+<style>
+  body { font-family: sans-serif; margin: 2rem; background: #f8f9fa; color: #212529; }
+  h1 { font-size: 1.25rem; margin-bottom: 1rem; }
+  .problem { font-weight: bold; text-align: center; margin-bottom: 2rem; padding: 0.5rem; border: 2px solid #333; display: inline-block; }
+  .diagram { position: relative; height: 420px; margin-bottom: 2rem; }
+  .spine { position: absolute; top: 210px; left: 4%; right: 4%; height: 4px; background: #333; }
+  .head { position: absolute; right: 2%; top: 210px; transform: translateY(-50%); width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 20px solid transparent; border-left: 30px solid #333; }
+  .category { position: absolute; width: 110px; text-align: center; }
+  .category .label { font-weight: bold; font-size: 0.85rem; margin-bottom: 0.25rem; }
+  .category .causes { font-size: 0.75rem; color: #495057; }
+  .cat-top { top: 40px; }
+  .cat-bottom { top: 310px; }
+  .c1 { left: 10%; } .c2 { left: 30%; } .c3 { left: 50%; } .c4 { left: 10%; } .c5 { left: 30%; } .c6 { left: 50%; }
+  .bone { position: absolute; height: 2px; background: #666; transform-origin: left center; }
+  .bone-top { top: 115px; width: 140px; transform: rotate(35deg); }
+  .bone-bottom { top: 275px; width: 140px; transform: rotate(-35deg); }
+  .notes { margin-top: 1rem; }
+  .notes textarea { width: 100%; min-height: 120px; border: 1px solid #ced4da; border-radius: 0.25rem; padding: 0.5rem; }
+</style>
+</head>
+<body>
+  <h1>Fishbone Diagram Template</h1>
+  <div class="problem" contenteditable="true">PROBLEM STATEMENT</div>
+
+  <div class="diagram">
+    <div class="spine"></div>
+    <div class="head"></div>
+
+    <div class="bone bone-top" style="left: 10%;"></div>
+    <div class="bone bone-top" style="left: 30%;"></div>
+    <div class="bone bone-top" style="left: 50%;"></div>
+    <div class="bone bone-bottom" style="left: 10%;"></div>
+    <div class="bone bone-bottom" style="left: 30%;"></div>
+    <div class="bone bone-bottom" style="left: 50%;"></div>
+
+    <div class="category c1 cat-top"><div class="label">People</div><div class="causes" contenteditable="true">skills, training, staffing</div></div>
+    <div class="category c2 cat-top"><div class="label">Process</div><div class="causes" contenteditable="true">steps, policies, approvals</div></div>
+    <div class="category c3 cat-top"><div class="label">Technology</div><div class="causes" contenteditable="true">tools, infra, config</div></div>
+    <div class="category c4 cat-bottom"><div class="label">Data</div><div class="causes" contenteditable="true">quality, completeness</div></div>
+    <div class="category c5 cat-bottom"><div class="label">Environment</div><div class="causes" contenteditable="true">external conditions</div></div>
+    <div class="category c6 cat-bottom"><div class="label">Management</div><div class="causes" contenteditable="true">priorities, resources</div></div>
+  </div>
+
+  <div class="notes">
+    <label><strong>Notes / Evidence:</strong></label><br>
+    <textarea placeholder="Add supporting facts, timestamps, logs, or observations for each category..."></textarea>
+  </div>
+</body>
+</html>

--- a/submissions/root-cause-analysis/assets/fishbone-template.html
+++ b/submissions/root-cause-analysis/assets/fishbone-template.html
@@ -15,17 +15,33 @@
   .category { min-width: 0; flex: 1 1 0; max-width: 220px; border: 1px solid #ced4da; border-radius: 6px; padding: 0.75rem; background: white; word-wrap: break-word; overflow-wrap: break-word; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
   .category .label { font-weight: 600; font-size: 0.8rem; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.03em; color: #495057; }
   .category .causes { font-size: 0.85rem; color: #212529; min-height: 1.2em; line-height: 1.4; }
+  .causes .tag { display: inline-block; padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; margin-right: 0.35rem; vertical-align: middle; }
+  .tag-confirmed { background: #d1e7dd; color: #0f5132; }
+  .tag-unverified { background: #fff3cd; color: #664d03; }
+  .tag-disproven { background: #f8d7da; color: #842029; }
   .spine-area { position: relative; height: 50px; display: flex; align-items: center; margin: 0.5rem 0; }
   .spine-line { flex: 1; height: 3px; background: #333; }
   .head { position: absolute; right: 0; top: 50%; transform: translateY(-50%); width: 0; height: 0; border-top: 12px solid transparent; border-bottom: 12px solid transparent; border-left: 20px solid #333; }
   .notes { margin-top: 1.5rem; }
   .notes label { display: block; font-weight: 600; margin-bottom: 0.25rem; }
   .notes textarea { width: 100%; min-height: 120px; border: 1px solid #ced4da; border-radius: 4px; padding: 0.75rem; font-family: inherit; }
+  .legend { display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  .legend-item { display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; color: #495057; }
+  .legend-dot { width: 10px; height: 10px; border-radius: 2px; }
+  .legend-confirmed { background: #198754; }
+  .legend-unverified { background: #ffc107; }
+  .legend-disproven { background: #dc3545; }
 </style>
 </head>
 <body>
   <h1>Fishbone Diagram Template</h1>
   <div class="problem" contenteditable="true">PROBLEM STATEMENT</div>
+
+  <div class="legend">
+    <div class="legend-item"><span class="legend-dot legend-confirmed"></span> Confirmed</div>
+    <div class="legend-item"><span class="legend-dot legend-unverified"></span> Unverified</div>
+    <div class="legend-item"><span class="legend-dot legend-disproven"></span> Disproven</div>
+  </div>
 
   <div class="diagram" id="diagram">
     <svg class="overlay" id="overlay"></svg>

--- a/submissions/root-cause-analysis/metadata.json
+++ b/submissions/root-cause-analysis/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Root Cause Analysis",
+  "description": "Diagnose the true cause of a problem — not just its symptoms — using structured techniques like 5 Whys, Fishbone diagrams, and contributing factor analysis.",
+  "platforms": ["Cowork", "Copilot Studio", "Scout"],
+  "tags": ["problem-solving", "analysis", "decision-making", "investigation", "debugging"],
+  "author": "Nayananshu Garai",
+  "authorUrl": "https://github.com/N-Garai",
+  "version": "1.0.0",
+  "createdAt": "2026-08-04",
+  "updatedAt": "2026-08-04"
+}

--- a/submissions/root-cause-analysis/references/rca-methods.md
+++ b/submissions/root-cause-analysis/references/rca-methods.md
@@ -1,0 +1,60 @@
+# RCA Techniques Reference
+
+Load this file when the user wants deeper guidance on a specific technique, or when the problem is complex enough that a single-pass analysis is not sufficient.
+
+## 5 Whys
+
+Starting from the problem statement, ask "why" repeatedly. Each answer becomes the next question.
+
+**Rules:**
+- Ask "why" at least three times before stopping. Most root causes are found between 3 and 5 levels.
+- Each answer must be factual. If you do not know, say so and ask the user.
+- Stop when you reach a cause that, if fixed, would prevent the symptom from recurring.
+- If you reach a person's name rather than a process or system condition, you have stopped too early. Keep going until you reach a mechanism.
+
+**Example chain:**
+1. Why did the deploy fail? The build step returned 500.
+2. Why did the build step return 500? The linter crashed on a missing config file.
+3. Why was the config file missing? The bootstrap script skips it when the environment variable is absent.
+4. Why is the environment variable absent in CI? The pipeline template was not updated when the config was moved.
+
+Root cause: the pipeline template was not updated when the config was moved.
+
+## Fishbone Diagram (Ishikawa)
+
+Categorize causes across six standard categories. For each category, list specific contributing factors.
+
+**Categories:**
+- **People** — skills, training, staffing, communication, handoffs.
+- **Process** — steps, policies, approvals, dependencies, sequencing.
+- **Technology** — tools, infrastructure, integrations, capacity, configuration.
+- **Data** — quality, completeness, freshness, schema, access.
+- **Environment** — external conditions, market, regulations, physical constraints.
+- **Management** — priorities, resources, decisions, risk tolerance, oversight.
+
+**Rules:**
+- List causes, not fixes. The diagram is diagnostic, not prescriptive.
+- Each item should be specific enough to verify. "Bad communication" is vague; "the handoff doc was not updated after the migration" is specific.
+- Mark items as confirmed, unverified, or disproven. Do not present guesses as facts.
+
+## Contributing Factors vs Root Cause
+
+A **root cause** is the fundamental origin. Eliminate it and the problem does not recur.
+
+A **contributing factor** increases the likelihood or severity of the problem, but is not the origin. Eliminate it and the problem can still happen.
+
+**Example:**
+- Symptom: server crashed.
+- Root cause: the memory leak was never fixed because the monitoring alert was disabled.
+- Contributing factors: traffic was 3x normal, the instance type was undersized, the deploy happened at peak load.
+
+Fixing the instance size or deferring the deploy reduces the chance of another crash, but the memory leak will eventually cause another one. Fix the root cause first.
+
+## Output Format
+
+When presenting the diagnosis:
+
+1. **Root cause** — one sentence.
+2. **Evidence** — the why-chain nodes or fishbone entries that support it.
+3. **Contributing factors** — bullet list with estimated impact or likelihood.
+4. **Recommended actions** — ordered by whether they address the root cause or only contributing factors.


### PR DESCRIPTION
Adds a new `root-cause-analysis` skill that guides agents through structured problem diagnosis using 5 Whys, Fishbone diagrams, and contributing factor analysis. Fills a gap in the gallery — no existing skill targets root cause identification for incidents, defects, or post-mortems.

## Files added
submissions/root-cause-analysis/
├── metadata.json
├── SKILL.md
├── README.md
├── references/rca-methods.md
└── assets/fishbone-template.html
src/content/skills/root-cause-analysis.md
src/content/guides/root-cause-analysis.md
public/bundles/root-cause-analysis.zip

## Validation

- `npm run check:submissions` — 78/78 pass
- `npm run import:submissions` — generates skill, guide, and bundle
- `npm run build` — 330 pages built successfully
