### PR TITLE
Add action-items-todo skill

### DIFF
--- a/submissions/action-items-todo/README.md
+++ b/submissions/action-items-todo/README.md
@@ -1,0 +1,64 @@
+# Action Items to To Do
+
+Things people ask you to do arrive scattered across Teams, meetings, and mail, and the ones that get forgotten are rarely the urgent ones. This skill watches all three, works out which messages contain a genuine ask directed at you, and files each one as a Microsoft To Do task with a due date, a priority, and a link back to where it came from.
+
+It runs on a schedule you choose. Microsoft To Do is the only place it writes tasks.
+
+## Setup
+
+Invoke the skill once and it asks three questions:
+
+1. Which Microsoft To Do list captured items go into. Your existing lists are shown, and naming a new one creates it.
+2. How often to scan: every 15 minutes, 30 minutes, hour, or 2 hours.
+3. When to scan: around the clock every day, around the clock on weekdays, working hours on weekdays, or a schedule you describe in your own words.
+
+The around-the-clock option exists because plenty of people work across time zones, where a 9-to-5 scan window misses half the day. Pick whichever matches how you actually work.
+
+Setup writes a config file, then creates the recurring automation for you. Nothing scans before setup finishes.
+
+## What it captures
+
+An action item is anything asking you to do, decide, respond, review, attend, prepare, or follow up. Soft and future-dated asks count, so "when you get a chance, could you look at this?" is captured just like a hard deadline. Urgency is not a requirement.
+
+The ask has to be aimed at you specifically. That means you are named, you are @mentioned, it arrived in a 1:1 chat, or the surrounding conversation clearly puts the item on your plate. Generic group requests, FYIs, status updates, newsletters, and notifications are skipped.
+
+Two things it deliberately does not do: it will not treat a topic in your area as an implied assignment, and it will not capture your own promises. Commitments you make to other people are a different problem from asks other people make of you, and mixing them produces a task list you stop trusting.
+
+Task titles are always written in English, even when the source message is not.
+
+## What each task gets
+
+- **Due date** from an explicit or clearly implied deadline, otherwise today.
+- **Priority** from detected urgency. High for blockers, escalations, ASAP language, or a deadline inside two days. Low for tentative or far-future asks. Normal for everything else.
+- **Owner tagging** as a single `Customer:` or `Workstream:` line at the top of the task body. When the evidence is thin the line is left off, because an untagged task is easy to find and fix while a wrongly tagged one quietly hides in the wrong account.
+- **Source link** back to the original Teams message, meeting, or email.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `setup` | Re-run the wizard and update the existing automation |
+| `scan now` | Run a single scan immediately and show what it found |
+| `status` | Current config, last scan time, items captured in the last 7 days |
+| `pause` / `resume` | Disable or re-enable the automation |
+
+## Optional configuration
+
+Two fields in `config.json` are not covered by the wizard:
+
+- `owners`: lists of known customer and workstream names. Set these and tagging will only ever use a name from your list, which is worth doing if you work across a fixed set of accounts.
+- `excludedChats`: chat or channel names to always ignore. High-volume group chats where people post questions into the void are the usual candidates.
+
+## A note on Teams recency
+
+The skill ranks chats by the timestamp of the most recent message rather than the chat's `lastUpdatedDateTime`. Microsoft Graph frequently fails to advance `lastUpdatedDateTime` on 1:1 chats, so a chat with a message from this morning can report a last-updated date from two years ago and sink to the bottom of the list. During testing this affected several chats containing real, unanswered asks. If you build something similar, this is the detail that will bite you.
+
+## Privacy
+
+Tasks go to your own Microsoft To Do. Notifications go to your own Teams self-chat. The skill never messages anyone else and never forwards the content of a source message.
+
+Configuration and dedupe state live in `%USERPROFILE%\.scout\action-items-todo\`. Delete that folder to reset the skill completely.
+
+## Requirements
+
+Scout, with Microsoft 365 access for Teams, Outlook, calendar, and To Do. Meeting transcript capture only works for meetings where a transcript exists and your tenant policy allows reading it.

--- a/submissions/action-items-todo/README.md
+++ b/submissions/action-items-todo/README.md
@@ -57,7 +57,7 @@ The skill ranks chats by the timestamp of the most recent message rather than th
 
 Tasks go to your own Microsoft To Do. Notifications go to your own Teams self-chat. The skill never messages anyone else and never forwards the content of a source message.
 
-Configuration and dedupe state live in `%USERPROFILE%\.scout\action-items-todo\`. Delete that folder to reset the skill completely.
+Configuration and dedupe state live under your home directory, in `.scout/action-items-todo/`. Delete that folder to reset the skill completely.
 
 ## Requirements
 

--- a/submissions/action-items-todo/README.md
+++ b/submissions/action-items-todo/README.md
@@ -12,7 +12,7 @@ Invoke the skill once and it asks three questions:
 2. How often to scan: every 15 minutes, 30 minutes, hour, or 2 hours.
 3. When to scan: around the clock every day, around the clock on weekdays, working hours on weekdays, or a schedule you describe in your own words.
 
-The around-the-clock option exists because plenty of people work across time zones, where a 9-to-5 scan window misses half the day. Pick whichever matches how you actually work.
+The around-the-clock option exists because plenty of people work across time zones, where a 9-to-5 scan window misses half the day.
 
 Setup writes a config file, then creates the recurring automation for you. Nothing scans before setup finishes.
 
@@ -22,7 +22,7 @@ An action item is anything asking you to do, decide, respond, review, attend, pr
 
 The ask has to be aimed at you specifically. That means you are named, you are @mentioned, it arrived in a 1:1 chat, or the surrounding conversation clearly puts the item on your plate. Generic group requests, FYIs, status updates, newsletters, and notifications are skipped.
 
-Two things it deliberately does not do: it will not treat a topic in your area as an implied assignment, and it will not capture your own promises. Commitments you make to other people are a different problem from asks other people make of you, and mixing them produces a task list you stop trusting.
+Two things it deliberately does not do: it will not treat a topic in your area as an implied assignment, and it will not capture your own promises. Commitments you make to other people have different failure modes, and combining both kinds in one list makes both harder to act on.
 
 Task titles are always written in English, even when the source message is not.
 
@@ -30,7 +30,7 @@ Task titles are always written in English, even when the source message is not.
 
 - **Due date** from an explicit or clearly implied deadline, otherwise today.
 - **Priority** from detected urgency. High for blockers, escalations, ASAP language, or a deadline inside two days. Low for tentative or far-future asks. Normal for everything else.
-- **Owner tagging** as a single `Customer:` or `Workstream:` line at the top of the task body. When the evidence is thin the line is left off, because an untagged task is easy to find and fix while a wrongly tagged one quietly hides in the wrong account.
+- **Owner tagging** as a single `Customer:` or `Workstream:` line at the top of the task body. When the evidence is thin the line is left off, because an untagged task still appears in the list while a task filed against the wrong account does not.
 - **Source link** back to the original Teams message, meeting, or email.
 
 ## Commands
@@ -51,7 +51,7 @@ Two fields in `config.json` are not covered by the wizard:
 
 ## A note on Teams recency
 
-The skill ranks chats by the timestamp of the most recent message rather than the chat's `lastUpdatedDateTime`. Microsoft Graph frequently fails to advance `lastUpdatedDateTime` on 1:1 chats, so a chat with a message from this morning can report a last-updated date from two years ago and sink to the bottom of the list. During testing this affected several chats containing real, unanswered asks. If you build something similar, this is the detail that will bite you.
+The skill ranks chats by the timestamp of the most recent message rather than the chat's `lastUpdatedDateTime`. Microsoft Graph frequently fails to advance `lastUpdatedDateTime` on 1:1 chats, so a chat with a message from this morning can report a last-updated date from two years ago and sink to the bottom of the list. During testing this affected several chats containing real, unanswered asks.
 
 ## Privacy
 

--- a/submissions/action-items-todo/SKILL.md
+++ b/submissions/action-items-todo/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: action-items-todo
+description: >-
+  Use this skill whenever the user asks to monitor, capture, or track action
+  items directed at them across Microsoft Teams chats, meeting transcripts, and
+  Outlook mail, and record them as Microsoft To Do tasks — e.g. "set up action
+  item tracking", "monitor my action items", "capture asks into To Do", "scan
+  for action items now", "what did people ask me to do". Run the SETUP wizard
+  first when no config exists; it asks for the To Do list, scan frequency, and
+  schedule, then creates the recurring automation. Also handles the follow-up
+  commands "scan now", "status", "pause", "resume", and "reconfigure".
+---
+
+:: ACTION ITEMS TO MICROSOFT TO DO ::
+Monitors Teams chats, meeting transcripts, and Outlook mail for action items EXPLICITLY directed at the user, and captures each one as a Microsoft To Do task with a due date, importance, and owner tagging. Microsoft To Do is the only task store this skill writes to.
+
+Nothing about the user (name, email, list name, schedule, customer and workstream names) is hardcoded. Everything lives in the config file written by SETUP.
+
+== FILES ==
+- CONFIG: %USERPROFILE%\.scout\action-items-todo\config.json
+- STATE (dedupe + last scan): %USERPROFILE%\.scout\action-items-todo\state.json
+Create the directory if missing. Write both files as UTF-8 JSON, atomically (temp file then rename). Always preserve unknown fields.
+
+== CONFIG SCHEMA ==
+{
+  "version": 1,
+  "identity": { "displayName": str, "mail": str, "upn": str, "aadId": str },
+  "listName": str,                  // the Microsoft To Do list tasks are written to
+  "frequency": str,                 // natural-language interval, e.g. "every 30 minutes"
+  "schedule": "24/7" | "weekdays-allhours" | "workhours" | str,
+  "timeZone": str,                  // IANA zone, from the machine
+  "language": "en",                 // task titles are always written in this language
+  "owners": { "customers": [str], "workstreams": [str] },   // optional, may be empty
+  "excludedChats": [str],           // chat/channel names to always ignore
+  "notifyTeams": bool,              // send a Teams self-message when items are captured
+  "automationId": str|null,
+  "setupCompleted": ISO8601|null
+}
+
+== STATE SCHEMA ==
+{ "last_scan": ISO8601,
+  "seen": [ { "key": str, "title": str, "created": ISO8601, "source": "teams"|"transcript"|"email", "url": str|null } ] }
+"key" is a stable hash of source + thread/message id. Keep the last 500 entries; drop older ones.
+
+== SETUP (first run, or on demand) ==
+Run SETUP automatically whenever CONFIG is missing or setupCompleted is null. Never run a scan before SETUP completes.
+
+1. Call workiq_get_my_profile and fill identity. If it fails, say so and stop; the skill cannot target asks without knowing who the user is.
+2. Read the machine time zone (PowerShell Get-TimeZone) and store the IANA name.
+3. Read the user's existing lists with workiq_list_task_lists, then ask QUESTION 1 with m_ask_user, free-text mode, inputHint "list name, e.g. Work":
+   "Which Microsoft To Do list should captured action items go into?"
+   Show the existing list names in the assistant message BEFORE the call so the user can pick one or name a new one. After the reply: if the list does not exist, confirm creation, then workiq_create_task_list.
+4. Ask QUESTION 2 with m_ask_user, multiple choice, recommended index 1:
+   "How often should I scan for new action items?"
+   Answers: "Every 15 minutes" / "Every 30 minutes" / "Every hour" / "Every 2 hours".
+   Store the matching natural-language interval in frequency.
+5. Ask QUESTION 3 with m_ask_user, multiple choice, recommended index 0:
+   "When should the scan run?"
+   Answers:
+     - "Around the clock, every day" (desc: best when you work across time zones) -> schedule "24/7"
+     - "Around the clock, weekdays only" -> "weekdays-allhours"
+     - "Working hours only, weekdays" (desc: 8am-6pm in your local time zone) -> "workhours"
+     - "Let me describe it" -> free-text follow-up, stored verbatim.
+6. Ask nothing else. Default the remaining config: language "en", owners empty, excludedChats empty, notifyTeams true.
+7. Write CONFIG and an empty STATE with last_scan = now minus one frequency interval.
+   Do NOT seed last_scan further back to "catch up". The first run would then backfill items that were already handled or already completed elsewhere, and create tasks for them. A short first window is correct.
+8. Create the automation with m_create_automation, then store its id in automationId:
+   - name: "Action Items to To Do"   // avoid > and < in the name; they get HTML-escaped in the automation list
+   - schedule: derived from frequency + schedule (see SCHEDULE MAPPING)
+   - teamsNotify: "auto"
+   - prompt: "Load the action-items-todo skill with m_get_skill and run the SCAN procedure exactly as written. Output only the strict result format the skill defines."
+9. Confirm back in one short block: list name, frequency, schedule, automation id, and how to change any of them ("run /action-items-todo setup again").
+
+== SCHEDULE MAPPING ==
+The scheduler parses a fixed set of forms. A minute interval CANNOT be combined with an hour window in natural language, so the working-hours case must use cron.
+- "24/7"              -> "<frequency>"                e.g. "every 30 minutes"
+- "weekdays-allhours" -> "<frequency> on weekdays"    e.g. "every 30 minutes on weekdays"
+- "workhours"         -> cron, built from the interval:
+                           every 15 minutes -> "cron: 0,15,30,45 8-17 * * 1-5"
+                           every 30 minutes -> "cron: 0,30 8-17 * * 1-5"
+                           every hour       -> "cron: 0 8-17 * * 1-5"
+                           every 2 hours    -> "cron: 0 8,10,12,14,16 * * 1-5"
+- custom              -> pass the user's phrasing through; if m_create_automation rejects it, show the supported_forms list it returns and ask the user to pick one.
+All schedules run in machine-local time. Verify the automation was actually created: m_create_automation returns success:false with a supported_forms list when it cannot parse the schedule, and SETUP must not report success in that case.
+
+== SCAN (what the automation runs) ==
+Load CONFIG first. If it is missing, output AUTOMATION_ERROR|setup not completed and stop.
+Scan window: from state.last_scan to now. If last_scan is missing or older than 24h, scan the trailing 24h.
+
+Sources, all three every run:
+(a) TEAMS CHATS — workiq_list_chats, then workiq_list_chat_messages on candidates.
+(b) MEETING TRANSCRIPTS — workiq_list_meetings for meetings that ended inside the window, then workiq_list_meeting_transcripts and workiq_get_meeting_transcript. Transcripts for a recurring series come back out of order: filter transcripts[] by createdDateTime to the target meeting date, never take transcripts[0].
+(c) OUTLOOK MAIL — workiq_list_emails on the Inbox for the window.
+
+=== TEAMS RECENCY RULE (apply before targeting) ===
+Do NOT use a chat's lastUpdatedDateTime or the default chat-list order to judge recency. Graph frequently fails to advance lastUpdatedDateTime on 1:1 chats, so a chat with a brand-new message can look a month stale.
+- Rank and window chats by lastMessagePreview.date, which is authoritative.
+- Always open any 1:1 chat where lastMessagePreview.date is later than viewpoint.lastMessageReadDateTime, or falls inside the scan window.
+- Read the whole recent thread, not just the message naming the user. The ask often sits in a follow-up that does not repeat the name.
+
+=== TARGETING RULE ===
+An action item is anything asking the user to do, decide, respond, review, attend, prepare, or follow up. Soft and future-dated asks count ("when you have time, could you look at this?"). Urgency is NOT required.
+Capture ONLY when the ask is specifically for the user:
+- The activity names the user (display name, first name, or mail from identity) or uses a proper Teams @mention of them, OR the surrounding context clearly assigns the action to them.
+- A 1:1 Teams chat always satisfies the context test: any genuine ask there is directed at the user even without their name.
+- In a meeting transcript, capture only when someone assigns the item to the user by name, or the user is the clear owner from the immediately surrounding exchange. Do not capture the user's own statements about what they will do; this skill tracks asks TO the user.
+- Do NOT capture generic group asks, broad team requests, messages addressed to "Everyone"/"Tutti"/a channel/a whole group, status updates, FYIs, newsletters, or notifications.
+- Do NOT infer ownership from topic area, past participation, or the fact the user could help. There must be a specific ask.
+- Skip any chat or channel named in config.excludedChats.
+
+=== LANGUAGE RULE ===
+Task titles and bodies are ALWAYS written in config.language (default English), regardless of the source language. Translate the gist into a clear, concise imperative title. Never copy foreign-language phrasing verbatim.
+
+=== URGENCY -> IMPORTANCE ===
+- high: incident, blocker, escalation, customer-impacting issue, explicit urgent/ASAP language, or a deadline inside the next two days.
+- normal: a standard direct request with no specific deadline. This is the default.
+- low: a soft, tentative, optional, or clearly far-future ask ("eventually", "no rush", "when you get a chance").
+
+=== DUE DATE ===
+- Explicit or clearly implied deadline ("by Friday", "before the review") -> that date, YYYY-MM-DD.
+- Otherwise -> today's date in config.timeZone.
+Always set a due date; never omit it.
+
+=== OWNER TAGGING ===
+To Do has no custom fields, so ownership goes in the task body as a metadata block above the summary, at most ONE line:
+  Customer: <Name>
+or
+  Workstream: <Name>
+Rules:
+- If config.owners lists customers or workstreams, match against those exact names only, including obvious variants the thread supports.
+- If config.owners is empty, you may infer a customer or project name that is stated plainly in the thread. Only use a name that actually appears in the source.
+- Topic overlap is not ownership. Never invent a name.
+- If a task touches both a customer and a workstream, prefer Customer.
+- When the evidence is thin, leave the block off. An untagged task is easy to fix; a wrongly tagged one hides.
+
+=== TASK BODY FORMAT ===
+  [optional owner line]
+  <one-sentence summary of the ask, in config.language>
+  Source: <deep link to the Teams message / meeting / email, when available>
+
+=== WRITE PROCEDURE, per captured item ===
+1. Dedupe twice: check state.seen for the item key, and call workiq_list_tasks on config.listName for an open task with the same title. Skip if either matches.
+2. workiq_create_task with list = config.listName, the English title, due, importance, and body.
+3. If the list is missing, recreate it with workiq_create_task_list under the exact configured name and retry once.
+4. Append the item to state.seen.
+5. After all items, set state.last_scan = now and write STATE atomically. Write STATE even on a run with no items, so the window advances.
+
+=== NOTIFICATION ===
+If config.notifyTeams is true AND at least one task was created this run, send ONE Teams self-message listing each captured item: source, importance, owner (or "unassigned"), summary, link. Send nothing on a run that captured nothing.
+
+=== OUTPUT FORMAT, STRICT ===
+The final output is exactly one of these, with no preamble, narration, or progress commentary:
+(A) one line per captured item:
+    ACTION_ITEM|<source>|<importance>|<owner or ->|<summary>|<url>
+(B) the single token:
+    SILENT_NO_ACTION_ITEMS
+(C) on a tool or permission failure:
+    AUTOMATION_ERROR|<what was blocked and why>
+
+Presentation rule for the assistant rendering the result: if the output is SILENT_NO_ACTION_ITEMS, or contains no ACTION_ITEM and no AUTOMATION_ERROR line, render a completely empty response. No heading, no acknowledgement, no "nothing found" message.
+
+== ON-DEMAND COMMANDS ==
+- "setup" / "reconfigure" -> re-run SETUP, keeping existing answers as the recommended defaults, then update the automation with m_update_automation instead of creating a duplicate.
+- "scan now" -> run SCAN once, immediately, and report the items in a readable list rather than the strict format.
+- "status" -> print the current config, last scan time, and the number of items captured in the last 7 days.
+- "pause" / "resume" -> m_update_automation with enabled false/true.
+
+== PRIVACY ==
+Everything this skill writes stays in the user's own Microsoft To Do and their own Teams self-chat. It never sends a message to a third party, never forwards source content, and never posts to a group chat or channel.

--- a/submissions/action-items-todo/SKILL.md
+++ b/submissions/action-items-todo/SKILL.md
@@ -17,8 +17,8 @@ Monitors Teams chats, meeting transcripts, and Outlook mail for action items EXP
 Nothing about the user (name, email, list name, schedule, customer and workstream names) is hardcoded. Everything lives in the config file written by SETUP.
 
 == FILES ==
-- CONFIG: %USERPROFILE%\.scout\action-items-todo\config.json
-- STATE (dedupe + last scan): %USERPROFILE%\.scout\action-items-todo\state.json
+- CONFIG: <user home>/.scout/action-items-todo/config.json
+- STATE (dedupe + last scan): <user home>/.scout/action-items-todo/state.json
 Create the directory if missing. Write both files as UTF-8 JSON, atomically (temp file then rename). Always preserve unknown fields.
 
 == CONFIG SCHEMA ==

--- a/submissions/action-items-todo/SKILL.md
+++ b/submissions/action-items-todo/SKILL.md
@@ -17,9 +17,10 @@ Monitors Teams chats, meeting transcripts, and Outlook mail for action items EXP
 Nothing about the user (name, email, list name, schedule, customer and workstream names) is hardcoded. Everything lives in the config file written by SETUP.
 
 == FILES ==
+Both live in the user's home directory, so write them with the platform's own separator and never hardcode a Windows path:
 - CONFIG: <user home>/.scout/action-items-todo/config.json
 - STATE (dedupe + last scan): <user home>/.scout/action-items-todo/state.json
-Create the directory if missing. Write both files as UTF-8 JSON, atomically (temp file then rename). Always preserve unknown fields.
+Resolve <user home> at runtime (Node os.homedir(), $HOME, or %USERPROFILE% on Windows). Create the directory if missing. Write both files as UTF-8 JSON, atomically (temp file then rename). Always preserve unknown fields.
 
 == CONFIG SCHEMA ==
 {
@@ -28,7 +29,7 @@ Create the directory if missing. Write both files as UTF-8 JSON, atomically (tem
   "listName": str,                  // the Microsoft To Do list tasks are written to
   "frequency": str,                 // natural-language interval, e.g. "every 30 minutes"
   "schedule": "24/7" | "weekdays-allhours" | "workhours" | str,
-  "timeZone": str,                  // IANA zone, from the machine
+  "timeZone": str,                  // IANA zone name, e.g. "Europe/Berlin"
   "language": "en",                 // task titles are always written in this language
   "owners": { "customers": [str], "workstreams": [str] },   // optional, may be empty
   "excludedChats": [str],           // chat/channel names to always ignore
@@ -46,7 +47,7 @@ Create the directory if missing. Write both files as UTF-8 JSON, atomically (tem
 Run SETUP automatically whenever CONFIG is missing or setupCompleted is null. Never run a scan before SETUP completes.
 
 1. Call workiq_get_my_profile and fill identity. If it fails, say so and stop; the skill cannot target asks without knowing who the user is.
-2. Read the machine time zone (PowerShell Get-TimeZone) and store the IANA name.
+2. Read the machine time zone as an IANA name with a cross-platform runtime API: Intl.DateTimeFormat().resolvedOptions().timeZone, e.g. `node -p "Intl.DateTimeFormat().resolvedOptions().timeZone"`. Do NOT use PowerShell Get-TimeZone: on Windows it returns a Windows zone ID such as "W. Europe Standard Time", which is not an IANA name and will not match the format the rest of the skill expects. If the lookup fails, ask the user for their IANA zone rather than guessing.
 3. Read the user's existing lists with workiq_list_task_lists, then ask QUESTION 1 with m_ask_user, free-text mode, inputHint "list name, e.g. Work":
    "Which Microsoft To Do list should captured action items go into?"
    Show the existing list names in the assistant message BEFORE the call so the user can pick one or name a new one. After the reply: if the list does not exist, confirm creation, then workiq_create_task_list.

--- a/submissions/action-items-todo/metadata.json
+++ b/submissions/action-items-todo/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Action Items to To Do",
+  "description": "Watches your Teams chats, meeting transcripts, and Outlook mail for things people actually asked you to do, and files each one as a Microsoft To Do task with a due date, priority, and source link.",
+  "platforms": ["Scout"],
+  "tags": [
+    "productivity",
+    "automation",
+    "tasks",
+    "teams",
+    "email",
+    "meetings",
+    "microsoft-365",
+    "action-items"
+  ],
+  "author": "Matteo Pagani",
+  "authorUrl": "https://github.com/qmatteoq",
+  "version": "1.0.0",
+  "createdAt": "2026-08-19",
+  "updatedAt": "2026-08-19"
+}


### PR DESCRIPTION
## What this adds

`submissions/action-items-todo/`, a Scout skill that watches Teams chats, meeting transcripts, and Outlook mail for things people have asked you to do, then files each one as a Microsoft To Do task with a due date, importance, owner tagging, and a link back to the source.

## Why

Asks turn up in three different places, and the ones I lose are almost never the urgent ones. A "when you get a chance, could you look at this?" in a 1:1 chat carries no deadline and stops existing the moment it scrolls off screen.

The skill only captures asks made **to** you. It ignores promises you make to other people, which is a separate problem with different failure modes, and combining them in one list makes both harder to act on.

## First-run setup

The skill hardcodes nothing about the person running it. On first use a wizard asks three questions, writes a config file, and creates the recurring automation:

1. Which To Do list to write to. Existing lists are shown, and a new name creates the list.
2. How often to scan: 15 minutes, 30 minutes, hourly, or every 2 hours.
3. When to scan: around the clock, weekdays only, weekday working hours, or describe your own.

## Capture rules

An action item is anything asking you to do, decide, respond, review, attend, prepare, or follow up. Urgency isn't part of the test, so tentative and far-future asks still count.

The ask has to be aimed at you. That means you're named, you're @mentioned, it arrived in a 1:1, or the conversation around it clearly puts the item on your plate. The skill skips generic group asks, FYIs, status updates and newsletters, and it never reads "this is your topic area" as ownership.

Titles come out in English whatever language the source was in. Owner tagging (`Customer:` / `Workstream:`) gets left off whenever the evidence is thin.

## Validation

`npm run check:submissions` passes: 91 submissions, nothing written.

## Checklist

- [x] One submission folder, one unpacked payload
- [x] `SKILL.md` frontmatter `name` matches the folder slug
- [x] Agent-facing description in `SKILL.md`, catalog description in `metadata.json`
- [x] `README.md` is human-facing only, no stray docs beside the payload
- [x] No personal paths, names, tenant identifiers or customer names in the bundled files
