### PR TITLE
Add PFK/JKK Operating System skill

### DIFF
--- a/submissions/pfk-jkk-operating-system/README.md
+++ b/submissions/pfk-jkk-operating-system/README.md
@@ -1,0 +1,33 @@
+# PFK/JKK Operating System
+
+Build a shared operating flow for any product or service. This skill turns meeting notes, email, tickets, documents, retrospectives, and visual process material into a maintainable PFK and JKK workflow.
+
+PFK makes the full path of work visible so the team can improve one shared flow. JKK puts quality at the source: every process node has a defined input, deliverable, owner, pass criteria, and response when a check fails.
+
+## What It Produces
+
+- An evidence register that separates confirmed facts, observations, assumptions, and conflicts.
+- Concise questions for gaps that would change the flow or its quality standard.
+- A whole-process Mermaid diagram with normal handoffs, quality gates, rework loops, and blocker escalation.
+- A JKK node card for every meaningful process outcome.
+- A Kaizen backlog and change record for continuous improvement.
+
+## Typical Prompts
+
+```text
+Use the attached meeting notes, launch retrospective, and support tickets to create the current product-onboarding flow. Ask only the questions required to finalize ownership, handoffs, and quality gates.
+```
+
+```text
+Update node N4 in the customer-support flow: an escalation now requires a reproducible case and severity assessment. Show the updated node card and the complete Mermaid flow.
+```
+
+```text
+Create a future-state service-delivery flow from these artifacts. Save the Mermaid source, node cards, open decisions, and a PNG export.
+```
+
+## Notes
+
+The skill instructions and templates are in English. User-facing questions, reports, node cards, and diagram labels follow the user's language unless another output language is requested. Supplied images are analyzed as evidence and are not copied into the skill or stored as examples.
+
+Mermaid source is the editable record and the required output. The optional Python helper can render it to SVG or PNG when the host allows command execution and has Python 3, Node.js, `npx`, and network access. Copilot Studio use does not depend on the helper; hosts that cannot execute scripts still receive the complete Mermaid source and flow artifacts.

--- a/submissions/pfk-jkk-operating-system/README.md
+++ b/submissions/pfk-jkk-operating-system/README.md
@@ -4,6 +4,25 @@ Build a shared operating flow for any product or service. This skill turns meeti
 
 PFK makes the full path of work visible so the team can improve one shared flow. JKK puts quality at the source: every process node has a defined input, deliverable, owner, pass criteria, and response when a check fails.
 
+## Concepts and Origin
+
+The skill is informed by Lean thinking and the Toyota Production System (TPS): make work flow visible, build quality into the work, surface abnormalities, and continuously improve the system.
+
+- **JKK, Jikotei Kanketsu, or self-process completion**: a TPS quality-at-the-source practice. A team completes and verifies its own work against a clear standard before passing an output to the next process. In this skill, JKK becomes a node contract: input, accountable owner, deliverable, good-product criteria, evidence, and a failed-check response.
+- **PFK, Process Flow Kaizen**: the flow-improvement practice used by this skill. It combines visible end-to-end process flow with Kaizen, the ongoing improvement of work. PFK is a practical name for applying Lean and TPS ideas to a shared workflow; it should not be presented as an official, fixed Toyota program name.
+- **Jidoka, Just-in-Time, visual management, and standardized work**: related TPS ideas. This skill uses them as practical patterns: stop or escalate when a quality condition fails, let downstream demand pull work, expose flow and blockers, and make good execution repeatable with usable standards and toolboxes.
+
+## Where It Applies
+
+PFK/JKK works beyond manufacturing. Use it wherever one role's output becomes another role's input:
+
+- Product discovery, design, development, testing, release, and service operation.
+- Project management, including planning, decision gates, risk handoffs, and delivery governance.
+- IT operations, incident response, change management, problem management, and post-incident improvement.
+- Customer support, onboarding, professional services, fulfillment, and other service-delivery workflows.
+
+The goal is not to impose a factory metaphor or add bureaucracy. The goal is to make ownership, quality standards, flow delays, and improvement opportunities visible enough to manage.
+
 ## What It Produces
 
 - An evidence register that separates confirmed facts, observations, assumptions, and conflicts.

--- a/submissions/pfk-jkk-operating-system/SKILL.md
+++ b/submissions/pfk-jkk-operating-system/SKILL.md
@@ -7,6 +7,12 @@ description: "Use this skill whenever the user wants to turn project meeting not
 
 Create a shared operating flow for products and services. Apply PFK to make one end-to-end flow visible and continuously improve it. Apply JKK to ensure each owner completes work to a clear good-product standard before handoff.
 
+## Terminology and Origin
+
+When users ask what PFK or JKK means, use [the PFK/JKK foundations reference](./references/pfk-jkk-foundations.md). Explain JKK as a quality-at-the-source practice associated with the Toyota Production System (TPS). Explain PFK as this skill's practical combination of visible end-to-end process flow and Kaizen; do not claim that PFK is an official, fixed Toyota program name.
+
+Connect the method to its usable TPS and Lean patterns: Jidoka for surfacing and resolving quality problems, Just-in-Time and pull for managing flow, visual management for exposing work and blockers, standardized work for repeatable execution, and Kaizen for continuous improvement. Explain that these patterns apply to project management, product delivery, IT operations, customer support, and service delivery whenever work crosses handoffs.
+
 ## Core Principles
 
 - All material work belongs on one visible flow.

--- a/submissions/pfk-jkk-operating-system/SKILL.md
+++ b/submissions/pfk-jkk-operating-system/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: pfk-jkk-operating-system
+description: "Use this skill whenever the user wants to turn project meeting notes, email, documents, tickets, photos, or retrospectives into a complete PFK (Process Flow Kaizen) and JKK (Jikotei Kanketsu) workflow; clarify missing workflow facts; create or update flow nodes, Mermaid diagrams, node cards, quality gates, Definition of Ready, Definition of Done, or continuous-improvement actions."
+---
+
+# PFK/JKK Operating System
+
+Create a shared operating flow for products and services. Apply PFK to make one end-to-end flow visible and continuously improve it. Apply JKK to ensure each owner completes work to a clear good-product standard before handoff.
+
+## Core Principles
+
+- All material work belongs on one visible flow.
+- Each node produces an accepted input for the next node; do not pass preventable defects downstream.
+- Work is complete only when observable pass criteria are met.
+- Pair standards with practical toolboxes: templates, examples, checklists, systems, and automation.
+- Turn defects, delays, and exceptions into improvements to the earliest preventative node.
+
+## Language and Visual Reference Rules
+
+Keep this skill, its templates, scripts, file names, and comments in English. Write user-facing questions, reports, flow labels, node cards, and exported diagram labels in the language used in the user's latest request, unless another language is explicitly requested. Keep node IDs and Mermaid identifiers language-neutral and stable, such as `N1`, `G1`, and `A1`.
+
+Treat supplied images as process and visual evidence. Do not copy, bundle, or store user-supplied images as examples. Apply [the visual reference principles](./assets/visual-reference-principles.md) and generate a new Mermaid-derived SVG or PNG only when the user requests a portable image or saved flow package.
+
+## Host-Neutral Operation
+
+The canonical output is Mermaid source plus node cards and a flow register. It must work without shell access, code execution, file-system access, or a diagram renderer.
+
+When the host can create files, save the requested flow package. When the host can render Mermaid directly, provide the Mermaid source and use the host's renderer. Use [the optional Python renderer](./scripts/render_mermaid.py) only after confirming that Python 3 and `npx` are available and the host permits command execution and package download. Do not require PowerShell, a local browser, Node.js, or npm in Copilot Studio. In a GitHub Copilot coding harness, verify the available runtime and project instructions before running the optional renderer.
+
+## Evidence Intake and Clarification
+
+Accept meeting notes, email threads, documents, tickets, screenshots, photos, spreadsheets, retrospectives, and existing process diagrams. Treat the material as evidence, not as an approved standard.
+
+Before proposing a flow, build an evidence table:
+
+| Claim | Source | Type | Confidence | Effect on flow |
+| --- | --- | --- | --- | --- |
+| QA accepts release evidence | Meeting notes, 2026-08-31 | Explicit | High | Add release gate |
+
+Classify every claim as **Explicit**, **Observed**, **Inferred**, or **Conflicting**. Label inferred claims as assumptions. Do not make conflicting claims part of the standard until resolved.
+
+Ask concise, numbered questions only when missing information changes the flow boundary, node sequence, owner, input, deliverable, pass criteria, exception path, or toolchain behavior. Ask no more than five related questions at once. If the user requests a draft first, create a clearly labeled draft flow with assumptions and open decisions; do not present assumptions as confirmed facts.
+
+## Create a New Flow
+
+1. Define the trigger, customer or business outcome, scope, flow owner, and excluded work. Use outcome-based boundaries, not departmental labels.
+2. Reconstruct the current flow from evidence. Capture actions, handoffs, approvals, wait states, rework, and exceptions. Add every material action to a node or explicitly remove it from the required process.
+3. Create a whole-process map from [the Mermaid template](./assets/whole-process-flow-template.mmd). Read left to right from trigger to outcome. Use solid arrows for normal handoffs, labeled decision nodes for conditional routes, dashed arrows for feedback or rework, and visible quality gates before accepted handoffs. Add an Andon escalation node for blockers outside a node's authority or time expectation.
+4. Create a JKK node card for every meaningful outcome using [the node-card template](./assets/node-card-template.md). Each card needs a stable ID, accountable role, input, deliverable, key actions, time expectation, good-product standard, verification owner, toolbox, failed-check response, and allowed exception path.
+5. Use [the flow package template](./assets/flow-package-template.md) to track the boundary, evidence, open decisions, artifacts, and flow changes. Never renumber an existing node only because the flow changes.
+6. When saving is requested and the host can write files, keep editable materials together in `flows/<flow-name>/`: `flow.md`, Mermaid source, `nodes/N<id>-<short-name>.md`, and optional rendered SVG or PNG. Mermaid source and node cards are the source of truth; generated images are derived views.
+7. Map approved node contracts to the working toolchain. Use work-item states, checklists, linked artifacts, automated CI or approval gates, and visible, time-bound exceptions. Do not add a workflow state merely to describe a meeting or person.
+
+## Quality at the Source
+
+For every node, determine:
+
+- Which defect the node can introduce.
+- Which inexpensive check detects it before handoff.
+- Who resolves a failed check.
+- How a failure returns to the corrective node.
+
+The default rule is no handoff until the good-product standard passes. An exception must name a risk owner, expiry date, and follow-up work item.
+
+## Update an Existing Flow or Node
+
+1. Identify the target flow and stable node ID. Ask for clarification only if either is ambiguous.
+2. Restate the requested change and identify affected input, deliverable, owner, pass criteria, time expectation, toolbox, gates, and connected nodes.
+3. Apply the change when the facts are sufficient. Otherwise ask only the decision-changing questions.
+4. Update the target node card and append a dated change-log entry with the source or user decision.
+5. Update Mermaid whenever the node label, sequence, handoff, decision, quality gate, exception route, or rework path changes.
+6. Recheck connected nodes. Update mismatched entry criteria or report the unresolved conflict.
+7. Output exactly the requested artifact: one node card, the full Mermaid flow, a rendered image path, or a complete flow package summary. Include a concise impact summary.
+
+Do not silently modify unrelated nodes. Preserve the prior version or show the exact before-and-after difference.
+
+## Kaizen Review
+
+Pilot one or two repeatable flows for two to four delivery cycles. Review lead time, waiting time, first-pass rate, rework count, escaped defects, blocker age, exception count, and work occurring outside the shared flow. For each material issue, change the earliest preventative node and record the hypothesis, owner, expected measure, and review date.
+
+## Completion Check
+
+The flow is ready to pilot only when every material activity and handoff is visible; every node has an owner, input, deliverable, time expectation, good-product standard, and toolbox; pass criteria are independently checkable; failed checks block or explicitly govern handoff; inferred and conflicting rules are resolved or visibly open; and a recurring improvement review is scheduled.

--- a/submissions/pfk-jkk-operating-system/assets/flow-package-template.md
+++ b/submissions/pfk-jkk-operating-system/assets/flow-package-template.md
@@ -1,0 +1,38 @@
+# <Flow Name> PFK/JKK Flow Register
+
+## Flow Boundary
+
+| Field | Definition |
+| --- | --- |
+| Trigger | |
+| Customer or business outcome | |
+| In scope | |
+| Out of scope | |
+| Flow owner | |
+| Status | Draft / Confirmed / In pilot / Standard |
+
+## Evidence Register
+
+| Claim | Source | Type | Confidence | Effect on flow |
+| --- | --- | --- | --- | --- |
+| | | Explicit / Observed / Inferred / Conflicting | High / Medium / Low | |
+
+## Open Decisions and Assumptions
+
+| ID | Question or assumption | Why it matters | Owner | Due date | Status |
+| --- | --- | --- | --- | --- | --- |
+| OD-1 | | | | | Open / Resolved |
+
+## Artifact Index
+
+| Artifact | Purpose | Status |
+| --- | --- | --- |
+| `current-state.mmd` | Observed workflow | |
+| `future-state.mmd` | Proposed standard workflow | |
+| `nodes/N1-<short-name>.md` | JKK node contract | |
+
+## Change Log
+
+| Date | Changed by | Scope | Change | Evidence or decision | Impacted nodes |
+| --- | --- | --- | --- | --- | --- |
+| YYYY-MM-DD | | | | | |

--- a/submissions/pfk-jkk-operating-system/assets/node-card-template.md
+++ b/submissions/pfk-jkk-operating-system/assets/node-card-template.md
@@ -1,0 +1,50 @@
+# PFK/JKK Process Node Card
+
+## Identity
+
+| Field | Value |
+| --- | --- |
+| Node name | |
+| Flow and boundary | |
+| Node ID | |
+| Accountable role | |
+| Contributors | |
+| Target time or service expectation | |
+
+## Contract
+
+| Field | Definition |
+| --- | --- |
+| Trigger / input | What must be true or available before the node starts |
+| Deliverable | Concrete artifact or system state supplied to the next node |
+| Receiving role | Who accepts and uses the deliverable |
+| Key actions | 1.  2.  3. |
+| Good-product standard | Objective pass criteria and required evidence |
+| Verification owner | Who confirms each criterion |
+| Toolbox | Templates, checklists, examples, systems, automation, and knowledge links |
+
+## Handoff and Exceptions
+
+| Field | Definition |
+| --- | --- |
+| DoR for this node | Entry checks that make work ready to start |
+| DoD / release gate | Exit checks that permit handoff |
+| Failed-check response | Rework path, resolution owner, and escalation point |
+| Allowed exception | Risk owner, expiry date, and required follow-up work item |
+
+## Evidence and Decisions
+
+| Item | Source or decision | Status |
+| --- | --- | --- |
+| Ownership | Link or reference to meeting note, email, ticket, or user decision | Confirmed / Assumption / Open |
+| Pass criteria | Link or reference to approval, standard, or user decision | Confirmed / Assumption / Open |
+| Exception route | Link or reference to policy or user decision | Confirmed / Assumption / Open |
+
+## Improvement Evidence
+
+| Signal | Baseline | Target | Review date |
+| --- | --- | --- | --- |
+| First-pass rate | | | |
+| Elapsed time | | | |
+| Rework count | | | |
+| Escaped defects | | | |

--- a/submissions/pfk-jkk-operating-system/assets/visual-reference-principles.md
+++ b/submissions/pfk-jkk-operating-system/assets/visual-reference-principles.md
@@ -1,0 +1,27 @@
+# PFK/JKK Visual Reference Principles
+
+These principles capture the workflow meaning of supplied PFK/JKK visual material. They are not image samples and must not be used to reproduce any source image.
+
+## Whole-Flow Composition
+
+- Present one visible, end-to-end flow so that every material activity and handoff has a known place.
+- Read in chronological order, preferably left to right. Add phase or time bands when they clarify timing.
+- Use stable, compact node IDs and concise labels. Put detailed work instructions in the node card rather than overcrowding the diagram.
+- Make normal flow, quality gates, rework loops, and blocker escalation visually distinct.
+- Treat the diagram as a shared operating view, not a departmental reporting structure.
+
+## Node Card Composition
+
+Each node card makes its operating contract scannable: identity, specific action, completion decision, deliverable, and toolbox.
+
+## Improvement Loop
+
+- Link standards, templates, examples, methods, and knowledge resources to the nodes that use them.
+- Capture frontline proposals, recurring reviews, training needs, and collaboration as inputs to improve the same shared flow.
+- When a defect escapes or a handoff fails, update the earliest preventative node and regenerate the diagram from Mermaid source.
+
+## Accessibility and Export
+
+- Do not rely on color alone to communicate state; use labels and arrow styles as well.
+- Keep labels legible at normal presentation size and avoid dense paragraphs in diagram nodes.
+- Preserve Mermaid source for editing. Treat generated SVG or PNG files as portable views, not editable sources of truth.

--- a/submissions/pfk-jkk-operating-system/assets/whole-process-flow-template.mmd
+++ b/submissions/pfk-jkk-operating-system/assets/whole-process-flow-template.mmd
@@ -1,0 +1,20 @@
+flowchart LR
+    Start([Start: agreed trigger]) --> N1["N1: First process<br/>Owner: accountable role<br/>Output: verified deliverable"]
+    N1 --> G1{{"G1: input / quality gate"}}
+    G1 -->|Pass| N2["N2: Next process<br/>Owner: accountable role<br/>Output: verified deliverable"]
+    G1 -.->|Fail: correct and recheck| N1
+    N2 --> D1{"Decision: exception or standard route?"}
+    D1 -->|Standard| N3["N3: Final process<br/>Owner: accountable role<br/>Output: accepted outcome"]
+    D1 -->|Blocked| A1["Andon: escalate blocker<br/>Owner: flow lead"]
+    A1 -.->|Resolution| N2
+    N3 --> End([End: customer or business outcome])
+
+    classDef process fill:#E8F1F5,stroke:#226A80,color:#102A35,stroke-width:2px;
+    classDef gate fill:#FFF3C4,stroke:#9A6700,color:#4D3500,stroke-width:2px;
+    classDef andon fill:#FCE8E6,stroke:#B3261E,color:#601410,stroke-width:2px;
+    classDef boundary fill:#E8F5E9,stroke:#2E7D32,color:#123819,stroke-width:2px;
+
+    class N1,N2,N3 process;
+    class G1,D1 gate;
+    class A1 andon;
+    class Start,End boundary;

--- a/submissions/pfk-jkk-operating-system/metadata.json
+++ b/submissions/pfk-jkk-operating-system/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "PFK/JKK Operating System",
+  "description": "Turn project evidence into visible, quality-built-in product and service workflows that teams continuously improve together.",
+  "platforms": ["Cowork", "Copilot Studio"],
+  "tags": ["workflow", "process-improvement", "quality", "continuous-improvement", "service-design"],
+  "author": "DB API BUILDER",
+  "version": "1.0.0",
+  "createdAt": "2026-08-31",
+  "updatedAt": "2026-08-31",
+  "coverColor": "#226A80"
+}

--- a/submissions/pfk-jkk-operating-system/references/pfk-jkk-foundations.md
+++ b/submissions/pfk-jkk-operating-system/references/pfk-jkk-foundations.md
@@ -1,0 +1,41 @@
+# PFK/JKK Foundations
+
+## Toyota Production System Context
+
+The Toyota Production System (TPS) is commonly described through two mutually reinforcing ideas:
+
+- **Just-in-Time**: make and move the needed work at the needed time in the needed amount. In knowledge and service work, this supports managing queues, limiting work in progress, and using clear handoff readiness rather than starting work prematurely.
+- **Jidoka**: build in quality by detecting abnormal conditions, stopping or escalating when necessary, and correcting the cause before defects move downstream. In this skill, quality gates and Andon escalation make abnormalities visible.
+
+TPS also relies on visual management, standardized work, and Kaizen. These ideas transfer to non-manufacturing work as operating patterns, not as a claim that every team should use manufacturing-specific roles or measures.
+
+## JKK: Jikotei Kanketsu
+
+**Jikotei Kanketsu**, often translated as *self-process completion*, means that the current process ensures its output meets the next process's requirements before handoff. It puts quality in the work rather than relying only on a later inspection step.
+
+For a workflow node, express JKK as:
+
+1. A defined input and accountable owner.
+2. A specific deliverable for the receiving role.
+3. Observable good-product criteria and verification evidence.
+4. A defined response when a criterion fails, including rework or escalation.
+5. A bounded exception path with a risk owner, expiry, and follow-up action.
+
+## PFK: Process Flow Kaizen
+
+In this skill, **Process Flow Kaizen (PFK)** is the practice of making an end-to-end workflow visible, observing delays and defects, and iteratively improving the shared flow. It draws on the Lean and TPS concepts above.
+
+Do not present PFK as an official Toyota program or proprietary Toyota term without a source that establishes that claim. Use the term to describe this skill's operating method: one visible flow, explicit handoffs, JKK-quality node contracts, and recurring Kaizen improvement.
+
+## Cross-Domain Translation
+
+| TPS or Lean pattern | Product, project, operations, or service equivalent |
+| --- | --- |
+| Next process is the customer | Receiving role defines the input contract and acceptance criteria |
+| Jidoka | Automated or manual quality gate, incident trigger, or escalation route |
+| Andon | Visible blocker, alert, incident declaration, or decision escalation |
+| Pull | Begin work only when the input is ready and downstream capacity exists |
+| Standardized work | Node card, checklist, template, runbook, or automated pipeline |
+| Kaizen | Measured improvement backlog, retrospective action, and review cycle |
+
+Adapt the terminology and controls to the team's domain. The method should reduce ambiguity, rework, and hidden work, not add ceremonies that do not improve an observed problem.

--- a/submissions/pfk-jkk-operating-system/scripts/render_mermaid.py
+++ b/submissions/pfk-jkk-operating-system/scripts/render_mermaid.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Render a Mermaid source file to SVG or PNG using Mermaid CLI.
+
+Requires Python 3, Node.js, npx, and network access when Mermaid CLI is not
+already cached. This helper is optional; the .mmd source remains canonical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a Mermaid .mmd file to SVG or PNG using Mermaid CLI."
+    )
+    parser.add_argument("input_file", type=Path, help="Path to the Mermaid source file.")
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        type=Path,
+        help="Output image path. Defaults to the input path with the chosen extension.",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("svg", "png"),
+        default="svg",
+        help="Image format to produce. Default: svg.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    input_file = arguments.input_file.resolve()
+
+    if not input_file.is_file():
+        raise FileNotFoundError(f"Mermaid source file does not exist: {input_file}")
+
+    npx = shutil.which("npx")
+    if npx is None:
+        raise RuntimeError("npx was not found. Install Node.js, or render the Mermaid source in the host.")
+
+    output_file = arguments.output_file or input_file.with_suffix(f".{arguments.format}")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    command = [
+        npx,
+        "--yes",
+        "@mermaid-js/mermaid-cli",
+        "-i",
+        str(input_file),
+        "-o",
+        str(output_file),
+        "-e",
+        arguments.format,
+    ]
+    subprocess.run(command, check=True)
+    print(f"Rendered Mermaid diagram: {output_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the PFK/JKK Operating System skill for building and continuously improving shared product and service workflows from project evidence.

- Turns meeting notes, email, tickets, documents, retrospectives, and visual process material into evidence-backed flow maps.
- Produces editable Mermaid whole-process diagrams, JKK node cards, quality gates, Andon escalation paths, and Kaizen follow-up actions.
- Supports targeted node updates with stable IDs, impact checks for connected nodes, and multi-language user-facing output.
- Keeps Mermaid source as the canonical artifact and provides an optional Python renderer for compatible coding hosts; Copilot Studio use does not depend on script execution.
- Includes English-only agent instructions and templates; source images are analyzed as evidence and are not copied into the submission.

## Validation

- Editor diagnostics found no issues in the submission metadata, Markdown, or Python helper.
- The local gallery `npm` validation could not be completed because `npm install` was interrupted by OneDrive `EPERM` file locks while installing dependencies.