### PR TITLE
Add Slashbooks submission

### DIFF
--- a/submissions/slashbooks/SKILL.md
+++ b/submissions/slashbooks/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: slashbooks
+description: Replace QuickBooks with an AI agent you control.
+---
+
+# Slashbooks
+
+Slashbooks is an open-source alternative to QuickBooks. An AI agent you control imports bank and card activity, closes the month, and creates the files your accountant needs.
+
+- Homepage: https://slashbooks.org
+- Source: https://github.com/giltotherescue/slashbooks
+- License: Apache-2.0
+- Author: Gil Hildebrand (https://github.com/giltotherescue)
+
+## What it does
+
+1. Imports bank and credit card activity.
+2. Categorizes and reconciles transactions to close the month.
+3. Exports the files your accountant needs.
+
+## Usage
+
+Point the agent at your transaction exports and ask it to close the month. It returns categorized books plus accountant-ready files.

--- a/submissions/slashbooks/metadata.json
+++ b/submissions/slashbooks/metadata.json
@@ -1,0 +1,20 @@
+{
+  "name": "Slashbooks",
+  "description": "Replace QuickBooks with an AI agent you control.",
+  "platforms": [
+    "Cowork",
+    "Copilot Studio",
+    "Scout"
+  ],
+  "tags": [
+    "bookkeeping",
+    "accounting",
+    "finance",
+    "automation"
+  ],
+  "author": "Gil Hildebrand",
+  "authorUrl": "https://github.com/giltotherescue",
+  "version": "1.0.0",
+  "createdAt": "2026-08-24",
+  "updatedAt": "2026-08-24"
+}


### PR DESCRIPTION
Adds one submission folder, `submissions/slashbooks/` (metadata.json + SKILL.md).

Slashbooks — Replace QuickBooks with an AI agent you control. It imports bank and card activity, closes the month, and creates the files your accountant needs.

- Homepage: https://slashbooks.org
- Source: https://github.com/giltotherescue/slashbooks
- License: Apache-2.0
- Platforms: Cowork, Copilot Studio, Scout
- Author: Gil Hildebrand (https://github.com/giltotherescue)