### PR TITLE
Fix Chart Builder attribution

### DIFF
--- a/src/content/skills/chart-builder.md
+++ b/src/content/skills/chart-builder.md
@@ -4,8 +4,9 @@ description: "Generate clean, consistently-styled matplotlib charts (bar, line, 
 agentDescription: "Use this skill whenever the user asks to visualize, chart, plot, or graph data (bar, line, scatter, histogram, pie) from a CSV, table, or DataFrame. It gives the agent prebuilt, parameterized matplotlib functions so charts are produced faster and more reliably — with consistent styling and sane defaults — instead of hand-writing matplotlib each time."
 platforms: [Cowork, Copilot Studio, Scout]
 tags: [data, charts, matplotlib, scripts]
-author: CAT Agent Skills
-authorUrl: "https://github.com/microsoft/cat-agent-skills"
+author: Adi Leibowitz
+authorUrl: "https://github.com/adilei"
+authorGithub: adilei
 version: 1.0.0
 createdAt: 2026-07-14
 updatedAt: 2026-07-14

--- a/submissions/chart-builder/metadata.json
+++ b/submissions/chart-builder/metadata.json
@@ -12,8 +12,8 @@
     "matplotlib",
     "scripts"
   ],
-  "author": "CAT Agent Skills",
-  "authorUrl": "https://github.com/microsoft/cat-agent-skills",
+  "author": "Adi Leibowitz",
+  "authorUrl": "https://github.com/adilei",
   "version": "1.0.0",
   "createdAt": "2026-07-14",
   "updatedAt": "2026-07-14",


### PR DESCRIPTION
## Summary
- attribute Chart Builder to Adi Leibowitz (`@adilei`) in source metadata
- regenerate the canonical skill entry so `authorGithub` is derived from the GitHub profile URL
- ensure Chart Builder's 255 downloads count toward `@adilei` contributor badges

## Validation
- `npm run check:submissions`
- `npm run validate:skills`
- `npm test`
- `npm run build`
- catalog badge-engine check: `@adilei` totals 255 downloads, ranks in the top three, and earns Shelf Clearer

Follow-up to #260.