### PR TITLE
Clarify the rating action on skill pages

### DIFF
--- a/src/pages/skills/[slug].astro
+++ b/src/pages/skills/[slug].astro
@@ -226,15 +226,18 @@ const authorProfileUrl =
           )
         }
 
-        <div class="mt-4 flex items-center gap-2">
+        <div class="mt-4 flex flex-wrap items-center gap-2">
           <a
             href="#rate"
-            class="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-fg hover:border-accent/50 hover:text-fg transition-colors"
-            title={`Rate & discuss this ${noun}`}
+            class="inline-flex items-center rounded-full border border-border bg-surface-2 px-3 py-1 text-sm font-medium text-fg transition-colors hover:border-accent/50"
           >
-            <span aria-hidden="true">👍</span>
-            <span>{rating}</span>
-            <span class="text-muted">{rating === 1 ? "rating" : "ratings"}</span>
+            <span class="inline-flex items-center gap-1.5">
+              <span aria-hidden="true">👍</span>
+              <span>{rating}</span>
+              <span class="text-muted">{rating === 1 ? "rating" : "ratings"}</span>
+            </span>
+            <span class="mx-2 h-4 w-px bg-border" aria-hidden="true"></span>
+            <span class="text-accent-text">Rate &amp; discuss</span>
           </a>
           {
             downloads > 0 && (


### PR DESCRIPTION
## Summary
- make the rating badge explicitly say “Rate & discuss”
- keep the current rating count visible as context
- allow the metadata badges to wrap on narrow screens

## Validation
- `npm run build -- --silent`