### PR TITLE
Add explainer video skill

### DIFF
--- a/submissions/explainer-video/README.md
+++ b/submissions/explainer-video/README.md
@@ -1,0 +1,64 @@
+# explainer-video — Cowork skill
+
+Produces narrated, captioned 1080p explainer videos (MP4) that teach a concept, tool, process or
+policy. Researches the subject where facts matter, generates office b-roll, frames screenshots you
+supply, records a voiceover, and cuts the scenes to the narration.
+
+## What's in the skill
+
+```
+explainer-video/
+├─ SKILL.md                  the skill itself (instructions + guardrails)
+└─ scripts/
+   ├─ compose_cards.py       builds the 1920x1080 cards from a storyboard JSON
+   └─ render_video.py        aligns scenes to the narration, adds motion, burns in captions
+```
+
+## Install
+
+**Option A — OneDrive (easiest).** Download the skill bundle, unzip it, and copy the whole
+`explainer-video` folder into your
+Cowork folder in OneDrive, under `skills/`, so you end up with:
+
+```
+Documents/Cowork/skills/explainer-video/SKILL.md
+Documents/Cowork/skills/explainer-video/scripts/...
+```
+
+It is available in your next Cowork session — no other setup needed.
+
+**Option B — ask Copilot.** Attach the downloaded bundle in a Cowork chat and say
+"install this skill for me".
+
+**Sharing with a colleague:** send them the downloaded bundle and they follow Option A in their
+own OneDrive. The folder name must stay `explainer-video` — it has to match the `name` inside
+SKILL.md.
+
+## Use it
+
+Just ask for a video:
+
+- "make a video explaining our expenses policy"
+- "create an explainer video about [topic] for new starters"
+- "turn this into a two-minute video walkthrough" (attach screenshots)
+
+It asks one short round of questions (audience, length, dark or light style, screenshots), then
+shows you the narration script and scene list for approval before rendering. Allow roughly 20
+minutes end to end; the render itself is 10-15 of those.
+
+## What it needs
+
+Runs inside Cowork with no extra installation: Python with Pillow, ffmpeg, and the Copilot tools
+for image generation, narration and web research. The bundled scripts are called by the skill —
+you never need to run them by hand.
+
+## Good to know
+
+- The narration script is always approved by you before anything renders.
+- Screenshots you attach are shown exactly as supplied — never redrawn or retouched.
+- People in the b-roll are generated and generic; no real likenesses, logos or licensed music.
+- Statistics, dates and quotes come from research or your own content, never invented.
+- Alongside the MP4 you also get the narration MP3 and the script text, so you can reword and
+  re-render without starting over.
+
+Quality score at packaging time: 93/100 (Excellent).

--- a/submissions/explainer-video/SKILL.md
+++ b/submissions/explainer-video/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: explainer-video
+description: |
+  Produces narrated educational explainer videos (MP4, 1080p, burned-in captions) that teach a
+  concept, tool, process or policy — researching the subject where facts matter, generating office
+  b-roll, and framing screenshots the user attaches. Use when the user asks to "make a video",
+  "create an explainer video", "produce a training video", "a video explaining X", "turn this into
+  a video", "video walkthrough", "demo video", "record a narrated overview", or asks to change a
+  video this skill produced ("re-render with a longer script", "swap the b-roll"). Always writes
+  the narration script and scene list and waits for approval before rendering. Do NOT use for
+  slide decks with no narration or video (use pptx), for standalone images (use image-operations),
+  or for audio-only podcasts (use PodcastGenerate directly).
+cowork:
+  category: communication
+  icon: Video
+---
+
+# Explainer Video
+
+Turns a subject under discussion into a narrated, captioned MP4 that explains it. The output is a
+finished video in `output/`, not a deck and not a script.
+
+## When NOT to Use
+
+- **Slides for live presenting** → `pptx`. A deck is not a video.
+- **A single image, diagram or infographic** → `image-operations` / `pptx`.
+- **Audio only** (podcast, briefing) → call `host-PodcastGenerate` directly.
+- **A written explainer** (SOP, guide, one-pager) → `docx`.
+- **Marketing film, live action, real people's likenesses, licensed footage or music** — not
+  possible here. Say so plainly and offer the b-roll style this skill can do.
+
+## Workflow
+
+### 1. Frame the subject (one short round)
+
+Establish, from the conversation first and only then by asking: **subject**, **audience**
+(newcomer / practitioner / exec), **target length** (default ~2 minutes ≈ 6-8 beats), and the
+**angle** ("when to use each option", "how it works", "what changed"). Use `core-AskUserQuestion`
+once — never a chain of questions.
+
+Always ask the **visual style** in that same card: `dark` (navy slides, colour-coded sections,
+photographic b-roll) or `light` (white slides, brand accents, sparing photography).
+
+Ask whether they have **screenshots** to include if the subject is a product, tool or UI walkthrough.
+
+### 2. Gather (only what the video actually needs)
+
+- **Research when it matters** — external facts, product capabilities, statistics, "what's new":
+  use `host-web_search` / `host-web_fetch`, or the `deep-research-agent` when claims need citing.
+  Skip research entirely when the subject is already covered by this conversation or the user's
+  own content. Never research a topic the user has already explained.
+- **Internal subjects** — pull from `m365_search-SearchM365`, `sharepoint_onedrive-ReadFileContent`,
+  meeting transcripts. Ground every internal claim in what those return.
+- **Screenshots** — `Glob input/**/*` and check any `<attached_files>` block. Screenshots are used
+  **as supplied**: framed, optionally box-highlighted, never regenerated or redrawn, so the product
+  UI stays truthful. Note any UI text you rely on in narration so it matches the pixels.
+
+### 3. Write the script — and STOP for approval (mandatory gate)
+
+Build a storyboard: one **beat** per scene, each with its narration sentence(s). Rendering takes
+~10-15 minutes, so the script is approved before any pixels are generated.
+
+Show the user, inline in chat: the beat list (title + one-line narration each), the estimated
+runtime (≈ 150 spoken words per minute), and the style chosen. Ask for a go-ahead or edits. Do not
+generate images, audio or video until they approve.
+
+Write the approved storyboard to `working/storyboard.json`:
+
+```json
+{
+  "style": "dark",
+  "beats": [
+    {"kind": "title", "photo": "working/broll-wide.png", "title": "…", "sub": "…",
+     "foot": "…", "narration": "…"},
+    {"kind": "section", "accent": "blue", "tag": "1 / 4", "photo": "working/broll-1.png",
+     "title": "…", "kicker": "…", "bullets": ["…", "…", "…"], "example": "\u201c…\u201d",
+     "narration": "…"},
+    {"kind": "screenshot", "accent": "green", "image": "input/shot1.png", "title": "…",
+     "caption": "…", "callouts": [{"x": 40, "y": 120, "w": 400, "h": 90}], "narration": "…"},
+    {"kind": "table", "photo": "working/broll-team.png", "title": "…",
+     "rows": [{"left": "…", "right": "…", "accent": "blue"}], "narration": "…"},
+    {"kind": "closing", "photo": "working/broll-team.png", "title": "…", "sub": "…",
+     "foot": "…", "narration": "…"}
+  ]
+}
+```
+
+Accents: `blue`, `green`, `purple`, `orange`, `teal`, `red` — one per section, reused by its cards.
+
+### 4. Generate the b-roll
+
+One photo per beat that has no screenshot, via `host-ImageGenerate` (`quality="medium"`,
+`orientation="landscape"`, `size="large"`, `destination="working"`). Issue the calls in parallel —
+each takes ~2 minutes. Prompt pattern that works:
+
+> Cinematic corporate b-roll photograph: <specific office scene with people>, modern office,
+> <colour> tones, soft daylight, shallow depth of field, professional stock-photography look,
+> screen content abstract and not legible, no text or logos.
+
+Vary the scene, the people and the colour per section so the video does not repeat itself. Never
+ask for real individuals, real brand logos, or legible on-screen text (the model misspells it).
+
+### 5. Record the narration
+
+`host-PodcastGenerate` with `format="single_host"` and **one turn per beat, in beat order** — the
+renderer detects the pauses between turns to cut the scenes. Keep each turn conversational and
+self-contained; write numbers and symbols as words. It returns the MP3 path and duration.
+
+### 6. Compose and render
+
+```bash
+python scripts/compose_cards.py working/storyboard.json --out working/cards
+python scripts/render_video.py working/storyboard.json --cards working/cards \
+  --audio output/<narration>.mp3 --out working/<name>.mp4
+```
+
+`compose_cards.py` builds 1920x1080 cards (section beats get a b-roll interlude plus a detail
+card). `render_video.py` aligns scene changes to the narration pauses, applies slow Ken Burns
+motion to photo scenes, crossfades, generates captions from the narration and burns them in.
+Rendering takes 10-15 minutes — run it with a long `initial_wait` and wait for it, never abandon
+it mid-flight.
+
+Publish the finished file:
+
+```
+host-CopyArtifact(surface="output", source="working/<name>.mp4", destination="<name>.mp4")
+```
+
+Then `Glob output/**/*` to confirm it landed before telling the user it is ready.
+
+## Output Format
+
+Deliver to `output/`: the **MP4** (1080p, H.264 + AAC, burned-in captions), plus the narration MP3
+and script text that `host-PodcastGenerate` already writes there. In chat, state the exact
+filename, the true runtime, and what each section covers — then offer the likely next edits
+(different b-roll, longer script, add screenshots, a light-style version).
+
+## Guardrails
+
+- **The script gate is not optional.** Never generate images, audio or video before the user
+  approves the beat list.
+- **On-screen claims must be true of the video itself.** If a card says "a two-minute guide", the
+  render must be about two minutes. Check the reported duration against every claim before
+  publishing, and re-cut the card rather than shipping a mismatch.
+- **Never invent facts.** Statistics, quotes, dates, product capabilities and customer names come
+  from research or the user's content, or they do not appear. Where something is genuinely unknown,
+  leave a visible `[placeholder]` on the card and say so — never fill it with a plausible number.
+- **Screenshots are evidence, not art.** Show them as supplied. Never regenerate, retouch or
+  "clean up" a product UI, and never fabricate a screenshot of a UI the user did not provide.
+- **People in b-roll are synthetic and generic.** Never generate a real person's likeness, a real
+  brand's logo, or copyrighted characters — offer an original equivalent instead.
+- **Reproduce nothing copyrighted** in narration: no song lyrics, no verbatim article passages, no
+  licensed music. Narration is original writing; quote a researched source in under 15 words with
+  attribution, or paraphrase.
+- **Say what failed.** If narration, image generation or the render fails after one retry, tell the
+  user which part is missing rather than shipping a silent or half-built video.

--- a/submissions/explainer-video/SKILL.md
+++ b/submissions/explainer-video/SKILL.md
@@ -24,7 +24,7 @@ finished video in `output/`, not a deck and not a script.
 
 - **Slides for live presenting** → `pptx`. A deck is not a video.
 - **A single image, diagram or infographic** → `image-operations` / `pptx`.
-- **Audio only** (podcast, briefing) → call `host-PodcastGenerate` directly.
+- **Audio only** (podcast, briefing) → call `PodcastGenerate` directly.
 - **A written explainer** (SOP, guide, one-pager) → `docx`.
 - **Marketing film, live action, real people's likenesses, licensed footage or music** — not
   possible here. Say so plainly and offer the b-roll style this skill can do.

--- a/submissions/explainer-video/SKILL.md
+++ b/submissions/explainer-video/SKILL.md
@@ -35,7 +35,7 @@ finished video in `output/`, not a deck and not a script.
 
 Establish, from the conversation first and only then by asking: **subject**, **audience**
 (newcomer / practitioner / exec), **target length** (default ~2 minutes ≈ 6-8 beats), and the
-**angle** ("when to use each option", "how it works", "what changed"). Use `core-AskUserQuestion`
+**angle** ("when to use each option", "how it works", "what changed"). Use `AskUserQuestion`
 once — never a chain of questions.
 
 Always ask the **visual style** in that same card: `dark` (navy slides, colour-coded sections,
@@ -46,10 +46,10 @@ Ask whether they have **screenshots** to include if the subject is a product, to
 ### 2. Gather (only what the video actually needs)
 
 - **Research when it matters** — external facts, product capabilities, statistics, "what's new":
-  use `host-web_search` / `host-web_fetch`, or the `deep-research-agent` when claims need citing.
+  use `web_search` / `web_fetch`, or the `deep-research-agent` when claims need citing.
   Skip research entirely when the subject is already covered by this conversation or the user's
   own content. Never research a topic the user has already explained.
-- **Internal subjects** — pull from `m365_search-SearchM365`, `sharepoint_onedrive-ReadFileContent`,
+- **Internal subjects** — pull from `SearchM365`, `ReadFileContent`,
   meeting transcripts. Ground every internal claim in what those return.
 - **Screenshots** — `Glob input/**/*` and check any `<attached_files>` block. Screenshots are used
   **as supplied**: framed, optionally box-highlighted, never regenerated or redrawn, so the product
@@ -89,7 +89,7 @@ Accents: `blue`, `green`, `purple`, `orange`, `teal`, `red` — one per section,
 
 ### 4. Generate the b-roll
 
-One photo per beat that has no screenshot, via `host-ImageGenerate` (`quality="medium"`,
+One photo per beat that has no screenshot, via `ImageGenerate` (`quality="medium"`,
 `orientation="landscape"`, `size="large"`, `destination="working"`). Issue the calls in parallel —
 each takes ~2 minutes. Prompt pattern that works:
 
@@ -102,7 +102,7 @@ ask for real individuals, real brand logos, or legible on-screen text (the model
 
 ### 5. Record the narration
 
-`host-PodcastGenerate` with `format="single_host"` and **one turn per beat, in beat order** — the
+`PodcastGenerate` with `format="single_host"` and **one turn per beat, in beat order** — the
 renderer detects the pauses between turns to cut the scenes. Keep each turn conversational and
 self-contained; write numbers and symbols as words. It returns the MP3 path and duration.
 
@@ -123,7 +123,7 @@ it mid-flight.
 Publish the finished file:
 
 ```
-host-CopyArtifact(surface="output", source="working/<name>.mp4", destination="<name>.mp4")
+CopyArtifact(surface="output", source="working/<name>.mp4", destination="<name>.mp4")
 ```
 
 Then `Glob output/**/*` to confirm it landed before telling the user it is ready.
@@ -131,7 +131,7 @@ Then `Glob output/**/*` to confirm it landed before telling the user it is ready
 ## Output Format
 
 Deliver to `output/`: the **MP4** (1080p, H.264 + AAC, burned-in captions), plus the narration MP3
-and script text that `host-PodcastGenerate` already writes there. In chat, state the exact
+and script text that `PodcastGenerate` already writes there. In chat, state the exact
 filename, the true runtime, and what each section covers — then offer the likely next edits
 (different b-roll, longer script, add screenshots, a light-style version).
 

--- a/submissions/explainer-video/metadata.json
+++ b/submissions/explainer-video/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Explainer Video",
+  "description": "Create narrated, captioned 1080p explainer videos with researched scripts, generated b-roll, and supplied screenshots.",
+  "platforms": ["Cowork"],
+  "tags": ["video", "education", "training", "communication"],
+  "author": "Damien Bird",
+  "authorUrl": "https://github.com/DamoBird365",
+  "version": "1.0.0",
+  "createdAt": "2026-08-20",
+  "updatedAt": "2026-08-20"
+}

--- a/submissions/explainer-video/scripts/compose_cards.py
+++ b/submissions/explainer-video/scripts/compose_cards.py
@@ -18,8 +18,26 @@ import argparse, json, os, textwrap
 from PIL import Image, ImageDraw, ImageFont, ImageFilter
 
 W, H = 1920, 1080
-FB = "/usr/share/fonts/metric-compat/Carlito-Bold.ttf"
-FR = "/usr/share/fonts/metric-compat/Carlito-Regular.ttf"
+
+
+def resolve_font(weight):
+    filename = f"Carlito-{weight}.ttf"
+    candidates = [
+        f"/usr/share/fonts/metric-compat/{filename}",
+        f"/usr/share/fonts/truetype/crosextra/{filename}",
+        f"/usr/share/fonts/truetype/carlito/{filename}",
+        f"/usr/share/fonts/truetype/liberation2/LiberationSans{'-Bold' if weight == 'Bold' else ''}.ttf",
+    ]
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    raise RuntimeError(
+        f"Required {weight.lower()} font not found. Install Carlito or Liberation Sans."
+    )
+
+
+FB = resolve_font("Bold")
+FR = resolve_font("Regular")
 
 ACCENTS = {"blue": (0, 120, 212), "green": (22, 138, 40), "purple": (146, 92, 224),
            "orange": (214, 96, 24), "teal": (0, 140, 150), "red": (196, 60, 60)}
@@ -192,7 +210,12 @@ def main():
     ap.add_argument("--out", default="working/cards")
     a = ap.parse_args()
     sb = json.load(open(a.storyboard))
-    th = THEMES[sb.get("style", "dark")]
+    style = sb.get("style", "dark")
+    if style not in THEMES:
+        raise ValueError(
+            f"Unsupported storyboard style {style!r}; choose one of: {', '.join(THEMES)}"
+        )
+    th = THEMES[style]
     os.makedirs(a.out, exist_ok=True)
     made = []
     for i, beat in enumerate(sb["beats"], 1):

--- a/submissions/explainer-video/scripts/compose_cards.py
+++ b/submissions/explainer-video/scripts/compose_cards.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Compose the still cards for an explainer video from a JSON storyboard.
+
+Usage:  python compose_cards.py storyboard.json --out working/cards
+
+Every beat in the storyboard becomes one or two 1920x1080 PNG cards:
+  title      -> 1 card  (full-bleed photo, centred title)
+  section    -> 2 cards (b-roll lower-third, then a detail card with the photo
+                         panelled down the right-hand side)
+  screenshot -> 1 card  (user-supplied screenshot, framed, never redrawn)
+  table      -> 1 card  (blurred photo background, coloured recap rows)
+  closing    -> 1 card  (same treatment as title)
+
+The card filenames are printed in order, one per line, so render_video.py can
+consume them.
+"""
+import argparse, json, os, textwrap
+from PIL import Image, ImageDraw, ImageFont, ImageFilter
+
+W, H = 1920, 1080
+FB = "/usr/share/fonts/metric-compat/Carlito-Bold.ttf"
+FR = "/usr/share/fonts/metric-compat/Carlito-Regular.ttf"
+
+ACCENTS = {"blue": (0, 120, 212), "green": (22, 138, 40), "purple": (146, 92, 224),
+           "orange": (214, 96, 24), "teal": (0, 140, 150), "red": (196, 60, 60)}
+
+THEMES = {
+    "dark":  dict(bg=(16, 24, 40), card=(26, 37, 60), text=(255, 255, 255),
+                  muted=(176, 190, 212), veil=(8, 12, 22), veil_top=70, veil_bot=110),
+    "light": dict(bg=(245, 247, 250), card=(255, 255, 255), text=(23, 30, 44),
+                  muted=(90, 103, 124), veil=(255, 255, 255), veil_top=40, veil_bot=70),
+}
+
+
+def font(path, size):
+    return ImageFont.truetype(path, size)
+
+
+def accent_of(beat):
+    a = beat.get("accent", "blue")
+    return ACCENTS.get(a, ACCENTS["blue"]) if isinstance(a, str) else tuple(a)
+
+
+def cover(path, w, h):
+    im = Image.open(path).convert("RGB")
+    r = max(w / im.width, h / im.height)
+    im = im.resize((max(1, int(im.width * r + 1)), max(1, int(im.height * r + 1))), Image.LANCZOS)
+    l, t = (im.width - w) // 2, (im.height - h) // 2
+    return im.crop((l, t, l + w, t + h))
+
+
+def veil(img, th, top, bottom):
+    g = Image.new("L", (1, H))
+    for y in range(H):
+        g.putpixel((0, y), int(top + (bottom - top) * (y / H)))
+    return Image.composite(Image.new("RGB", img.size, th["veil"]), img, g.resize(img.size))
+
+
+def scrim(img, th, start=470, strength=300, cap=235):
+    g = Image.new("L", (1, H))
+    for y in range(H):
+        g.putpixel((0, y), 0 if y < start else int(min(cap, (y - start) / (H - start) * strength)))
+    return Image.composite(Image.new("RGB", (W, H), th["veil"]), img, g.resize((W, H)))
+
+
+def base(th, accent):
+    img = Image.new("RGB", (W, H), th["bg"])
+    d = ImageDraw.Draw(img)
+    d.rectangle([0, 0, W, 12], fill=accent)
+    return img, d
+
+
+def title_card(beat, th):
+    accent = accent_of(beat)
+    if beat.get("photo"):
+        img = veil(cover(beat["photo"], W, H), th, 170, 205).filter(ImageFilter.GaussianBlur(2))
+    else:
+        img = Image.new("RGB", (W, H), th["bg"])
+    d = ImageDraw.Draw(img)
+    d.rectangle([0, 0, W, 12], fill=accent)
+    d.text((W // 2, 400), beat["title"], font=font(FB, 100), fill=th["text"], anchor="mm")
+    if beat.get("sub"):
+        d.text((W // 2, 545), beat["sub"], font=font(FR, 44), fill=th["text"], anchor="mm")
+    d.rectangle([W // 2 - 130, 635, W // 2 + 130, 641], fill=accent)
+    if beat.get("foot"):
+        d.text((W // 2, 725), beat["foot"], font=font(FR, 38), fill=th["muted"], anchor="mm")
+    return img
+
+
+def broll_card(beat, th):
+    accent = accent_of(beat)
+    img = scrim(veil(cover(beat["photo"], W, H), th, 60, 60), th)
+    d = ImageDraw.Draw(img)
+    d.rectangle([0, 0, W, 12], fill=accent)
+    d.rectangle([140, 700, 152, 940], fill=accent)
+    if beat.get("tag"):
+        d.text((196, 700), beat["tag"], font=font(FB, 32), fill=accent)
+    d.text((196, 752), beat["title"], font=font(FB, 78), fill=th["text"])
+    if beat.get("kicker"):
+        d.text((196, 866), beat["kicker"], font=font(FR, 46), fill=th["text"])
+    return img
+
+
+def content_card(beat, th):
+    accent = accent_of(beat)
+    img, d = base(th, accent)
+    if beat.get("photo"):
+        pw = 780
+        img.paste(veil(cover(beat["photo"], pw, H), th, th["veil_top"], th["veil_bot"]), (W - pw, 0))
+        grad = Image.linear_gradient("L").rotate(270, expand=True).resize((360, H))
+        img.paste(Image.new("RGB", (360, H), th["bg"]), (W - pw, 0), grad)
+        d = ImageDraw.Draw(img)
+        d.rectangle([0, 0, W, 12], fill=accent)
+    if beat.get("tag"):
+        d.text((140, 120), beat["tag"], font=font(FB, 32), fill=accent)
+    y = 176
+    for line in textwrap.wrap(beat["title"], 26):
+        d.text((140, y), line, font=font(FB, 72), fill=th["text"])
+        y += 84
+    if beat.get("kicker"):
+        d.text((140, y + 18), beat["kicker"], font=font(FR, 42), fill=th["muted"])
+        y += 130
+    else:
+        y += 70
+    for b in beat.get("bullets", []):
+        lines = textwrap.wrap(b, 40)
+        d.ellipse([146, y + 18, 168, y + 40], fill=accent)
+        for i, line in enumerate(lines):
+            d.text((205, y + i * 52), line, font=font(FR, 44), fill=th["text"])
+        y += 52 * len(lines) + 46
+    if beat.get("example"):
+        d.rounded_rectangle([140, 900, 1120, 1000], 16, fill=th["card"])
+        d.rectangle([140, 900, 150, 1000], fill=accent)
+        ex = textwrap.wrap(beat["example"], 52)
+        d.text((186, 950 - (len(ex) - 1) * 22), "\n".join(ex), font=font(FR, 36),
+               fill=th["text"], anchor="lm")
+    return img
+
+
+def screenshot_card(beat, th):
+    """Frame a user-supplied screenshot. The pixels are never regenerated."""
+    accent = accent_of(beat)
+    img, d = base(th, accent)
+    shot = Image.open(beat["image"]).convert("RGB")
+    box_w, box_h = 1500, 720
+    r = min(box_w / shot.width, box_h / shot.height)
+    shot = shot.resize((int(shot.width * r), int(shot.height * r)), Image.LANCZOS)
+    x, y = (W - shot.width) // 2, 250 + (box_h - shot.height) // 2
+    d.rounded_rectangle([x - 14, y - 14, x + shot.width + 14, y + shot.height + 14], 14,
+                        fill=th["card"], outline=accent, width=3)
+    img.paste(shot, (x, y))
+    d = ImageDraw.Draw(img)
+    if beat.get("tag"):
+        d.text((140, 110), beat["tag"], font=font(FB, 32), fill=accent)
+    d.text((W // 2, 180), beat["title"], font=font(FB, 62), fill=th["text"], anchor="mm")
+    if beat.get("caption"):
+        d.text((W // 2, 1020), beat["caption"], font=font(FR, 38), fill=th["muted"], anchor="mm")
+    for cal in beat.get("callouts", []):     # {"x","y","w","h"} in screenshot pixels, pre-scale
+        d.rounded_rectangle([x + cal["x"] * r, y + cal["y"] * r,
+                             x + (cal["x"] + cal["w"]) * r, y + (cal["y"] + cal["h"]) * r],
+                            8, outline=accent, width=5)
+    return img
+
+
+def table_card(beat, th):
+    accent = accent_of(beat)
+    if beat.get("photo"):
+        img = veil(cover(beat["photo"], W, H).filter(ImageFilter.GaussianBlur(9)), th, 205, 225)
+    else:
+        img = Image.new("RGB", (W, H), th["bg"])
+    d = ImageDraw.Draw(img)
+    d.rectangle([0, 0, W, 12], fill=accent)
+    d.text((W // 2, 170), beat["title"], font=font(FB, 80), fill=th["text"], anchor="mm")
+    y, rows = 300, beat.get("rows", [])
+    for row in rows:
+        col = ACCENTS.get(row.get("accent", "blue"), accent)
+        d.rounded_rectangle([200, y, W - 200, y + 130], 18, fill=th["card"])
+        d.rectangle([200, y, 212, y + 130], fill=col)
+        d.text((256, y + 65), row["left"], font=font(FR, 44), fill=th["text"], anchor="lm")
+        d.text((W - 256, y + 65), row["right"], font=font(FB, 44), fill=col, anchor="rm")
+        y += 158
+    return img
+
+
+BUILDERS = {"title": title_card, "closing": title_card, "screenshot": screenshot_card,
+            "table": table_card, "content": content_card}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("storyboard")
+    ap.add_argument("--out", default="working/cards")
+    a = ap.parse_args()
+    sb = json.load(open(a.storyboard))
+    th = THEMES[sb.get("style", "dark")]
+    os.makedirs(a.out, exist_ok=True)
+    made = []
+    for i, beat in enumerate(sb["beats"], 1):
+        kind = beat.get("kind", "content")
+        if kind == "section":
+            if beat.get("photo"):
+                p = f"{a.out}/beat{i:02d}a.png"
+                broll_card(beat, th).save(p)
+                made.append(p)
+            p = f"{a.out}/beat{i:02d}b.png"
+            content_card(beat, th).save(p)
+            made.append(p)
+        else:
+            p = f"{a.out}/beat{i:02d}.png"
+            BUILDERS[kind](beat, th).save(p)
+            made.append(p)
+    print("\n".join(made))
+
+
+if __name__ == "__main__":
+    main()

--- a/submissions/explainer-video/scripts/render_video.py
+++ b/submissions/explainer-video/scripts/render_video.py
@@ -25,8 +25,16 @@ def run(cmd, **kw):
 
 
 def audio_duration(path):
-    out = subprocess.run([FFMPEG, "-i", path], capture_output=True, text=True).stderr
+    try:
+        out = subprocess.run(
+            [FFMPEG, "-i", path], capture_output=True, text=True
+        ).stderr
+    except FileNotFoundError as exc:
+        raise RuntimeError("ffmpeg is required to render the explainer video.") from exc
     m = re.search(r"Duration: (\d+):(\d+):([\d.]+)", out)
+    if not m:
+        detail = out.strip()[-500:] or "ffmpeg returned no diagnostic output"
+        raise RuntimeError(f"Could not read audio duration from {path!r}: {detail}")
     h, mi, s = m.groups()
     return int(h) * 3600 + int(mi) * 60 + float(s)
 

--- a/submissions/explainer-video/scripts/render_video.py
+++ b/submissions/explainer-video/scripts/render_video.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Assemble narration + cards into a finished 1080p explainer video.
+
+Usage:
+  python render_video.py storyboard.json --cards working/cards \
+      --audio output/narration.mp3 --out working/explainer.mp4 [--no-captions]
+
+Timing: the narration is ONE audio file whose turns match the storyboard beats
+1:1. The script finds the silent gaps between turns and cuts on them, so scene
+changes land exactly on the narration. If the gap count does not match the beat
+count it falls back to splitting proportionally by narration length.
+
+Captions are generated from the beat narration text and burned in.
+"""
+import argparse, json, os, re, subprocess, textwrap
+
+FPS = 30
+XFADE = 0.6
+BROLL_SHARE = 0.40          # b-roll interlude share of a section beat
+FFMPEG = "ffmpeg"
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, check=True, capture_output=True, text=True, **kw)
+
+
+def audio_duration(path):
+    out = subprocess.run([FFMPEG, "-i", path], capture_output=True, text=True).stderr
+    m = re.search(r"Duration: (\d+):(\d+):([\d.]+)", out)
+    h, mi, s = m.groups()
+    return int(h) * 3600 + int(mi) * 60 + float(s)
+
+
+def silence_boundaries(path, want, noise=-35, mind=0.45):
+    """Midpoints of the silent gaps between narration turns."""
+    out = subprocess.run(
+        [FFMPEG, "-hide_banner", "-i", path, "-af",
+         f"silencedetect=noise={noise}dB:d={mind}", "-f", "null", "-"],
+        capture_output=True, text=True).stderr
+    starts = [float(x) for x in re.findall(r"silence_start: ([\d.]+)", out)]
+    ends = [float(x) for x in re.findall(r"silence_end: ([\d.]+)", out)]
+    total = audio_duration(path)
+    gaps = [(s, e) for s, e in zip(starts, ends) if s > 0.5 and e < total - 0.5]
+    if len(gaps) != want:
+        return None
+    return [(s + e) / 2 for s, e in gaps]
+
+
+def beat_windows(sb, audio):
+    total = audio_duration(audio)
+    beats = sb["beats"]
+    cuts = silence_boundaries(audio, len(beats) - 1)
+    if cuts is None:                                    # proportional fallback
+        weights = [max(20, len(b.get("narration", ""))) for b in beats]
+        acc, cuts, s = sum(weights), [], 0.0
+        for w in weights[:-1]:
+            s += w / acc * total
+            cuts.append(s)
+    starts = [0.0] + cuts
+    ends = cuts + [total]
+    return list(zip(starts, ends)), total
+
+
+def srt_time(t):
+    h, rem = divmod(max(0.0, t), 3600)
+    m, s = divmod(rem, 60)
+    return f"{int(h):02d}:{int(m):02d}:{s:06.3f}".replace(".", ",")
+
+
+def write_srt(sb, windows, path):
+    cues, n = [], 0
+    for beat, (s, e) in zip(sb["beats"], windows):
+        text = " ".join(beat.get("narration", "").split())
+        if not text:
+            continue
+        words = text.split()
+        chunks, cur = [], []
+        for w in words:
+            cur.append(w)
+            if len(cur) >= 9 or w.endswith((".", "?", "!", ":")):
+                chunks.append(" ".join(cur))
+                cur = []
+        if cur:
+            chunks.append(" ".join(cur))
+        span = (e - s) / max(1, sum(len(c) for c in chunks))
+        t = s
+        for c in chunks:
+            d = len(c) * span
+            n += 1
+            cues.append(f"{n}\n{srt_time(t)} --> {srt_time(min(t + d, e))}\n"
+                        f"{chr(10).join(textwrap.wrap(c, 46))}\n")
+            t += d
+    open(path, "w").write("\n".join(cues))
+    return path
+
+
+def segments(sb, windows, cards_dir):
+    """(card_path, duration, motion) in playback order, matching compose_cards."""
+    segs, idx = [], 0
+    for i, (beat, (s, e)) in enumerate(zip(sb["beats"], windows), 1):
+        dur, kind = e - s, beat.get("kind", "content")
+        if kind == "section" and beat.get("photo"):
+            segs.append((f"{cards_dir}/beat{i:02d}a.png", dur * BROLL_SHARE, "zoom"))
+            segs.append((f"{cards_dir}/beat{i:02d}b.png", dur * (1 - BROLL_SHARE), "still"))
+        elif kind == "section":
+            segs.append((f"{cards_dir}/beat{i:02d}b.png", dur, "still"))
+        else:
+            motion = "zoom" if kind in ("title", "closing") and beat.get("photo") else "still"
+            segs.append((f"{cards_dir}/beat{i:02d}.png", dur, motion))
+    for p, _, _ in segs:
+        if not os.path.exists(p):
+            raise SystemExit(f"missing card: {p} — run compose_cards.py first")
+    return segs
+
+
+def build(segs, audio, out, srt=None):
+    n = len(segs)
+    cmd = [FFMPEG, "-y"]
+    for i, (path, dur, _) in enumerate(segs):
+        cmd += ["-loop", "1", "-t", f"{dur + (XFADE if i < n - 1 else 0):.3f}", "-i", path]
+    cmd += ["-i", audio]
+
+    filt = []
+    for i, (path, dur, motion) in enumerate(segs):
+        clip = dur + (XFADE if i < n - 1 else 0)
+        frames = int(clip * FPS) + 2
+        if motion == "zoom":
+            z = 0.10 / frames
+            filt.append(f"[{i}:v]scale=3840:-1,zoompan=z='min(1.02+{z:.6f}*on,1.13)'"
+                        f":x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)':d={frames}:s=1920x1080:"
+                        f"fps={FPS},format=yuv420p,setsar=1[v{i}]")
+        else:
+            filt.append(f"[{i}:v]format=yuv420p,fps={FPS},setsar=1[v{i}]")
+    prev, off = "v0", 0.0
+    for i in range(1, n):
+        off += segs[i - 1][1]
+        filt.append(f"[{prev}][v{i}]xfade=transition=fade:duration={XFADE}"
+                    f":offset={off - XFADE / 2:.3f}[x{i}]")
+        prev = f"x{i}"
+    if srt:
+        style = ("FontName=Carlito,Fontsize=22,PrimaryColour=&H00FFFFFF,"
+                 "BorderStyle=3,Outline=1,Shadow=0,BackColour=&HB0000000,MarginV=48")
+        filt.append(f"[{prev}]subtitles={srt}:force_style='{style}'[vout]")
+        prev = "vout"
+
+    cmd += ["-filter_complex", ";".join(filt), "-map", f"[{prev}]", "-map", f"{n}:a",
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "21", "-pix_fmt", "yuv420p",
+            "-r", str(FPS), "-c:a", "aac", "-b:a", "192k", "-shortest", out]
+    subprocess.run(cmd, check=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("storyboard")
+    ap.add_argument("--cards", default="working/cards")
+    ap.add_argument("--audio", required=True)
+    ap.add_argument("--out", default="working/explainer.mp4")
+    ap.add_argument("--no-captions", action="store_true")
+    a = ap.parse_args()
+
+    sb = json.load(open(a.storyboard))
+    windows, total = beat_windows(sb, a.audio)
+    srt = None if a.no_captions else write_srt(sb, windows, "working/captions.srt")
+    build(segments(sb, windows, a.cards), a.audio, a.out, srt)
+    print(json.dumps({"output": a.out, "duration_seconds": round(total, 1),
+                      "captions": srt, "scenes": len(sb["beats"])}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the `explainer-video` Cowork skill as an unpacked gallery submission.

The skill creates narrated, captioned 1080p explainer videos using researched scripts, generated b-roll, supplied screenshots, and bundled Python rendering helpers.

## Validation

- `npm run check:submissions`
- `npm run build`
- `python -m py_compile submissions/explainer-video/scripts/compose_cards.py submissions/explainer-video/scripts/render_video.py`