### PR TITLE
Extend GitHub Pages deployment timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,3 +96,5 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          timeout: 1200000


### PR DESCRIPTION
## Summary
- increase `actions/deploy-pages` polling timeout from its 10-minute default to 20 minutes
- allow Pages deployments to survive the queue duration reproduced after #261

## Context
The post-merge build for #261 succeeded, but GitHub Pages remained `deployment_queued` until the action's 10-minute default timeout. A failed-job retry and a fresh manual workflow run reproduced the same timeout; environment protections require no review, and the build/artifact upload both succeed.

## Validation
- workflow YAML parses successfully
- `git diff --check`