### PR TITLE
Verify Pages after deploy action timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,5 +96,36 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-        with:
-          timeout: 1200000
+        continue-on-error: true
+      # deploy-pages hard-caps its polling at 10 minutes and cancels at that
+      # boundary, even when Pages finishes the deployment shortly afterward.
+      - name: Verify Pages deployment after action timeout
+        if: steps.deployment.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in {1..120}; do
+            if ! status="$(gh api "repos/${GITHUB_REPOSITORY}/pages/deployments/${GITHUB_SHA}" --jq '.status')"; then
+              echo "::warning::Could not read Pages deployment status (attempt ${attempt}/120)."
+              sleep 5
+              continue
+            fi
+
+            case "$status" in
+              succeed)
+                echo "Pages deployment succeeded after the action timeout."
+                exit 0
+                ;;
+              deployment_failed|deployment_perms_error|deployment_content_failed|deployment_lost)
+                echo "::error::Pages deployment ended with status: $status"
+                exit 1
+                ;;
+              *)
+                echo "Pages deployment status: $status (attempt ${attempt}/120)"
+                sleep 5
+                ;;
+            esac
+          done
+
+          echo "::error::Pages deployment did not succeed within 10 additional minutes."
+          exit 1


### PR DESCRIPTION
## Summary
- tolerate the official `actions/deploy-pages` step's hard 10-minute polling cap
- continue polling the Pages deployment API for up to 10 additional minutes
- preserve failures for actual content, permissions, deployment, or lost-status errors

## Context
The official action clamps its configurable timeout to `MAX_TIMEOUT = 600000`, so the 20-minute input from #262 was ineffective. Pages later reported the supposedly canceled deployment for `f639eb9` as `succeed`, and the published Chart Builder page now shows Adi Leibowitz / `@adilei`. This follow-up makes the workflow conclusion reflect that eventual backend success.

## Validation
- workflow YAML parses successfully
- fallback verifier observes `succeed` for the deployed `f639eb9` Pages version
- `git diff --check`