### PR TITLE
Add clipchamp-video skill: narrated demo video recording (headless + …

### DIFF
--- a/submissions/clipchamp-video/README.md
+++ b/submissions/clipchamp-video/README.md
@@ -6,6 +6,7 @@ manually screen-recording or editing anything yourself.
 
 ## Before you start
 
+- **Windows only.** This skill drives PowerShell, Win32 window APIs, `msedge.exe`, and ffmpeg's `gdigrab` desktop capture — there's no macOS/Linux capture backend yet.
 - **Node.js + Playwright** (`npm install -g playwright`), **ffmpeg/ffprobe**, and
   **edge-tts** (`pip install edge-tts`) should be installed globally so every future
   run just works. The skill checks and installs these once if missing.
@@ -15,6 +16,20 @@ manually screen-recording or editing anything yourself.
 - Decide up front which agent/app you want demoed and roughly what it should show
   (an overview, a couple of live test prompts, etc.) — the more specific, the better
   the final narration.
+
+### One-time global installs
+
+**Install these ONCE, globally, so every future run has them without reinstalling.**
+Check each first; only install if missing. After changing PATH, refresh the *current*
+shell with `$env:Path = [Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [Environment]::GetEnvironmentVariable("Path","User")`
+(new shells pick it up automatically).
+
+| Need | Make it global (persist across runs) |
+| ---- | -------------- |
+| Node + Playwright (library) | Check: `node -e "require('playwright')"` via global root, or `npm ls -g playwright`. If missing: **`npm install -g playwright`** (global, not in a throwaway work dir). The scripts in `scripts/` resolve it automatically via `npm root -g` (see `scripts/require-playwright.js`) — you don't need to set `NODE_PATH` yourself. |
+| ffmpeg + ffprobe | Check: `ffmpeg -version`. If missing: `winget install --id Gyan.FFmpeg -e --accept-source-agreements --accept-package-agreements --disable-interactivity`, then **copy `ffmpeg.exe`/`ffprobe.exe` into `C:\Users\<user>\.copilot\bin` and add that folder to the User PATH** (`[Environment]::SetEnvironmentVariable("Path", $userPath + ";C:\Users\<user>\.copilot\bin", "User")`). The stable folder survives ffmpeg version bumps. |
+| edge-tts (Ava neural TTS, headless path) | Check: `python -c "import edge_tts"`. If missing: **`pip install edge-tts`** (user install is fine — `python -m edge_tts` then works in every run). For the bare `edge-tts` CLI, add the Python **Scripts** dir (e.g. `C:\Users\<user>\AppData\Roaming\Python\Python3XX\Scripts`) to the User PATH. Voice: `en-US-AvaNeural`. |
+| Logged-in browser | The MCP Playwright browser holds your session. Profile dir typically `C:\Users\<user>\AppData\Local\ms-playwright\mcp-msedge`, Edge at `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`. For a **different tenant**, **clone** your real Edge profile to a non-default `User Data` root and launch that with the matching `--profile-directory` — Playwright cannot attach to Edge's default data dir. See `SKILL.md`'s "Pick the right profile / tenant" section for the exact steps. |
 
 ## How to use it
 

--- a/submissions/clipchamp-video/README.md
+++ b/submissions/clipchamp-video/README.md
@@ -1,0 +1,51 @@
+# Clipchamp Narrated Demo Video
+
+Turn a live web app or Copilot Studio agent into a polished, narrated demo — real
+screen-flow footage (cursor, typing, live responses) under an AI voiceover — without
+manually screen-recording or editing anything yourself.
+
+## Before you start
+
+- **Node.js + Playwright** (`npm install -g playwright`), **ffmpeg/ffprobe**, and
+  **edge-tts** (`pip install edge-tts`) should be installed globally so every future
+  run just works. The skill checks and installs these once if missing.
+- A **logged-in browser session** for whatever you're recording (Copilot Studio, an
+  internal app, etc.) — the skill drives your real, authenticated session so it
+  captures the actual product, not a mocked one.
+- Decide up front which agent/app you want demoed and roughly what it should show
+  (an overview, a couple of live test prompts, etc.) — the more specific, the better
+  the final narration.
+
+## How to use it
+
+Ask for a demo video the way you'd ask a person: *"Record a demo of my Copilot Studio
+agent"*, *"make a narrated walkthrough of this app"*, *"turn this into a product demo
+video"*. The skill will:
+
+1. Ask you to pick an assembly path: **(A) headless** (ffmpeg + Ava neural TTS —
+   fast, deterministic, hands you a finished MP4) or **(B) Clipchamp web UI**
+   (slower, but leaves an editable Clipchamp project for hand-tweaking later).
+2. Drive a real browser against your logged-in session, record the actual screen
+   flow, and trim out dead time (auth screens, long tool-call waits) so the final
+   cut only shows the meaningful beats.
+3. Generate a natural-sounding voiceover (Ava neural voice) narrating what's on
+   screen, timed to the visible beats — not one long monotone block.
+4. Hand you back a finished MP4 (headless path) or a ready-to-tweak Clipchamp
+   project (UI path), named after your agent/product.
+
+## Good to know
+
+- The recorded frame is the **browser's internal viewport buffer**, not your visible
+  screen — so you can keep using your laptop while it records (headless path). The
+  one exception is the dual-capture mode (recording your own actions *and* the app
+  side-by-side), which does need the desktop free of other windows/notifications.
+- Copilot Studio's Build/Preview/Evaluate/Monitor switcher is a dropdown, not tabs —
+  the skill already knows to jump straight to the `/preview` URL rather than
+  clicking through menus.
+- If the recorded video shows your app content in a small corner with a lot of gray
+  padding around it, that's the browser window not filling the screen — the skill
+  crops and rescales this automatically during post-processing, but it's a good
+  sanity check to do yourself on a sample frame before narrating.
+- A demo full of red error cards from a sleeping backend is worse than no demo —
+  the skill tests one real prompt before the full recording run specifically to
+  catch this early.

--- a/submissions/clipchamp-video/SKILL.md
+++ b/submissions/clipchamp-video/SKILL.md
@@ -77,16 +77,7 @@ A slideshow of static screenshots is almost never what the user wants. They want
 
 ## Prerequisites
 
-**Install these ONCE, GLOBALLY, so every future chat has them without reinstalling.** Check each first; only install if missing. After changing PATH, refresh the *current* shell with `$env:Path = [Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [Environment]::GetEnvironmentVariable("Path","User")` (new chats pick it up automatically).
-
-| Need | Make it global (persist across chats) |
-| ---- | -------------- |
-| Node + Playwright (library) | Check: `node -e "require('playwright')"` via global root, or `npm ls -g playwright`. If missing: **`npm install -g playwright`** (global, not in a throwaway work dir). The recorder loads it via NODE_PATH = `npm root -g`. |
-| ffmpeg + ffprobe | Check: `ffmpeg -version`. If missing: `winget install --id Gyan.FFmpeg -e --accept-source-agreements --accept-package-agreements --disable-interactivity`, then **copy `ffmpeg.exe`/`ffprobe.exe` into `C:\Users\<user>\.copilot\bin` and add that folder to the User PATH** (`[Environment]::SetEnvironmentVariable("Path", $userPath + ";C:\Users\<user>\.copilot\bin", "User")`). The stable folder survives ffmpeg version bumps. |
-| edge-tts (Ava neural TTS, headless path) | Check: `python -c "import edge_tts"`. If missing: **`pip install edge-tts`** (user install is fine — `python -m edge_tts` then works in every chat). For the bare `edge-tts` CLI, add the Python **Scripts** dir (e.g. `C:\Users\<user>\AppData\Roaming\Python\Python3XX\Scripts`) to the User PATH. Voice: `en-US-AvaNeural`. |
-| Logged-in browser | The MCP Playwright browser holds the user's session. Profile dir typically `C:\Users\<user>\AppData\Local\ms-playwright\mcp-msedge`, Edge at `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`. For a **different tenant**, **clone** the user's real Edge profile to a non-default `User Data` root and launch that with the matching `--profile-directory` (see below) — Playwright cannot attach to Edge's default data dir. |
-
-> Once installed globally, they persist across chats (ffmpeg/ffprobe in `.copilot\bin`, edge-tts user install, playwright global). Just verify first; don't reinstall unless a check fails.
+**Windows only** (PowerShell, Win32 window APIs, `msedge.exe`, ffmpeg `gdigrab` desktop capture) — this skill does not currently have macOS/Linux capture backends. See `README.md` for the one-time global install steps (Node + Playwright, ffmpeg/ffprobe, edge-tts) and how to check each is already present before installing.
 
 ### Ready-made scripts (`scripts/`)
 
@@ -95,7 +86,7 @@ Working, battle-tested versions live next to this file. Copy them into the task'
 | Script | Purpose |
 | ------ | ------- |
 | `clone.ps1` | Kill real Edge, clone the tenant profile to a non-default root (caches excluded), regex-patch `Preferences`. **Re-run whenever auth breaks.** |
-| `prep.ps1` | Between runs: kill stale Edge/node, clear `Singleton*` locks, reset `exit_type`/`exited_cleanly`. Run before every launch. |
+| `prep.ps1` | Between runs: kill stale Edge (cloned profile only) and this workflow's own Node processes, clear `Singleton*` locks, reset `exit_type`/`exited_cleanly`. Run before every launch. |
 | `maximize.ps1` | Win32 `MoveWindow`+`SW_MAXIMIZE` on the cloned-profile Edge window (the only thing that reliably resizes it). |
 | `arrange.ps1` | Side-by-side placement (browser left, Scout right) for §1b dual capture. |
 | `common.js` | Shared launch `ARGS`, the `settle()` auth/stability loop, `dismissPopups()`, `logViewport()`, `maximizeWindow()`. |
@@ -223,7 +214,7 @@ The user sees the automated window while it records; a tiny 800×600 window that
 > Reference that passes for Copilot Studio at 1920 wide: viewport **1920×880**. Treat this as a starting point, still verify per app/screen.
 
 - Confirm the target URL and the scenario steps (prompts to type / buttons to click) with the user.
-- **Free the browser profile first.** Only one process can lock the persistent profile. Kill any Edge processes using the profile dir before launching the recorder (see `scripts/free-profile.ps1`), otherwise `launchPersistentContext` fails with "Failed to launch… Opening in existing browser session".
+- **Free the browser profile first.** Only one process can lock the persistent profile. Kill any Edge processes using the profile dir before launching the recorder (see `scripts/prep.ps1`, which also clears stale `Singleton*` lock files and normalizes the crash-restore flags), otherwise `launchPersistentContext` fails with "Failed to launch… Opening in existing browser session".
 - Run `scripts/recorder.js` (template provided) **only after the visibility gate passes**. It launches the logged-in profile, records page video, drives the chat/app with human-like typing, waits for each response to stabilize, holds for readability, then closes to flush the `.webm`.
 - **Submit reliably:** prefer clicking the Send button and confirm the input box empties; pressing Enter alone can concatenate prompts into one bubble. The template's `submit()` handles this.
 - **Copilot Studio's Build/Preview/Evaluate/Monitor switcher is a `menuitemradio` DROPDOWN behind a single "Build" button, not tabs.** `getByRole('tab', {name: /Preview/i})` will silently find nothing and `openTestPane()` will time out waiting for the chat input. Two fixes, prefer the first:

--- a/submissions/clipchamp-video/SKILL.md
+++ b/submissions/clipchamp-video/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: "clipchamp-video"
+description: >-
+  Create narrated demo/explainer videos of a live web app or agent, with real
+  screen-flow footage under an AI (Ava neural) voiceover. Use whenever the user
+  wants to "make a video", "record a demo", "create a walkthrough", "screen
+  record an agent/app and narrate it", "build a Clipchamp video", "produce a
+  product demo", or turn a Copilot Studio / web-app flow into a narrated MP4.
+  FIRST ask the user which assembly method to use: (A) headless ffmpeg +
+  edge-tts Ava — fast, scripted, produces a finished MP4 directly — or (B) the
+  Clipchamp web UI — slower, but leaves an editable Clipchamp project for
+  hand-tweaking later.
+---
+
+# Clipchamp Narrated Demo Video Skill
+
+Produce a polished, narrated demo video: **real screen-flow footage of a live app/agent** under an **AI voiceover**. This captures hard-won lessons — read it fully before starting.
+
+## STEP 0 — ASK THE USER: which assembly method? (do this FIRST, before recording)
+
+The recording step is identical for both. The **assembly + narration** step has two paths — ask the user to pick before you start, e.g. via `m_ask_user`:
+
+> "How should I assemble the video — **(A) Headless (ffmpeg + Ava neural TTS)** — faster (~2–3 min), scripted, precise, produces a finished MP4; or **(B) Clipchamp web UI** — slower (~15–25 min of browser clicks) but gives you an **editable Clipchamp project** to hand-tweak later (transitions, captions, music)?"
+
+Guidance to offer with the question:
+- **Default / recommended: (A) Headless** — faster, deterministic, exact narration timing, no session-drop/upload-hook risk. Best when the deliverable is just the finished MP4.
+- **Choose (B) Clipchamp** only if the user wants an editable project living in their Clipchamp account, or plans manual edits (transitions, captions, background music, hand re-timing).
+- **(B) requires the `playwright-browser_*` MCP tools.** If those tools are not available in the session (they can be disabled/dropped), (B) is impossible — tell the user and either have them re-enable the Browser Control tools / start a new chat, or fall back to (A).
+
+Record the flow the same way either path (§1), then follow **§2 + §2b (headless)** or **§3 (Clipchamp)** based on their choice.
+
+## STEP 0b — ASK: page-only capture, or "your actions + the chat" (dual capture)?
+
+If the user says anything like *"record your actions and the chat at the same time"*, *"show what you're doing while it runs"*, *"a making-of"*, or *"I want to see both"* — they want **the Scout/assistant conversation visible alongside the app**, not just the app. That is a **different capture mode** and you must pick it BEFORE recording:
+
+- **Page-only (default, §1).** Playwright `recordVideo` captures the page's internal buffer. Clean, no browser chrome, immune to other windows / screen switches. **It physically cannot capture the Scout window** — `recordVideo` only ever sees the one page.
+- **Dual capture (§1b).** OS-level desktop capture with **ffmpeg `gdigrab`** while Scout and the automated browser sit **side by side**. One capture, so the two halves are perfectly in sync for free.
+
+Do NOT try to satisfy a dual-capture request by recording the page and hoping to add the chat later — you cannot recover the chat pixels after the fact.
+
+## §1b — Dual capture: agent actions + the app, side by side
+
+Verified working (`ffmpeg 8.x`, Windows): `-f gdigrab -framerate 15 -i desktop` produced a clean 1920×1280 H.264 capture.
+
+**Ready-made scripts:** `scripts/arrange.ps1` (side-by-side window placement) and `scripts/dual-capture.js` (starts gdigrab, runs `recorder.js`, stops ffmpeg cleanly, probes the result). Run `node dual-capture.js out.mp4`.
+
+1. **Arrange the two windows first.** Put the automated Edge on one half and the Scout window on the other — see `scripts/arrange.ps1`. It matches Edge by command line (`*edge-tenant*`) and Scout by process name / window title, then `MoveWindow`s each to half the working area.
+   **Recompute the device-scale factor for the narrower window** — half-width means the CSS viewport halves too. Re-run the empirical calibration from "Make the window fill the user's screen" against the half-width, or the chat input bar will be cut off. The MANDATORY GATE still applies, at the half-width geometry.
+2. **Start ffmpeg detached, before the recorder**, and give it a couple of seconds of lead-in:
+   ```powershell
+   ffmpeg -y -f gdigrab -framerate 15 -i desktop -c:v libx264 -pix_fmt yuv420p -crf 23 -preset veryfast dual.mp4
+   ```
+   Capture `desktop` (the whole screen) rather than `-i title=<window>`: per-window gdigrab breaks whenever the window is occluded, moved, or redrawn, and it silently drops frames. Crop later with ffmpeg if you want a tighter frame.
+3. **Stop ffmpeg gracefully** — write `q` to its stdin, or it may leave the MP4 without a moov atom (unplayable). If you must kill it, use `Stop-Process -Id <pid>` and then remux: `ffmpeg -y -i broken.mp4 -c copy fixed.mp4`.
+4. **Consequences of desktop capture — tell the user up front:**
+   - **They must not use the machine while it records.** Unlike `recordVideo`, everything on screen ends up in the video: notifications, other windows, the taskbar.
+   - **Toasts and popups will appear.** Enable Focus Assist / Do Not Disturb first.
+   - **Anything private on screen is captured.** Close unrelated mail/chat windows before starting.
+5. **Alternative when the user wants both but can't stop working:** record the page-only video (§1), then composite the chat as a separate pass afterwards (screenshots of the conversation as an intro/outro, or a picture-in-picture strip). Sync will be approximate — say so rather than implying frame accuracy.
+6. **Compositing two separate sources** (only if you truly captured them separately) — normalize both to the same height and fps first, then stack:
+   ```powershell
+   ffmpeg -y -i app.mp4 -i chat.mp4 -filter_complex `
+     "[0:v]scale=-2:1080,setsar=1,fps=30[l];[1:v]scale=-2:1080,setsar=1,fps=30[r];[l][r]hstack=inputs=2,pad=ceil(iw/2)*2:ceil(ih/2)*2" `
+     -c:v libx264 -pix_fmt yuv420p -crf 20 composite.mp4
+   ```
+   `hstack` **requires identical heights** or it errors out; the trailing `pad=ceil(iw/2)*2:...` keeps dimensions even for yuv420p. For picture-in-picture use `overlay=W-w-40:H-h-40` instead of `hstack`.
+
+## The winning approach (and why)
+
+A slideshow of static screenshots is almost never what the user wants. They want to **see the app move** — cursor, typing, live responses. The reliable way to get that autonomously:
+
+1. **Drive the real app with Playwright** and record **page-only video** (`recordVideo`). This is clean (no browser chrome) and hands-off. Raw OS screen capture is worse: synthetic automation cursors often don't render, and it captures the whole desktop. **Exception:** if the user explicitly wants the assistant conversation in-frame too, `recordVideo` cannot do it — switch to §1b dual capture.
+2. **Reuse the user's logged-in browser profile** so auth is preserved (e.g. Copilot Studio, M365). Never spin up a fresh profile — you'll lose the session. **If the target lives in a different tenant than the MCP browser's signed-in account, use the real Edge profile for that tenant instead of signing in interactively** — see "Pick the right profile / tenant" below.
+3. **Cut the auth/loading head** from the recording with ffmpeg — the account picker, "Stay signed in", and app "Initializing…" spinner are dead air.
+4. **Narrate with the Ava neural voice** — either Clipchamp's built-in Text to speech or edge-tts `en-US-AvaNeural` — split into **several short blocks aligned to on-screen moments**, not one long block. Silence between events feels broken; short blocks with technical call-outs ("here it invokes a skill to query the table") make it feel alive.
+5. **Name the export after the agent/product**, not "Video Project 1".
+
+## Prerequisites
+
+**Install these ONCE, GLOBALLY, so every future chat has them without reinstalling.** Check each first; only install if missing. After changing PATH, refresh the *current* shell with `$env:Path = [Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [Environment]::GetEnvironmentVariable("Path","User")` (new chats pick it up automatically).
+
+| Need | Make it global (persist across chats) |
+| ---- | -------------- |
+| Node + Playwright (library) | Check: `node -e "require('playwright')"` via global root, or `npm ls -g playwright`. If missing: **`npm install -g playwright`** (global, not in a throwaway work dir). The recorder loads it via NODE_PATH = `npm root -g`. |
+| ffmpeg + ffprobe | Check: `ffmpeg -version`. If missing: `winget install --id Gyan.FFmpeg -e --accept-source-agreements --accept-package-agreements --disable-interactivity`, then **copy `ffmpeg.exe`/`ffprobe.exe` into `C:\Users\<user>\.copilot\bin` and add that folder to the User PATH** (`[Environment]::SetEnvironmentVariable("Path", $userPath + ";C:\Users\<user>\.copilot\bin", "User")`). The stable folder survives ffmpeg version bumps. |
+| edge-tts (Ava neural TTS, headless path) | Check: `python -c "import edge_tts"`. If missing: **`pip install edge-tts`** (user install is fine — `python -m edge_tts` then works in every chat). For the bare `edge-tts` CLI, add the Python **Scripts** dir (e.g. `C:\Users\<user>\AppData\Roaming\Python\Python3XX\Scripts`) to the User PATH. Voice: `en-US-AvaNeural`. |
+| Logged-in browser | The MCP Playwright browser holds the user's session. Profile dir typically `C:\Users\<user>\AppData\Local\ms-playwright\mcp-msedge`, Edge at `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`. For a **different tenant**, **clone** the user's real Edge profile to a non-default `User Data` root and launch that with the matching `--profile-directory` (see below) — Playwright cannot attach to Edge's default data dir. |
+
+> Once installed globally, they persist across chats (ffmpeg/ffprobe in `.copilot\bin`, edge-tts user install, playwright global). Just verify first; don't reinstall unless a check fails.
+
+### Ready-made scripts (`scripts/`)
+
+Working, battle-tested versions live next to this file. Copy them into the task's work dir and edit the constants at the top of `common.js` (clone path, env id, agent id, target account) rather than writing new ones from scratch.
+
+| Script | Purpose |
+| ------ | ------- |
+| `clone.ps1` | Kill real Edge, clone the tenant profile to a non-default root (caches excluded), regex-patch `Preferences`. **Re-run whenever auth breaks.** |
+| `prep.ps1` | Between runs: kill stale Edge/node, clear `Singleton*` locks, reset `exit_type`/`exited_cleanly`. Run before every launch. |
+| `maximize.ps1` | Win32 `MoveWindow`+`SW_MAXIMIZE` on the cloned-profile Edge window (the only thing that reliably resizes it). |
+| `arrange.ps1` | Side-by-side placement (browser left, Scout right) for §1b dual capture. |
+| `common.js` | Shared launch `ARGS`, the `settle()` auth/stability loop, `dismissPopups()`, `logViewport()`, `maximizeWindow()`. |
+| `verify.js` | **The MANDATORY GATE** — loads the target, opens the test pane, sends one real prompt, screenshots the frame. |
+| `recorder.js` | The real run: overview → instructions → skills/tools scroll → N live test prompts, with `progress.log` beat markers. |
+| `dual-capture.js` | §1b: starts gdigrab, runs `recorder.js`, stops ffmpeg cleanly, probes the output. |
+| `findagent.js` | Scrape the agents grid (`[role="row"]`) for names, then open one and harvest its real id from the URL. |
+| `diag.js` | When a page renders blank: timed screenshots + console errors + HTTP ≥400 logging. |
+
+### Pick the right profile / tenant (do this BEFORE anything else)
+
+The MCP browser is usually signed in to the user's **primary** work account. If the agent/app lives in a **different tenant** (e.g. a `*.onmicrosoft.com` dev/demo tenant), that session will 404 or bounce to the wrong environment. **Do not try to sign in interactively** and do not ask the user to type a password — the user almost always already has a **second Edge profile** signed in to that tenant. Find it and drive that.
+
+1. **Detect the mismatch early.** Open the target URL in the MCP browser; a blank page, `404` on `api.bap.microsoft.com/.../environments/<id>`, or a redirect to `~personal`/a different environment ID means wrong tenant. Confirm the signed-in identity (in Copilot Studio: click `[data-testid="account-profile-button-trigger"]`).
+2. **Enumerate the real Edge profiles and their accounts** — map `Default`, `Profile 1`, `Profile 2`… to emails by reading each profile's `Preferences`:
+   ```powershell
+   $ud = "$env:LOCALAPPDATA\Microsoft\Edge\User Data"
+   Get-ChildItem $ud -Directory | Where-Object { $_.Name -eq 'Default' -or $_.Name -like 'Profile*' } | ForEach-Object {
+     $p = Join-Path $_.FullName 'Preferences'
+     if (Test-Path $p) { try { $j = Get-Content $p -Raw -Encoding UTF8 | ConvertFrom-Json
+       [PSCustomObject]@{ Dir=$_.Name; Name=$j.profile.name; Email=$j.account_info[0].email } } catch {} }
+   } | Format-Table -AutoSize
+   ```
+   Note the **directory name** (`Profile 1`), *not* the display name (`Profile 2`) — they routinely disagree, and Playwright needs the directory.
+3. **CLONE the profile to a non-default User Data root — do NOT drive the real one.** Edge **refuses remote debugging on its default data directory** and `launchPersistentContext` dies after 180 s with:
+   `Timeout 180000ms exceeded` + `[err] DevTools remote debugging requires a non-default data directory. Specify this using --user-data-dir.`
+   Cloning also frees you from the real-Edge profile lock. Copy only what carries auth — skip the caches, which are the bulk (a 3 GB profile drops to ~300 MB, and `Service Worker` alone was 2 GB):
+   ```powershell
+   $src = "$env:LOCALAPPDATA\Microsoft\Edge\User Data"; $dst = "C:\Users\<user>\.copilot\video-work\edge-tenant"
+   New-Item -ItemType Directory -Force -Path $dst | Out-Null
+   Copy-Item "$src\Local State" "$dst\Local State" -Force
+   robocopy "$src\Profile 1" "$dst\Profile 1" /E /NFL /NDL /NJH /NJS /R:0 /W:0 /XJ `
+     /XD "Service Worker" "Cache" "Code Cache" "GPUCache" "Shared Dictionary" "DawnGraphiteCache" "DawnWebGPUCache" "Crashpad" "optimization_guide_model_store"
+   ```
+   Keep `Network\Cookies`, `Login Data`, `Local Storage`, `IndexedDB`, `WebStorage`, `Preferences` — that's what preserves the session. Then launch `launchPersistentContext(<clone root>, { args: ['--profile-directory=Profile 1', ...] })` — still the **root**, never the profile subfolder.
+   **The clone is a snapshot, not a link.** If auth later breaks, have the user load the target URL in their own Edge and then **re-clone** — that is the fastest repair, and far more reliable than any scripted sign-in (see the passkey pitfall below). Close the real Edge only while cloning (files are locked mid-copy).
+4. **Close the real Edge only while cloning** (files are locked mid-copy). Kill only the non-Playwright `msedge.exe` processes, delete `Singleton*` under the target root, and patch `Profile 1\Preferences` (`exit_type`→`Normal`, `exited_cleanly`→`true`) so no "Restore pages?" bubble appears in-frame.
+   ```powershell
+   Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
+     Where-Object { $_.CommandLine -notlike '*m-playwright-profiles*' -and $_.CommandLine -notlike '*ms-playwright*' } |
+     ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+   ```
+   Filtering by command line matters: killing everything also kills the MCP browser you may still need.
+5. Real profiles can be **multi-GB** and slower to boot than `mcp-msedge` — allow generous first-navigation timeouts (90–120 s) and a long post-load settle before recording.
+6. **Wait for auth with a stability loop, never a fixed sleep.** MSAL bounces *back* to `login.microsoftonline.com/…/oauth2/v2.0/authorize` for a silent token refresh **after** you appear to have landed on the app — a one-shot "am I on the app host?" check passes, then the very next screenshot is a login URL with 200 chars of body text. Poll every 2 s and require **N consecutive good polls** (host matches AND `document.body.innerText.length` is large AND no `Initializing|Loading your|Getting things ready` spinner). Handle the sign-in UI inside the same loop:
+   ```js
+   async function settle(page, budgetMs = 240000, needStable = 4) {
+     const t0 = Date.now(); let stable = 0;
+     while (Date.now() - t0 < budgetMs) {
+       const u = page.url();
+       if (u.includes('login.microsoftonline.com')) {           // "Stay signed in?"
+         stable = 0;
+         const cb = page.locator('#KmsiCheckboxField').first();
+         if (await cb.isVisible({ timeout: 400 }).catch(() => false)) await cb.check({ timeout: 2000 }).catch(() => {});
+         const yes = page.locator('#idSIButton9').first();       // the Yes/Next button
+         if (await yes.isVisible({ timeout: 800 }).catch(() => false)) { await yes.click({ timeout: 3000 }); await page.waitForTimeout(4000); continue; }
+         const tile = page.locator('div[role="button"]:has-text("user@"), small:has-text("user@")').first();
+         if (await tile.isVisible({ timeout: 600 }).catch(() => false)) { await tile.click({ timeout: 3000 }); await page.waitForTimeout(4000); continue; }
+         await page.waitForTimeout(2000); continue;
+       }
+       if (u.includes('<app-host>')) {
+         const len = await page.evaluate(() => document.body.innerText.length).catch(() => 0);
+         const busy = await page.locator('text=/Initializing|Loading your|Getting things ready/i').count().catch(() => 0);
+         if (len > 400 && !busy) { stable++; if (stable >= needStable) return true; } else stable = 0;
+       } else stable = 0;
+       await page.waitForTimeout(2000);
+     }
+     return false;
+   }
+   ```
+   Use the account **tile** selectors (`div[role="button"]:has-text("user@")`, `small:has-text("user@")`) — `[data-test-id*="…"]` attributes on the account picker are unstable. Check `#KmsiCheckboxField` ("Don't show this again") before clicking `#idSIButton9` so the prompt stops recurring on later runs.
+
+### Make the window fill the user's screen (they WILL be watching it)
+
+The user sees the automated window while it records; a tiny 800×600 window that can't be moved or resized is a real complaint. Three separate traps:
+
+1. **`viewport: {width, height}` locks the window.** Playwright *emulates* a fixed viewport and the window becomes unresizable. Use **`viewport: null`** so the page tracks the real window — then control size via launch args. (`recordVideo` still captures the page buffer, so the recording stays clean.)
+2. **`--start-maximized` and `--window-size` are BOTH silently ignored on a profile that has saved window bounds** — you get a stubborn 800×600. Removing `browser.window_placement` from the clone's `Preferences` is *not* reliable either, and CDP `Browser.setWindowBounds` fails under `launchPersistentContext` (`Protocol error: Browser window not found`). **What actually works: resize the real Win32 window after launch.** Call this right after launch, and again after each navigation (the app can re-trigger a resize):
+   ```powershell
+   # maximize.ps1 - maximize the Edge window belonging to our cloned profile
+   Add-Type @"
+   using System; using System.Runtime.InteropServices;
+   public class Win {
+     [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+     [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
+     [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+   }
+   "@ -ErrorAction SilentlyContinue
+   Add-Type -AssemblyName System.Windows.Forms
+   $wa = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+   Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
+     Where-Object { $_.CommandLine -like '*edge-tenant*' } | ForEach-Object {
+       $p = Get-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
+       if ($p -and $p.MainWindowHandle -ne 0 -and [Win]::IsWindowVisible($p.MainWindowHandle)) {
+         [Win]::ShowWindow($p.MainWindowHandle, 9) | Out-Null              # SW_RESTORE
+         [Win]::MoveWindow($p.MainWindowHandle, $wa.X, $wa.Y, $wa.Width, $wa.Height, $true) | Out-Null
+         [Win]::ShowWindow($p.MainWindowHandle, 3) | Out-Null              # SW_MAXIMIZE
+       } }
+   ```
+   Filter by command line (`*edge-tenant*`) so you only touch your own window, and invoke it from Node with `child_process.execSync('powershell -NoProfile -ExecutionPolicy Bypass -File maximize.ps1')`.
+3. **Measure the screen correctly — logical ≠ physical.** `[System.Windows.Forms.Screen]` reports **logical** px (already divided by the Windows display scale), while `screen.width` in the browser reports **physical**. A machine reporting `1536×1024` from PowerShell was really `2400×1600` at 156 % scale. Reconcile before computing sizes, or you will undersize the window by the scale factor.
+
+   **Calibrate empirically instead of deriving it.** Launch once at a known `--force-device-scale-factor`, maximize, and read the CSS width; CSS width scales as `1/dsf`, so:
+   `dsf_target = dsf_measured × (cssWidth_measured / cssWidth_wanted)`
+   Worked example: at `dsf 0.8` the maximized window measured **2376 CSS px** wide. For a 1920-wide capture: `0.8 × 2376/1920 = 0.99`. Relaunching at `--force-device-scale-factor=0.99` produced **1916×1162** — a full-screen window *and* a ~1920 px capture buffer.
+   ```
+   '--force-device-scale-factor=0.99', '--start-maximized',
+   ```
+   Read the real numbers from the browser, not from PowerShell, and log them every run:
+   ```js
+   await page.evaluate(() => ({ w: innerWidth, h: innerHeight, dpr: devicePixelRatio, sw: screen.width, sh: screen.height }))
+   ```
+
+## Workflow
+
+### 1. Record the real flow
+
+> ⛔ **MANDATORY GATE — DO NOT RECORD until the chat input bar is verified fully visible.**
+> The single most common defect is the chat input bar (and the end of the last message) being cut off at the bottom of the frame. You **MUST** pass this gate before every recording run — no exceptions, even if a previous run "looked fine":
+> 1. Run **`scripts/verify.js`** (same launch args/viewport as the recorder). It opens the target, dismisses popups, handles the account picker, sends ONE test message, and screenshots the **viewport buffer** (which is exactly what gets recorded — NOT the on-screen window).
+> 2. **View that screenshot** and confirm ALL of these are visible in-frame: the header, the latest message bubble's END, the chat **input bar** ("Ask a question…"), and the disclaimer line. Do not rely on the on-screen window (it may be cut by the physical screen/taskbar); judge only from the screenshot.
+> 3. If ANY of them is cut off → **adjust the viewport height and re-run verify.js. Repeat until the screenshot passes.** Never proceed to the real recording on a failed/uncertain frame.
+> 4. Use the SAME `viewport` and launch `args` in `recorder.js` that passed the gate.
+>
+> Reference that passes for Copilot Studio at 1920 wide: viewport **1920×880**. Treat this as a starting point, still verify per app/screen.
+
+- Confirm the target URL and the scenario steps (prompts to type / buttons to click) with the user.
+- **Free the browser profile first.** Only one process can lock the persistent profile. Kill any Edge processes using the profile dir before launching the recorder (see `scripts/free-profile.ps1`), otherwise `launchPersistentContext` fails with "Failed to launch… Opening in existing browser session".
+- Run `scripts/recorder.js` (template provided) **only after the visibility gate passes**. It launches the logged-in profile, records page video, drives the chat/app with human-like typing, waits for each response to stabilize, holds for readability, then closes to flush the `.webm`.
+- **Submit reliably:** prefer clicking the Send button and confirm the input box empties; pressing Enter alone can concatenate prompts into one bubble. The template's `submit()` handles this.
+- **Copilot Studio's Build/Preview/Evaluate/Monitor switcher is a `menuitemradio` DROPDOWN behind a single "Build" button, not tabs.** `getByRole('tab', {name: /Preview/i})` will silently find nothing and `openTestPane()` will time out waiting for the chat input. Two fixes, prefer the first:
+  1. **Just navigate directly to `${AGENT_URL}/preview`** (`page.goto`) — clicking the option once reveals the URL pattern is stable (`/agents/<id>/preview`), and a direct `goto` is far more reliable than menu-click choreography. This is what `openTestPane()` in the shared `recorder.js`/`verify.js` templates now does.
+  2. If you must click through the UI: click the button whose accessible name is the *current* tab label (e.g. `Build`) to open the menu, then click the `menuitemradio` named `Preview` inside it (`page.getByRole('menuitemradio', {name: /^Preview$/i})`).
+  - **Diagnose this class of bug fast:** if a locator search for the expected tab/button comes back empty, don't guess — take a `browser_snapshot`/screenshot of the live page (via the `playwright-browser_*` MCP tools, reusing the same signed-in tenant profile) to see the actual accessibility tree before patching the recorder script blind.
+
+#### Robust, clean capture (learned the hard way — bake these into the recorder)
+- **Suppress Edge nag UI with launch args** so no banners/bubbles pollute the frame:
+  `--test-type` (kills the yellow "unsupported command-line flag" infobar), `--disable-infobars`, `--hide-crash-restore-bubble`, `--disable-session-crashed-bubble`, `--no-first-run`.
+- **Kill the "Restore pages?" bubble at the source:** after force-killing Edge between runs, patch the profile `Default/Preferences` before relaunch — replace `"exit_type":"..."` → `"exit_type":"Normal"` and `"exited_cleanly":false` → `"exited_cleanly":true`.
+- **Auto-handle the Microsoft account picker.** If a sign-in/account chooser appears, click the correct account by regex on its email/tenant (ask the user which account once, then match it) — otherwise the run stalls. See `pickAccountIfNeeded()` in the template.
+- **Dismiss product coach-marks / NPS / cookie popups.** Loop over buttons named `Close`, `Got it`, `Dismiss`, `No thanks`, `Skip`, `Not now`, `Accept`, `OK`, then press `Escape`. Call it after load AND after opening the chat/preview pane. See `dismissPopups()`.
+- **Size the viewport so the chat input bar is fully in-frame (see the MANDATORY GATE above).** The recorded frame is the *viewport buffer*, not the on-screen window, so it can exceed the physical screen. For Copilot Studio at 1920-wide, a viewport of **1920×880** shows the header, messages, the "Ask a question" input bar, and the disclaimer line. This is NOT optional guesswork — you must prove it with `verify.js` and a screenshot before recording, and re-run until it passes.
+- **Scroll to the END of each response before typing the next turn** so the full answer is on screen, and pin to bottom during holds — this also hides the floating "Scroll to bottom" down-arrow. See `scrollBottom()` + `readHold()`.
+- **You can keep using the laptop / switch screens during recording.** `recordVideo` captures the page's internal buffer, not your monitor, so other windows, screen switches, or minimizing never appear. Only avoid closing the automated Edge window or sleeping the machine.
+- **Run detached with synchronous file logging.** Long recordings (slow tool calls, timeouts) can outlive a tool call; launch the recorder detached so it survives, and have it `fs.appendFileSync` a timestamped `progress.log` per step (console output to a redirected file is block-buffered and looks "stuck"). Poll `progress.log` + node/edge process counts to track real progress.
+
+### 2. Post-process with ffmpeg
+- Probe duration & sample frames every few seconds to **map when each scenario happens** and **find where auth ends**:
+  ```powershell
+  ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 in.webm
+  ffmpeg -y -i in.webm -vf "fps=1/5" frame_%03d.png    # then view frames
+  ```
+- **Cut auth + crop empty margins**, convert to H.264 MP4 (Clipchamp-friendly). Example: drop first 30s, crop to content:
+  ```powershell
+  ffmpeg -y -ss 30 -i in.webm -vf "crop=1280:600:0:0,setsar=1" -c:v libx264 -pix_fmt yuv420p -crf 20 -preset medium out.mp4
+  ```
+- **If `maximize.ps1` couldn't fill the physical screen** (small/low-res display, or a screen-resolution change since the empirical DSF calibration), the recorded buffer will show the real app content only in a small corner with a large flat-gray dead zone around it — check a sampled frame BEFORE narrating, not after. Fix by cropping to the actual content bounding box (read it off a sample frame — e.g. `crop=782:600:0:0`), then `scale` up to a target size and `pad` onto a white/black canvas to reach a standard resolution (16:9 for a normal video deliverable):
+  ```powershell
+  ffmpeg -y -i in.webm -vf "crop=782:600:0:0,scale=1303:1000,pad=1920:1080:(ow-iw)/2:(oh-ih)/2:color=white" -c:v libx264 -pix_fmt yuv420p -crf 20 out.mp4
+  ```
+  Do this crop/scale/pad **per trimmed segment inside the same `trim`+`concat` filter_complex** (not as a separate pass) so segments stay in sync — see the worked multi-segment example below.
+- **Hit a target length (e.g. ≤ 2 min) by cutting DEAD TIME, not content.** Agent demos have long dead gaps during slow tool calls / timeouts. Don't speed-ramp the whole clip — instead pick keep-windows around each meaningful beat (question asked, skill loads, result appears) and drop the multi-second waits between them. Extract each window with `-ss <start> -t <dur>`, normalize them all to the same size/fps (`scale=...,pad=1920:1080,setsar=1,fps=30`), then concat. Use the recorder's `progress.log` timestamps to locate beats fast.
+  - concat gotcha: `ffmpeg -f concat` resolves `file '...'` paths **relative to the concat file's own directory** — list bare filenames and run from that dir, or use absolute paths.
+- Note the trimmed clip's exact duration and each segment's start offset — you'll align narration to these.
+
+### 2b. Narration without the Clipchamp UI (headless, reliable fallback)
+### 2b. PATH (A) — Narration without the Clipchamp UI (headless, fast, recommended default)
+When the browser/Clipchamp UI isn't available (or you just want a deterministic build), generate the voiceover with **edge-tts** (same Ava neural voice) and mux with ffmpeg:
+- Write one text block per beat with `(start_time, max_dur, text)`. Generate each: `python -m edge_tts --voice en-US-AvaNeural --text "..." --write-media bNN.mp3` (in code, bump `rate` `+8%`/`+15%`/… until a block fits its `max_dur`).
+- Build a single voice track by delaying each block to its start: `[i:a]adelay=START_ms|START_ms,apad[ai]` then `amix=inputs=N:normalize=0` and `atrim=0:TOTAL`.
+- Mux onto the trimmed video: `ffmpeg -i cut.mp4 -i voice.m4a -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 -shortest final.mp4`.
+- Name the output after the agent/product and copy it into the user's workspace/OneDrive folder so it renders inline and syncs.
+
+### 3. PATH (B) — Assemble in Clipchamp (browser automation; editable project)
+Only if the user chose (B) in STEP 0 AND the `playwright-browser_*` tools are available.
+Read **[clipchamp-ui.md](clipchamp-ui.md)** for the exact click targets, selectors, and gotchas. High level:
+1. Open https://app.clipchamp.com → open (or recover) the project, or create a new one.
+2. **Import media** → file chooser → `browser_file_upload` the trimmed MP4 (+ any intro screenshot). If a permission hook blocks uploads, ask the user to enable **Settings → Permissions → Allow agent file uploads**.
+3. Add media to the timeline via each item's "Add to timeline" button (drops at the playhead).
+4. Optionally add an intro still (e.g. a "Build"/architecture screenshot) so the video opens on context.
+5. **Voiceover:** open **Record & create → Text to speech** (or select an existing TTS clip's **Text to speech** tab), pick **Ava Multilingual**, type the block text, **Save** to render. New TTS blocks drop **at the playhead** — set the playhead precisely first via the time input spinbuttons (Minutes/Seconds), then create the block.
+6. Cover any black tail after the video ends with a closing still so the final voiceover has a visual.
+
+### 4. Export
+- **Export → set the File name to the agent/product** (e.g. `Contoso IT Assistant - Demo`), 1080p, keep "Store in the cloud" → **Export**. If prompted about an existing name, choose **Keep both** or **Replace** as the user prefers.
+- Output lands in OneDrive: `Videos/Clipchamp/<project>/Exports/<name>.mp4`. It may not sync to the local folder immediately; the export screen's **Copy link** / **Save to your computer** are the fallbacks.
+
+## Narration authoring tips
+- One block per on-screen beat; ~1–3 short sentences each. Keep total pacing tight — aim for little dead air.
+- Add **technical call-outs** that describe the mechanics the viewer is seeing: which skill/tool fired, what data source it hit ("queries the knowledge table", "calls the create-record tool", "reads the live schedule").
+- Keep it **generic** if asked — strip customer/company names.
+- End on a **hero voiceover line** (no card needed) that names the value prop and the tech, e.g. "That's the power of AI, combining X and Y to turn Z into one seamless, autonomous experience."
+- Remove leftover title-text overlays if the intro screenshot already shows the name.
+
+## Common pitfalls (all learned the hard way)
+- **`Timeout 180000ms exceeded` on `launchPersistentContext` + `DevTools remote debugging requires a non-default data directory`** → you pointed Playwright at Edge's **default** `User Data` root. Edge blocks remote debugging there. **Clone the profile to a separate root** (see "Pick the right profile / tenant" step 3) and launch against the clone.
+- **App renders a totally blank page, `document.body.innerText.length === 0`, `outerHTML` is ~1 MB, and the network log shows `404` on `api.bap.microsoft.com/.../environments/<id>`** → the app shell loaded but **MSAL silently issued a token for the wrong tenant**. Confirm by reading the MSAL cache instead of guessing:
+  ```js
+  await page.evaluate(() => { const o = [];
+    for (let i = 0; i < localStorage.length; i++) { const k = localStorage.key(i);
+      try { const j = JSON.parse(localStorage.getItem(k)); if (j && (j.username || j.tenantId)) o.push({ u: j.username, t: j.tenantId }); } catch {} }
+    return o; });
+  ```
+  A `tenantId` of `72f988bf-86f1-41af-91ab-2d7cd011db47` is the **Microsoft corp** tenant — i.e. it authenticated as the primary work account, not the dev/demo tenant. Clearing `localStorage`/`sessionStorage` and the app's cookies does **not** fix it: the `login.microsoftonline.com` session cookie still defaults to the primary account, so it silently re-SSOs to the same wrong identity.
+  **Fix:** force the picker by navigating to the tenant-scoped authorize endpoint with `prompt=select_account` + `login_hint` before loading the app:
+  ```
+  https://login.microsoftonline.com/<tenant>.onmicrosoft.com/oauth2/v2.0/authorize
+    ?client_id=<app spa client id>&response_type=code
+    &redirect_uri=<url-encoded app redirect>&response_mode=fragment
+    &scope=openid%20profile%20offline_access
+    &prompt=select_account&login_hint=<user@tenant>
+  ```
+  Read the SPA `client_id` straight out of the MSAL localStorage key (`msal.<client-id>.active-account-filters`). Then click the tenant tile — `div[data-test-id="<full upn>"]` is the reliable selector on the "Pick an account" screen.
+- **Never test "did we land on the app?" with `url.includes('<app-host>')`** → the authorize URL embeds the app host inside its own `redirect_uri` query param, so `includes()` returns true while you are still sitting on the login page, and your picker loop exits before clicking anything. Compare `new URL(u).host` instead. Apply this to `settle()` too.
+- **Sign-in loop spins forever re-clicking the account tile and the host becomes `login.microsoft.com/<tenant>/bridge/fido`** → the account requires **passkey / Windows Hello**, which cannot be automated. The cookie-based SSO you cloned has expired.
+  **Do not burn time scripting around this.** An automated `prompt=select_account` flow will *still* silently resolve back to the Windows-connected primary account (`Connected to Windows` on the picker always wins), so the MSAL cache stays on the wrong tenant no matter how many times you clear storage.
+  **The reliable fix — always prefer it:** ask the user to open **their own normal Edge** on the target URL and confirm it loads. Then **re-clone the profile** (the clone captures the freshly-minted cookies) and every subsequent automated run works. This takes one message and ~2 minutes; driving an in-Playwright interactive sign-in is slower, and the user may not notice the window at all — an unattended "waiting for user" poller will just time out.
+  Note `login.microsoft.com` and `login.microsoftonline.com` are **different hosts** — match both when detecting auth pages. Treat the clone as a **cache of the user's live session**: whenever auth looks wrong, re-run the clone step before debugging anything else.
+- **Do NOT round-trip Chromium `Preferences` through `ConvertFrom-Json`/`ConvertTo-Json`** → it reorders keys and retypes values, and can leave the profile in a broken state. Patch it with **targeted regex string replacement** only:
+  ```powershell
+  $c = Get-Content $pf -Raw -Encoding UTF8
+  $c = $c -replace '"exit_type":"[^"]*"','"exit_type":"Normal"' -replace '"exited_cleanly":false','"exited_cleanly":true'
+  [System.IO.File]::WriteAllText($pf, $c, (New-Object System.Text.UTF8Encoding($false)))
+  ```
+- **User asks for "your actions and the chat at the same time" and you already recorded page-only** → `recordVideo` captured only the page buffer; the assistant conversation was never in those pixels and cannot be added retroactively. You must re-record with **§1b dual capture** (gdigrab + side-by-side windows). Ask which capture mode they want *before* recording.
+- **gdigrab MP4 won't play / has no duration** → ffmpeg was killed instead of being asked to stop, so the moov atom was never written. Send `q` to stdin to stop it; recover an existing file with `ffmpeg -i broken.mp4 -c copy fixed.mp4`.
+- **`hstack` fails with "Input link parameters do not match"** → the two sources have different heights or SAR. Scale both to the same height and `setsar=1` before stacking.
+- **Chat input bar cut off after switching to side-by-side windows** → halving the window width changes the CSS viewport, so the previously-calibrated device-scale factor no longer holds. Re-calibrate and re-run the visibility gate at the new geometry.
+- **Copilot Studio agent tabs are `Build | Preview | Evaluate | Monitor`** → the test chat is under **Preview** (not "Test"). The agent's overview page under **Build** already lists Instructions, Model, **Skills**, **Tools**, and **Knowledge** in one scrollable column — one slow scroll covers the whole "what this agent is" section, no tab-hopping needed.
+- **A tool call in the demo returns a red error card (e.g. `Request validation · 400`)** → the backing system may be asleep (some dev/sandbox backends hibernate) or the action is genuinely misconfigured. **Check this during the visibility gate, not after recording** — send one real test prompt and read the answer. If the backend is down, tell the user and get it woken up before the real run; a demo video full of error cards is worthless.
+- **The agent you want isn't in the agents list** → the list only shows agents in *that* environment, and a broken-tenant session renders an empty body so **every** agent looks missing. Confirm auth first, then try the direct `/agents/<id>` URL — an agent can load fine by id even when you can't spot it in the list. Harvest names/ids by scraping `[role="row"]` from the grid.
+- **Window is tiny (800×600), can't be moved or resized, user complains they can't see it** → three causes, check all: (a) `viewport: {w,h}` locks the window — use `viewport: null`; (b) saved `browser.window_placement` in the cloned `Preferences` overrides `--window-size` **and** `--start-maximized` — delete that key before launch; (c) you sized from `[System.Windows.Forms.Screen]` (logical px) instead of `screen.width` (physical px) and undersized by the display-scale factor. Always log `innerWidth/innerHeight/devicePixelRatio` from inside the page to confirm.
+- **`Browser.getWindowForTarget` → `Protocol error: Browser window not found`** → CDP window control is unreliable under `launchPersistentContext`; fix the profile `Preferences` + launch args instead.
+- **App "loads", then the next screenshot is a login page with ~200 chars of text** → MSAL redirected back to `/oauth2/v2.0/authorize` for a silent token refresh after your one-shot check passed. Use the **N-consecutive-stable-polls `settle()` loop**, never a fixed `waitForTimeout`.
+- **Wrong tenant / blank page / 404 on the environment** → the MCP browser is signed in to a different account than the one that owns the agent. Don't sign in interactively; enumerate the real Edge profiles, find the one whose `account_info[0].email` matches the tenant, clone it, and relaunch with `--profile-directory=<dir>` against the clone root (see "Pick the right profile / tenant").
+- **`--profile-directory` picked the wrong profile** → the profile's *display name* and its *folder name* differ (folder `Profile 1` can be shown as "Profile 2"). Always use the folder name from `Get-ChildItem`.
+- **Profile lock** → recorder can't launch. Kill stale Edge procs on the profile dir first, and remove any `Singleton*` lock files under the profile dir. Filter by command line so you don't also kill the MCP browser.
+- **Recorder looks "stuck" at an early turn** → it's usually block-buffered redirected console output, not a hang. Use synchronous `fs.appendFileSync` logging to `progress.log` and check node/edge process counts to see real progress.
+- **Yellow "unsupported command-line flag" banner in-frame** → add `--test-type` (+ `--disable-infobars`).
+- **"Restore pages?" bubble in-frame** → patch the profile `Preferences` (`exit_type`→`Normal`, `exited_cleanly`→`true`) before relaunch, and pass `--hide-crash-restore-bubble --disable-session-crashed-bubble`.
+- **Account picker / sign-in stalls the run** → auto-click the right account by email/tenant regex (`pickAccountIfNeeded`).
+- **Chat input bar half-cut / off-screen** → the recorded frame is the viewport buffer, not the physical window; size the viewport tall enough (e.g. 1920×880 for Copilot Studio) and verify with a pre-record viewport screenshot.
+- **Video too long** → cut dead tool-call/timeout gaps into per-beat keep-windows and concat; don't speed-ramp the whole thing.
+- **Browser session drops mid-session** → the MCP browser can be relaunched with `browser_navigate`; the Clipchamp project autosaves to the cloud, so reopen it from the home page. If the browser tools are removed entirely mid-task, fall back to the **§2b headless edge-tts + ffmpeg** narration path — same narrated-MP4 deliverable.
+- **Enter-to-send concatenation** → use the Send button + confirm the box cleared.
+- **TTS block lands in the wrong place** (Clipchamp UI) → it drops at the playhead; set the time input first. Delete a misplaced block and recreate rather than dragging.
+- **Black tail** at the end when the last voiceover outlasts the footage → extend the last clip or add a closing still.
+- **ffmpeg not on PATH** → install once to `C:\Users\<user>\.copilot\bin` and add it to the User PATH (persists across chats); in the current shell refresh `$env:Path` from Machine+User.

--- a/submissions/clipchamp-video/metadata.json
+++ b/submissions/clipchamp-video/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Clipchamp Narrated Demo Video",
+  "description": "Produce a polished, narrated demo video of a live web app or Copilot Studio agent — real screen-flow footage under an AI (Ava neural) voiceover — either fully headless (ffmpeg + edge-tts) or assembled in the Clipchamp web UI as an editable project.",
+  "platforms": ["Scout"],
+  "tags": ["video", "demo", "narration", "playwright", "ffmpeg", "copilot-studio", "clipchamp", "tts"],
+  "author": "Phi-Lay Nguyen",
+  "authorUrl": "https://github.com/phnguy",
+  "version": "1.0.0",
+  "createdAt": "2026-08-21",
+  "updatedAt": "2026-08-21"
+}

--- a/submissions/clipchamp-video/scripts/arrange.ps1
+++ b/submissions/clipchamp-video/scripts/arrange.ps1
@@ -1,0 +1,46 @@
+# arrange.ps1 — put the automated browser on the left half and Scout on the right half,
+# so a single gdigrab desktop capture shows the agent actions AND the chat, in sync.
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class WinArr {
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+  [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+}
+"@ -ErrorAction SilentlyContinue
+
+Add-Type -AssemblyName System.Windows.Forms
+$wa   = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+$half = [int]($wa.Width / 2)
+
+function Place([IntPtr]$h, [int]$x, [int]$w) {
+  [WinArr]::ShowWindow($h, 9) | Out-Null                                   # SW_RESTORE first
+  [WinArr]::MoveWindow($h, $x, $wa.Y, $w, $wa.Height, $true) | Out-Null
+}
+
+# Left half: the automated browser (matched by its cloned profile dir on the command line)
+$placedBrowser = 0
+Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
+  Where-Object { $_.CommandLine -like '*edge-tenant*' } | ForEach-Object {
+    $p = Get-Process -Id $_.ProcessId -ErrorAction SilentlyContinue
+    if ($p -and $p.MainWindowHandle -ne 0 -and [WinArr]::IsWindowVisible($p.MainWindowHandle)) {
+      Place $p.MainWindowHandle 0 $half
+      Write-Host "browser pid=$($p.Id) -> left ${half}x$($wa.Height)"
+      $placedBrowser++
+    }
+  }
+if ($placedBrowser -eq 0) { Write-Host "WARN: no automated browser window found" }
+
+# Right half: the Scout window
+$placedScout = 0
+Get-Process -ErrorAction SilentlyContinue |
+  Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -and
+                 ($_.ProcessName -match 'Scout|Clawpilot' -or $_.MainWindowTitle -match 'Scout') } |
+  ForEach-Object {
+    Place $_.MainWindowHandle $half $half
+    Write-Host "scout pid=$($_.Id) '$($_.MainWindowTitle)' -> right ${half}x$($wa.Height)"
+    $placedScout++
+  }
+if ($placedScout -eq 0) { Write-Host "WARN: no Scout window found - right half will show the desktop" }

--- a/submissions/clipchamp-video/scripts/clone.ps1
+++ b/submissions/clipchamp-video/scripts/clone.ps1
@@ -1,0 +1,23 @@
+$src = "$env:LOCALAPPDATA\Microsoft\Edge\User Data"
+$dst = "$env:USERPROFILE\.copilot\video-work\edge-tenant"
+
+Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='node.exe'" |
+  Where-Object { $_.CommandLine -notlike '*m-playwright-profiles*' -and $_.CommandLine -notlike '*ms-playwright*' } |
+  ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-Sleep 3
+
+Remove-Item $dst -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $dst | Out-Null
+Copy-Item "$src\Local State" "$dst\Local State" -Force
+robocopy "$src\Profile 1" "$dst\Profile 1" /E /NFL /NDL /NJH /NJS /R:0 /W:0 /XJ `
+  /XD "Service Worker" "Cache" "Code Cache" "GPUCache" "Shared Dictionary" "DawnGraphiteCache" "DawnWebGPUCache" "EdgeCoupons" "Crashpad" "optimization_guide_model_store" | Out-Null
+
+# Patch Preferences with REGEX ONLY. Round-tripping through ConvertFrom-Json/ConvertTo-Json
+# reorders and retypes the file and breaks the profile's signed-in identity (api.bap 404).
+$pf = Join-Path $dst 'Profile 1\Preferences'
+$c = Get-Content $pf -Raw -Encoding UTF8
+$c = $c -replace '"exit_type":"[^"]*"', '"exit_type":"Normal"' -replace '"exited_cleanly":false', '"exited_cleanly":true'
+[System.IO.File]::WriteAllText($pf, $c, (New-Object System.Text.UTF8Encoding($false)))
+
+"cloned: {0:N0} MB" -f ((Get-ChildItem $dst -Recurse -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum/1MB)
+Write-Host ("cookies: " + (Test-Path "$dst\Profile 1\Network\Cookies"))

--- a/submissions/clipchamp-video/scripts/clone.ps1
+++ b/submissions/clipchamp-video/scripts/clone.ps1
@@ -1,7 +1,9 @@
 $src = "$env:LOCALAPPDATA\Microsoft\Edge\User Data"
 $dst = "$env:USERPROFILE\.copilot\video-work\edge-tenant"
 
-Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='node.exe'" |
+# Close the REAL Edge (never the MCP/automation browser) so its profile files unlock for
+# copying. Unrelated to the recording workflow's own Node processes, so node.exe is left alone.
+Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
   Where-Object { $_.CommandLine -notlike '*m-playwright-profiles*' -and $_.CommandLine -notlike '*ms-playwright*' } |
   ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Start-Sleep 3

--- a/submissions/clipchamp-video/scripts/common.js
+++ b/submissions/clipchamp-video/scripts/common.js
@@ -1,0 +1,103 @@
+// common.js — shared launch/auth/UI helpers for a Copilot Studio agent demo recording.
+// EDIT THE CONSTANTS BELOW before running: UD/OUT can stay as-is (they're derived from
+// the current user profile), but ENV and AGENT_ID must point at YOUR agent, and the
+// account-tile match inside settle() below must match YOUR sign-in tenant/email.
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const UD = path.join(os.homedir(), '.copilot', 'video-work', 'edge-tenant');
+const EXE = 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe';
+const OUT = path.join(os.homedir(), '.copilot', 'video-work', 'agent-demo');
+const ENV = 'REPLACE_WITH_YOUR_ENVIRONMENT_ID';   // e.g. Default-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+const AGENT_ID = 'REPLACE_WITH_YOUR_AGENT_ID';    // the GUID from the agent's Copilot Studio URL
+// Current Copilot Studio experience uses /agents/<id>; /agents/designer/<id> renders blank.
+const AGENT_URL = `https://copilotstudio.microsoft.com/environments/${ENV}/agents/${AGENT_ID}`;
+const AGENT_URL_LEGACY = `https://copilotstudio.microsoft.com/environments/${ENV}/agents/designer/${AGENT_ID}`;
+
+// Physical screen working area is 1536x976. Chrome ignores --window-size on this
+// profile, so the window is maximized via Win32 after launch (maximize.ps1).
+// dsf 0.8 turns the 1536px-wide window into a 1920 CSS px capture buffer.
+// Measured: at dsf 0.8 the maximized window yields 2376 CSS px wide. CSS width scales
+// as 1/dsf, so 0.8 * (2376/1920) = 0.99 lands on a ~1920 CSS px capture buffer.
+const DSF = 0.99;
+const ARGS = [
+  '--profile-directory=Profile 1',
+  '--test-type', '--disable-infobars',
+  '--hide-crash-restore-bubble', '--disable-session-crashed-bubble',
+  '--no-first-run', '--no-default-browser-check',
+  '--disable-features=msEdgeSplitScreen,msUndersideButton,EdgeDiscoverEntrypoint',
+  `--force-device-scale-factor=${DSF}`,
+  '--start-maximized',
+];
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// Chrome silently ignores --window-size/--start-maximized on profiles carrying saved
+// bounds; drive the real Win32 window instead.
+function maximizeWindow(log) {
+  try {
+    const out = require('child_process').execSync(
+      `powershell -NoProfile -ExecutionPolicy Bypass -File "${path.join(OUT, 'maximize.ps1')}"`,
+      { encoding: 'utf8', timeout: 60000 });
+    if (log) log('maximize: ' + out.trim());
+  } catch (e) { if (log) log('maximize ERR ' + e.message); }
+}
+
+function mkLog(file) {
+  const p = path.join(OUT, file);
+  fs.writeFileSync(p, '');
+  return m => fs.appendFileSync(p, `[${new Date().toISOString()}] ${m}\n`);
+}
+
+async function dismissPopups(page) {
+  for (const n of ['Close', 'Got it', 'Dismiss', 'No thanks', 'Skip', 'Not now', 'Accept', 'OK', 'Maybe later']) {
+    try {
+      const b = page.getByRole('button', { name: new RegExp(`^${n}$`, 'i') }).first();
+      if (await b.isVisible({ timeout: 400 })) { await b.click({ timeout: 1500 }); await sleep(300); }
+    } catch {}
+  }
+  try { await page.keyboard.press('Escape'); } catch {}
+}
+
+// Poll until the app host is stable for N consecutive polls; click through MSAL on the way.
+// Match on HOST, not url.includes(): authorize URLs embed the app host in redirect_uri.
+async function settle(page, log, budgetMs = 240000, needStable = 4) {
+  const host = u => { try { return new URL(u).host.toLowerCase(); } catch { return ''; } };
+  const t0 = Date.now(); let stable = 0;
+  while (Date.now() - t0 < budgetMs) {
+    const h = host(page.url());
+    if (h.endsWith('login.microsoftonline.com') || h.endsWith('login.live.com')) {
+      stable = 0;
+      // Replace 'youraccount@yourtenant' with the email/tenant you sign in with.
+      try { const tile = page.locator('div[data-test-id="youraccount@yourtenant.onmicrosoft.com"], div[role="button"]:has-text("youraccount@yourtenant"), small:has-text("youraccount@yourtenant")').first();
+        if (await tile.isVisible({ timeout: 700 })) { log('auth: tenant account tile'); await tile.click({ timeout: 3000 }); await sleep(4500); continue; } } catch {}
+      try { const cb = page.locator('#KmsiCheckboxField').first();
+        if (await cb.isVisible({ timeout: 400 })) await cb.check({ timeout: 2000 }).catch(() => {}); } catch {}
+      try { const yes = page.locator('#idSIButton9').first();
+        if (await yes.isVisible({ timeout: 800 })) { log('auth: #idSIButton9'); await yes.click({ timeout: 3000 }); await sleep(4000); continue; } } catch {}
+      await sleep(2000); continue;
+    }
+    if (h.endsWith('copilotstudio.microsoft.com')) {
+      const len = await page.evaluate(() => document.body.innerText.length).catch(() => 0);
+      const busy = await page.locator('text=/Initializing|Loading your|Getting things ready/i').count().catch(() => 0);
+      if (len > 400 && !busy) { stable++; if (stable >= needStable) { log(`settled len=${len}`); return true; } }
+      else stable = 0;
+    } else stable = 0;
+    await sleep(2000);
+  }
+  log('SETTLE TIMEOUT ' + page.url());
+  return false;
+}
+
+async function logViewport(page, log) {
+  const v = await page.evaluate(() => ({
+    css: `${innerWidth}x${innerHeight}`, dpr: devicePixelRatio,
+    screen: `${screen.width}x${screen.height}`, avail: `${screen.availWidth}x${screen.availHeight}`,
+    outer: `${outerWidth}x${outerHeight}`,
+  }));
+  log('VIEWPORT ' + JSON.stringify(v));
+  return v;
+}
+
+module.exports = { UD, EXE, OUT, ENV, AGENT_ID, AGENT_URL, AGENT_URL_LEGACY, ARGS, DSF, sleep, mkLog, dismissPopups, settle, logViewport, maximizeWindow };

--- a/submissions/clipchamp-video/scripts/common.js
+++ b/submissions/clipchamp-video/scripts/common.js
@@ -38,13 +38,14 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 function maximizeWindow(log) {
   try {
     const out = require('child_process').execSync(
-      `powershell -NoProfile -ExecutionPolicy Bypass -File "${path.join(OUT, 'maximize.ps1')}"`,
+      `powershell -NoProfile -ExecutionPolicy Bypass -File "${path.join(__dirname, 'maximize.ps1')}"`,
       { encoding: 'utf8', timeout: 60000 });
     if (log) log('maximize: ' + out.trim());
   } catch (e) { if (log) log('maximize ERR ' + e.message); }
 }
 
 function mkLog(file) {
+  fs.mkdirSync(OUT, { recursive: true });
   const p = path.join(OUT, file);
   fs.writeFileSync(p, '');
   return m => fs.appendFileSync(p, `[${new Date().toISOString()}] ${m}\n`);
@@ -67,7 +68,7 @@ async function settle(page, log, budgetMs = 240000, needStable = 4) {
   const t0 = Date.now(); let stable = 0;
   while (Date.now() - t0 < budgetMs) {
     const h = host(page.url());
-    if (h.endsWith('login.microsoftonline.com') || h.endsWith('login.live.com')) {
+    if (h.endsWith('login.microsoftonline.com') || h.endsWith('login.microsoft.com') || h.endsWith('login.live.com')) {
       stable = 0;
       // Replace 'youraccount@yourtenant' with the email/tenant you sign in with.
       try { const tile = page.locator('div[data-test-id="youraccount@yourtenant.onmicrosoft.com"], div[role="button"]:has-text("youraccount@yourtenant"), small:has-text("youraccount@yourtenant")').first();

--- a/submissions/clipchamp-video/scripts/diag.js
+++ b/submissions/clipchamp-video/scripts/diag.js
@@ -1,5 +1,5 @@
 // diag.js — screenshot the bots list at intervals to see what actually renders
-const { chromium } = require('playwright');
+const { chromium } = require('./require-playwright');
 const fs = require('fs');
 const path = require('path');
 const C = require('./common');

--- a/submissions/clipchamp-video/scripts/diag.js
+++ b/submissions/clipchamp-video/scripts/diag.js
@@ -1,0 +1,35 @@
+// diag.js — screenshot the bots list at intervals to see what actually renders
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+const C = require('./common');
+
+const log = C.mkLog('diag.log');
+const BOTS = `https://copilotstudio.microsoft.com/environments/${C.ENV}/bots`;
+
+(async () => {
+  const ctx = await chromium.launchPersistentContext(C.UD, {
+    executablePath: C.EXE, headless: false, args: C.ARGS, viewport: null,
+  });
+  const page = ctx.pages()[0] || await ctx.newPage();
+  page.on('console', m => { if (m.type() === 'error') log('CONSOLE ' + m.text().slice(0, 200)); });
+  page.on('response', r => { if (r.status() >= 400) log(`HTTP ${r.status()} ${r.url().slice(0, 160)}`); });
+
+  await C.sleep(2000);
+  C.maximizeWindow(log);
+  await page.goto(BOTS, { waitUntil: 'domcontentloaded', timeout: 180000 });
+
+  for (let i = 1; i <= 8; i++) {
+    await C.sleep(15000);
+    const info = await page.evaluate(() => ({
+      url: location.href, len: document.body.innerText.length,
+      html: document.documentElement.outerHTML.length,
+      css: `${innerWidth}x${innerHeight}`,
+      head: document.body.innerText.replace(/\s+/g, ' ').slice(0, 200),
+    })).catch(e => ({ err: e.message }));
+    log(`t=${i * 15}s ` + JSON.stringify(info));
+    await page.screenshot({ path: path.join(C.OUT, `d-${String(i).padStart(2, '0')}.png`) }).catch(() => {});
+  }
+  log('DONE');
+  await ctx.close();
+})().catch(e => { log('ERR ' + e.message); process.exit(1); });

--- a/submissions/clipchamp-video/scripts/dual-capture.js
+++ b/submissions/clipchamp-video/scripts/dual-capture.js
@@ -1,0 +1,70 @@
+// dual-capture.js — run the recorder while ffmpeg gdigrab captures the whole desktop,
+// so the assistant conversation AND the automated browser are both in-frame, in sync.
+//
+// Usage: node dual-capture.js [outfile.mp4]
+// Arrange windows first with arrange.ps1 (browser left half, Scout right half).
+const { spawn, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const OUT = __dirname;
+const OUTFILE = path.resolve(process.argv[2] || path.join(OUT, 'dual.mp4'));
+const LOG = path.join(OUT, 'dual.log');
+const log = m => fs.appendFileSync(LOG, `[${new Date().toISOString()}] ${m}\n`);
+
+const LEAD_IN_MS = 3000;   // a beat of context before the run starts
+const LEAD_OUT_MS = 3000;  // let the last answer breathe before cutting
+
+(async () => {
+  fs.writeFileSync(LOG, '');
+  try {
+    execSync(`powershell -NoProfile -ExecutionPolicy Bypass -File "${path.join(OUT, 'arrange.ps1')}"`,
+      { encoding: 'utf8', timeout: 60000 });
+    log('windows arranged');
+  } catch (e) { log('arrange skipped: ' + e.message); }
+
+  // Capture the whole desktop: per-window gdigrab drops frames when occluded or redrawn.
+  const ff = spawn('ffmpeg', [
+    '-y', '-f', 'gdigrab', '-framerate', '15', '-i', 'desktop',
+    '-c:v', 'libx264', '-pix_fmt', 'yuv420p', '-crf', '23', '-preset', 'veryfast',
+    OUTFILE,
+  ], { stdio: ['pipe', 'ignore', 'pipe'] });
+  ff.stderr.on('data', d => {
+    const s = d.toString();
+    if (/error|Error|Invalid/.test(s)) log('ffmpeg: ' + s.trim().slice(0, 200));
+  });
+  log('ffmpeg started pid=' + ff.pid + ' -> ' + OUTFILE);
+
+  await new Promise(r => setTimeout(r, LEAD_IN_MS));
+
+  let code = 0;
+  try {
+    log('running recorder');
+    execSync(`node "${path.join(OUT, 'recorder.js')}"`, {
+      encoding: 'utf8', stdio: 'inherit', timeout: 40 * 60 * 1000,
+      env: { ...process.env, NODE_PATH: process.env.NODE_PATH || execSync('npm root -g', { encoding: 'utf8' }).trim() },
+    });
+    log('recorder finished');
+  } catch (e) { code = 1; log('recorder ERR ' + e.message); }
+
+  await new Promise(r => setTimeout(r, LEAD_OUT_MS));
+
+  // Ask ffmpeg to stop so it writes the moov atom; killing it yields an unplayable file.
+  log('stopping ffmpeg (q)');
+  try { ff.stdin.write('q'); ff.stdin.end(); } catch {}
+  await new Promise(res => {
+    const t = setTimeout(() => { try { process.kill(ff.pid); } catch {} res(); }, 20000);
+    ff.on('close', c => { clearTimeout(t); log('ffmpeg exited ' + c); res(); });
+  });
+
+  try {
+    const probe = execSync(
+      `ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${OUTFILE}"`,
+      { encoding: 'utf8' }).trim();
+    log('duration=' + probe + 's size=' + fs.statSync(OUTFILE).size);
+  } catch (e) {
+    log('probe failed (missing moov?) — remux: ffmpeg -i broken.mp4 -c copy fixed.mp4');
+  }
+  log('DONE');
+  process.exit(code);
+})();

--- a/submissions/clipchamp-video/scripts/findagent.js
+++ b/submissions/clipchamp-video/scripts/findagent.js
@@ -1,0 +1,58 @@
+// findagent.js — list agents (name + id) and environments to locate your target agent
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+const C = require('./common');
+
+const log = C.mkLog('findagent.log');
+const BOTS = `https://copilotstudio.microsoft.com/environments/${C.ENV}/bots`;
+
+(async () => {
+  const ctx = await chromium.launchPersistentContext(C.UD, {
+    executablePath: C.EXE, headless: false, args: C.ARGS, viewport: null,
+  });
+  const page = ctx.pages()[0] || await ctx.newPage();
+  await C.sleep(2000);
+  C.maximizeWindow(log);
+  await page.goto(BOTS, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await C.settle(page, log);
+  C.maximizeWindow(log);
+  await C.dismissPopups(page);
+  await C.sleep(6000);
+
+  // Rows in the agents grid: capture visible name + any id we can find
+  const rows = await page.evaluate(() => {
+    const out = [];
+    document.querySelectorAll('[role="row"]').forEach(r => {
+      const t = r.innerText.replace(/\s+/g, ' ').trim();
+      if (!t) return;
+      const a = r.querySelector('a[href]');
+      out.push({ text: t.slice(0, 140), href: a ? a.getAttribute('href') : null });
+    });
+    return out;
+  });
+  fs.writeFileSync(path.join(C.OUT, 'agent-rows.json'), JSON.stringify(rows, null, 2), 'utf8');
+  log('rows=' + rows.length);
+
+  // Click each candidate row to harvest its agent id from the URL
+  const wanted = process.argv.slice(2);
+  for (const name of wanted) {
+    try {
+      log('--- opening ' + name);
+      await page.goto(BOTS, { waitUntil: 'domcontentloaded', timeout: 120000 });
+      await C.settle(page, log, 120000, 3);
+      await C.sleep(3000);
+      await page.getByText(name, { exact: false }).first().click({ timeout: 15000 });
+      await C.settle(page, log, 150000, 3);
+      await C.sleep(6000);
+      const u = page.url();
+      const txt = await page.evaluate(() => document.body.innerText).catch(() => '');
+      const slug = name.replace(/[^a-z0-9]+/gi, '-').toLowerCase();
+      fs.writeFileSync(path.join(C.OUT, `agent-${slug}.txt`), `URL ${u}\n\n${txt}`, 'utf8');
+      await page.screenshot({ path: path.join(C.OUT, `agent-${slug}.png`) }).catch(() => {});
+      log(`${name} -> ${u} len=${txt.length}`);
+    } catch (e) { log(name + ' ERR ' + e.message); }
+  }
+  log('DONE');
+  await ctx.close();
+})().catch(e => { log('ERR ' + e.message); process.exit(1); });

--- a/submissions/clipchamp-video/scripts/findagent.js
+++ b/submissions/clipchamp-video/scripts/findagent.js
@@ -1,5 +1,5 @@
 // findagent.js — list agents (name + id) and environments to locate your target agent
-const { chromium } = require('playwright');
+const { chromium } = require('./require-playwright');
 const fs = require('fs');
 const path = require('path');
 const C = require('./common');

--- a/submissions/clipchamp-video/scripts/maximize.ps1
+++ b/submissions/clipchamp-video/scripts/maximize.ps1
@@ -1,0 +1,31 @@
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class Win {
+  [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr h, int c);
+  [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr h, int x, int y, int w, int t, bool r);
+  [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr h);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr h);
+}
+"@ -ErrorAction SilentlyContinue
+
+Add-Type -AssemblyName System.Windows.Forms
+$wa = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+
+$targets = Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
+  Where-Object { $_.CommandLine -like '*video-work\edge-tenant*' } |
+  Select-Object -ExpandProperty ProcessId
+
+$done = 0
+foreach ($procId in $targets) {
+  $p = Get-Process -Id $procId -ErrorAction SilentlyContinue
+  if ($p -and $p.MainWindowHandle -ne 0 -and [Win]::IsWindowVisible($p.MainWindowHandle)) {
+    [Win]::ShowWindow($p.MainWindowHandle, 9) | Out-Null   # SW_RESTORE
+    [Win]::MoveWindow($p.MainWindowHandle, $wa.X, $wa.Y, $wa.Width, $wa.Height, $true) | Out-Null
+    [Win]::ShowWindow($p.MainWindowHandle, 3) | Out-Null   # SW_MAXIMIZE
+    [Win]::SetForegroundWindow($p.MainWindowHandle) | Out-Null
+    Write-Host "maximized pid=$procId to $($wa.Width)x$($wa.Height)"
+    $done++
+  }
+}
+if ($done -eq 0) { Write-Host "no visible edge window found" }

--- a/submissions/clipchamp-video/scripts/prep.ps1
+++ b/submissions/clipchamp-video/scripts/prep.ps1
@@ -1,0 +1,14 @@
+$dst = "$env:USERPROFILE\.copilot\video-work\edge-tenant"
+$pf  = Join-Path $dst 'Profile 1\Preferences'
+
+Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='node.exe'" |
+  Where-Object { $_.CommandLine -notlike '*m-playwright-profiles*' -and $_.CommandLine -notlike '*ms-playwright*' } |
+  ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Start-Sleep 2
+Get-ChildItem $dst -Filter 'Singleton*' -Force -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
+
+# REGEX ONLY - never ConvertFrom-Json/ConvertTo-Json this file (breaks signed-in state).
+$c = Get-Content $pf -Raw -Encoding UTF8
+$c = $c -replace '"exit_type":"[^"]*"', '"exit_type":"Normal"' -replace '"exited_cleanly":false', '"exited_cleanly":true'
+[System.IO.File]::WriteAllText($pf, $c, (New-Object System.Text.UTF8Encoding($false)))
+Write-Host "profile prepped"

--- a/submissions/clipchamp-video/scripts/prep.ps1
+++ b/submissions/clipchamp-video/scripts/prep.ps1
@@ -1,8 +1,15 @@
 $dst = "$env:USERPROFILE\.copilot\video-work\edge-tenant"
 $pf  = Join-Path $dst 'Profile 1\Preferences'
 
-Get-CimInstance Win32_Process -Filter "Name='msedge.exe' OR Name='node.exe'" |
-  Where-Object { $_.CommandLine -notlike '*m-playwright-profiles*' -and $_.CommandLine -notlike '*ms-playwright*' } |
+# Only stop OUR OWN processes: the Edge instance running on the cloned "edge-tenant"
+# profile (never the MCP browser or any other Edge window), and any node.exe process
+# that's actually running one of this skill's scripts (never unrelated Node apps/dev
+# servers on the machine).
+Get-CimInstance Win32_Process -Filter "Name='msedge.exe'" |
+  Where-Object { $_.CommandLine -like '*edge-tenant*' } |
+  ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+Get-CimInstance Win32_Process -Filter "Name='node.exe'" |
+  Where-Object { $_.CommandLine -match 'recorder\.js|verify\.js|findagent\.js|diag\.js|dual-capture\.js' } |
   ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
 Start-Sleep 2
 Get-ChildItem $dst -Filter 'Singleton*' -Force -ErrorAction SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue

--- a/submissions/clipchamp-video/scripts/recorder.js
+++ b/submissions/clipchamp-video/scripts/recorder.js
@@ -1,6 +1,6 @@
 // recorder.js — records a Copilot Studio agent demo: overview/instructions/skills/tools
 // + a handful of live test turns. Edit PROMPTS/MAXES/HOLDS below for your own scenario.
-const { chromium } = require('playwright');
+const { chromium } = require('./require-playwright');
 const fs = require('fs');
 const path = require('path');
 const C = require('./common');

--- a/submissions/clipchamp-video/scripts/recorder.js
+++ b/submissions/clipchamp-video/scripts/recorder.js
@@ -1,0 +1,137 @@
+// recorder.js — records a Copilot Studio agent demo: overview/instructions/skills/tools
+// + a handful of live test turns. Edit PROMPTS/MAXES/HOLDS below for your own scenario.
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+const C = require('./common');
+
+const log = C.mkLog('progress.log');
+const OUTDIR = path.join(C.OUT, 'video');
+
+const PROMPTS = [
+  "Hi, I can't connect to the company VPN from home. Is there a knowledge article that can help me fix this?",
+  "It still fails with a timeout and this is blocking my work. Can you escalate to a human and book an appointment with the IT support team?",
+  "I also need a Microsoft Project license for my new role. Please create a request ticket for that.",
+];
+const MAXES = [110000, 150000, 150000];
+const HOLDS = [5000, 5500, 6000];
+
+async function typeHuman(page, box, text) {
+  await box.click();
+  for (const ch of text) { await page.keyboard.type(ch); await C.sleep(12 + Math.random() * 30); }
+}
+
+async function scrollBottom(page) {
+  await page.evaluate(() => {
+    const els = [...document.querySelectorAll('*')].filter(e => e.scrollHeight > e.clientHeight + 60);
+    els.forEach(e => { e.scrollTop = e.scrollHeight; });
+    window.scrollTo(0, document.body.scrollHeight);
+  }).catch(() => {});
+}
+
+// A finished assistant turn adds a feedback ("Dislike") button.
+async function waitForTurn(page, prev, maxMs) {
+  const t0 = Date.now();
+  while (Date.now() - t0 < maxMs) {
+    let c = 0;
+    try { c = await page.getByRole('button', { name: /Dislike/i }).count(); } catch {}
+    if (c > prev) { await C.sleep(1500); return c; }
+    await C.sleep(700);
+  }
+  try { return await page.getByRole('button', { name: /Dislike/i }).count(); } catch { return prev; }
+}
+
+// Copilot Studio's Build/Preview/Evaluate/Monitor switcher is a menuitemradio DROPDOWN
+// behind one "Build" button, not tabs — a tab-role locator finds nothing and this used
+// to time out waiting for the chat input. Navigating straight to <agentUrl>/preview is
+// far more reliable than any menu-click choreography.
+async function openTestPane(page) {
+  log('goto preview url');
+  await page.goto(C.AGENT_URL + '/preview', { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => {});
+  await C.sleep(5000);
+  // Fallback for apps where /preview isn't a valid route: try tab, then dropdown+menuitemradio.
+  const input = page.getByRole('textbox', { name: /Chat message input|Ask a question|Type your message/i }).first();
+  if (await input.isVisible({ timeout: 3000 }).catch(() => false)) return;
+  for (const n of ['Test', 'Preview']) {
+    try {
+      const t = page.getByRole('tab', { name: new RegExp(`^${n}$`, 'i') }).first();
+      if (await t.isVisible({ timeout: 2500 })) { log('tab ' + n); await t.click(); await C.sleep(6000); return; }
+    } catch {}
+  }
+  try {
+    const dd = page.getByRole('button', { name: /^Build$/i }).first();
+    if (await dd.isVisible({ timeout: 2500 })) { log('dropdown Build'); await dd.click(); await C.sleep(1000); }
+    const opt = page.getByRole('menuitemradio', { name: /^Preview$/i }).first();
+    if (await opt.isVisible({ timeout: 2500 })) { log('menuitemradio Preview'); await opt.click(); await C.sleep(6000); }
+  } catch {}
+}
+
+(async () => {
+  fs.rmSync(OUTDIR, { recursive: true, force: true });
+  fs.mkdirSync(OUTDIR, { recursive: true });
+
+  const ctx = await chromium.launchPersistentContext(C.UD, {
+    executablePath: C.EXE, headless: false, args: C.ARGS, viewport: null,
+    recordVideo: { dir: OUTDIR, size: { width: 1920, height: 1160 } },
+  });
+  const page = ctx.pages()[0] || await ctx.newPage();
+  await C.sleep(1500);
+  C.maximizeWindow(log);
+
+  log('goto agent');
+  await page.goto(C.AGENT_URL, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await C.settle(page, log, 240000, 3);
+  C.maximizeWindow(log);
+  await C.dismissPopups(page);
+  await C.sleep(6000);
+  log('BEAT overview');
+  await C.logViewport(page, log);
+
+  // --- Beat 1: overview + instructions ---
+  await C.sleep(6000);
+  log('BEAT instructions-scroll');
+  try {
+    const instr = page.getByRole('textbox', { name: /Agent instructions|Instructions/i }).first();
+    if (await instr.isVisible({ timeout: 4000 })) await instr.hover();
+  } catch {}
+  for (let i = 0; i < 5; i++) { await page.mouse.wheel(0, 200); await C.sleep(1500); }
+  await C.sleep(2500);
+
+  // --- Beat 2: skills / tools / knowledge ---
+  log('BEAT tools');
+  for (let i = 0; i < 5; i++) { await page.mouse.wheel(0, 240); await C.sleep(1600); }
+  await C.sleep(3000);
+  await page.mouse.wheel(0, -1600); await C.sleep(2500);
+
+  // --- Beat 3-5: the three live tests ---
+  log('BEAT open-test');
+  await openTestPane(page);
+  await C.dismissPopups(page);
+  const input = page.getByRole('textbox', { name: /Chat message input|Ask a question|Type your message/i }).first();
+  await input.waitFor({ state: 'visible', timeout: 90000 });
+  await C.sleep(5000);
+
+  for (let i = 0; i < PROMPTS.length; i++) {
+    log(`BEAT test${i + 1}-start`);
+    let prev = 0;
+    try { prev = await page.getByRole('button', { name: /Dislike/i }).count(); } catch {}
+    await typeHuman(page, input, PROMPTS[i]);
+    await C.sleep(600);
+    try { await page.getByTestId('send-button').click(); }
+    catch { try { await page.getByRole('button', { name: /^Send/i }).first().click(); } catch { await page.keyboard.press('Enter'); } }
+    log(`BEAT test${i + 1}-sent`);
+    await C.sleep(1500);
+    await waitForTurn(page, prev, MAXES[i]);
+    await scrollBottom(page);
+    log(`BEAT test${i + 1}-answered`);
+    await C.sleep(HOLDS[i]);
+    await scrollBottom(page);
+  }
+
+  log('BEAT end');
+  await C.sleep(4000);
+  await ctx.close();
+
+  const files = fs.readdirSync(OUTDIR).filter(f => f.endsWith('.webm'));
+  log('VIDEO ' + JSON.stringify(files));
+})().catch(e => { log('ERR ' + e.message + '\n' + (e.stack || '')); process.exit(1); });

--- a/submissions/clipchamp-video/scripts/require-playwright.js
+++ b/submissions/clipchamp-video/scripts/require-playwright.js
@@ -1,0 +1,20 @@
+// require-playwright.js — resolve a GLOBALLY installed Playwright even when NODE_PATH
+// isn't set in the current shell. `npm install -g playwright` alone does NOT make
+// `require('playwright')` work from an arbitrary working directory unless NODE_PATH
+// points at the global node_modules root — this shim finds that root and requires
+// straight from it so every script in this folder "just works" without the caller
+// having to remember an env var.
+const path = require('path');
+const { execSync } = require('child_process');
+
+function loadPlaywright() {
+  // 1) Already resolvable (NODE_PATH set, or playwright installed locally) — use it.
+  try { return require('playwright'); } catch {}
+
+  // 2) Fall back to the global npm root and require the package straight from there.
+  const globalRoot = execSync('npm root -g', { encoding: 'utf8' }).trim();
+  return require(path.join(globalRoot, 'playwright'));
+}
+
+module.exports = loadPlaywright();
+

--- a/submissions/clipchamp-video/scripts/verify.js
+++ b/submissions/clipchamp-video/scripts/verify.js
@@ -1,5 +1,5 @@
 // verify.js — MANDATORY GATE: prove window fills the screen and the chat input bar is in-frame.
-const { chromium } = require('playwright');
+const { chromium } = require('./require-playwright');
 const path = require('path');
 const C = require('./common');
 

--- a/submissions/clipchamp-video/scripts/verify.js
+++ b/submissions/clipchamp-video/scripts/verify.js
@@ -1,0 +1,74 @@
+// verify.js — MANDATORY GATE: prove window fills the screen and the chat input bar is in-frame.
+const { chromium } = require('playwright');
+const path = require('path');
+const C = require('./common');
+
+const log = C.mkLog('verify.log');
+
+(async () => {
+  const ctx = await chromium.launchPersistentContext(C.UD, {
+    executablePath: C.EXE, headless: false, args: C.ARGS, viewport: null,
+  });
+  const page = ctx.pages()[0] || await ctx.newPage();
+  await C.sleep(2500);
+  C.maximizeWindow(log);
+  await C.sleep(2000);
+  await C.logViewport(page, log);
+  await page.goto(C.AGENT_URL, { waitUntil: 'domcontentloaded', timeout: 180000 });
+  await C.settle(page, log);
+  C.maximizeWindow(log);
+  await C.dismissPopups(page);
+  await C.sleep(5000);
+  await C.logViewport(page, log);
+
+  // Build view (overview + instructions)
+  await page.screenshot({ path: path.join(C.OUT, 'v-build.png') }).catch(() => {});
+  const txt = await page.evaluate(() => document.body.innerText).catch(() => '');
+  require('fs').writeFileSync(path.join(C.OUT, 'v-build.txt'), `URL ${page.url()}\n\n${txt}`, 'utf8');
+  log('build dump len=' + txt.length);
+
+  // Test pane — Copilot Studio uses a Build/Preview/Evaluate/Monitor DROPDOWN behind a
+  // single "Build" button (menuitemradio options), not tabs. Navigating straight to
+  // <agentUrl>/preview is far more reliable than menu-click choreography; fall back to
+  // tab/dropdown clicks for apps where that route doesn't exist.
+  await page.goto(C.AGENT_URL + '/preview', { waitUntil: 'domcontentloaded', timeout: 60000 }).catch(() => {});
+  await C.sleep(4000);
+  let onPreview = await page.getByRole('textbox', { name: /Chat message input|Ask a question/i }).first()
+    .isVisible({ timeout: 3000 }).catch(() => false);
+  if (!onPreview) {
+    for (const name of ['Test', 'Preview']) {
+      try {
+        const t = page.getByRole('tab', { name: new RegExp(`^${name}$`, 'i') }).first();
+        if (await t.isVisible({ timeout: 2500 })) { log('click tab ' + name); await t.click(); await C.sleep(6000); break; }
+      } catch {}
+    }
+    try {
+      const btn = page.getByRole('button', { name: /^Test$/i }).first();
+      if (await btn.isVisible({ timeout: 2000 })) { log('click Test button'); await btn.click(); await C.sleep(6000); }
+    } catch {}
+    try {
+      const dd = page.getByRole('button', { name: /^Build$/i }).first();
+      if (await dd.isVisible({ timeout: 2000 })) { log('click Build dropdown'); await dd.click(); await C.sleep(1000); }
+      const opt = page.getByRole('menuitemradio', { name: /^Preview$/i }).first();
+      if (await opt.isVisible({ timeout: 2000 })) { log('click Preview menuitemradio'); await opt.click(); await C.sleep(6000); }
+    } catch {}
+  }
+  await C.dismissPopups(page);
+  await C.sleep(4000);
+
+  const input = page.getByRole('textbox', { name: /Chat message input|Ask a question/i }).first();
+  const ok = await input.isVisible({ timeout: 30000 }).catch(() => false);
+  log('chat input visible=' + ok);
+  if (ok) {
+    await input.click();
+    await page.keyboard.type('Hi, can you help me reset my VPN access?', { delay: 22 });
+    await C.sleep(800);
+    try { await page.getByTestId('send-button').click(); } catch { await page.keyboard.press('Enter'); }
+    await C.sleep(30000);
+  }
+  await page.screenshot({ path: path.join(C.OUT, 'v-test.png') }).catch(() => {});
+  const t2 = await page.evaluate(() => document.body.innerText).catch(() => '');
+  require('fs').writeFileSync(path.join(C.OUT, 'v-test.txt'), t2, 'utf8');
+  log('DONE');
+  await ctx.close();
+})().catch(e => { log('ERR ' + e.message); process.exit(1); });


### PR DESCRIPTION
## What
Adds the **clipchamp-video** skill: produce a polished, narrated demo video of a live web app or Copilot Studio agent — real screen-flow footage under an AI (Ava neural) voiceover — either fully headless (ffmpeg + edge-tts) or assembled in the Clipchamp web UI as an editable project.

## Why
Built and refined this skill across several real recording sessions (Copilot Studio agent demos). Captures hard-won lessons that would otherwise be relearned every time, notably:
- Copilot Studio's Build/Preview/Evaluate/Monitor switcher is a dropdown (menuitemradio) behind one "Build" button, not tabs — navigating straight to `<agentUrl>/preview` is far more reliable than menu-click choreography.
- How to detect and fix a recorded frame that shows real content in a small corner surrounded by dead gray space (window not filling the screen) via crop+scale+pad during post-processing.
- A "MANDATORY GATE" workflow (verify.js) that proves the chat input bar is fully in-frame before committing to a full recording run.

## What's included
- `SKILL.md` — full agent-facing instructions (recording, post-processing, narration, Clipchamp UI path, troubleshooting).
- `scripts/` — ready-made, sanitized helper scripts (recorder, verify gate, profile cloning/prep, window arranging, dual capture, agent finder). All personal usernames, tenant IDs, and agent IDs have been replaced with placeholders / `$env:USERPROFILE`.
- `README.md` — human-facing overview for the gallery page.
- `metadata.json` — catalog details.

## Validation
`npm run check:submissions` passes locally (all 92 submissions, including this one).