### PR TITLE
Add tool-approval-designer skill submission

### DIFF
--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -143,9 +143,12 @@ file itself, is skipped with a note rather than reported with an `approval_mode`
 it does not have. A bare `@tool` with no traceable import is kept and marked
 `best-effort`.
 
-Test files and `tests/` directories are skipped when scanning a directory, unless
-you pass `--include-tests`. A file you name directly is always read, including a
-test file, on the basis that pointing at a path is an explicit request.
+Test files and `tests/` directories below the scan root are skipped when scanning
+a directory, unless you pass `--include-tests`. A path you name directly is
+always read, including a test file or a directory that is itself named `tests`,
+on the basis that pointing at a path is an explicit request. Directory names are
+judged only at or below the root, so a repo that happens to live under a folder
+called `build` or `venv` still scans normally.
 
 Regression tests, from the same directory:
 
@@ -154,17 +157,18 @@ python scripts/tests/test_inventory_tools.py
 python scripts/tests/test_approval_renderer.py
 ```
 
-110 tests covering decorator and alias detection, decorator provenance, approval
+114 tests covering decorator and alias detection, decorator provenance, approval
 mode reading, write and external and blast-radius signals including every
 write-capable `open()` mode permutation, the false positives that the
 vocabularies are tuned to avoid, best-effort Go detection and its line
 attribution, file handling including BOM-prefixed sources, explicitly named
-paths and pruned vendor directories, summary agreement, output shape, and exit
-codes. Two of them assert that the counts stated in this paragraph match the
-suites, so these numbers cannot go stale. A further 14 cover the shipped
-approval renderer template, most importantly that redaction is case-insensitive
-on both the argument name and the declared redaction list, since that is the
-boundary keeping a secret out of the approval text a human reads.
+paths, pruned vendor directories and a repo that itself lives under a directory
+named `build` or `venv`, summary agreement, output shape, and exit codes. Two of
+them assert that the counts stated in this paragraph match the suites, so these
+numbers cannot go stale. A further 14 cover the shipped approval renderer
+template, most importantly that redaction is case-insensitive on both the
+argument name and the declared redaction list, since that is the boundary
+keeping a secret out of the approval text a human reads.
 ## Verified product facts, with sources
 
 Every product claim the skill makes traces to one of these. Details are in

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -136,17 +136,23 @@ writes and looks externally visible. It cannot tell you whether the effect is
 truly irreversible, and it cannot read the logic behind `approval_mode="conditional"`.
 Its output is the first column of the matrix, never the matrix.
 
+It is also conservative about what it claims. `@tool` is a common decorator name,
+so a tool is only reported as `parsed` when the decorator traces to an
+`agent_framework` import. One borrowed from another library, or defined in the
+file itself, is skipped with a note rather than reported with an `approval_mode`
+it does not have. A bare `@tool` with no traceable import is kept and marked
+`best-effort`.
+
 Regression tests, from the same directory:
 
 ```bash
 python scripts/tests/test_inventory_tools.py
 ```
 
-64 tests covering decorator and alias detection, approval mode reading, write and
-external and blast-radius signals, the false positives that the vocabularies are
-tuned to avoid, best-effort Go detection, file handling, output shape, and exit
-codes.
-
+94 tests covering decorator and alias detection, decorator provenance, approval
+mode reading, write and external and blast-radius signals, the false positives
+that the vocabularies are tuned to avoid, best-effort Go detection, file handling
+including BOM-prefixed sources, summary agreement, output shape, and exit codes.
 ## Verified product facts, with sources
 
 Every product claim the skill makes traces to one of these. Details are in
@@ -172,7 +178,9 @@ Every product claim the skill makes traces to one of these. Details are in
   conversation is **this skill's proposed heuristic**, not a Microsoft standard.
   Override it with your own and the record will say which one was applied.
 - The parser reads Python properly, detects Go on a best-effort basis, and does not
-  read C# at all.
+  read C# at all. It only claims a Python `@tool` it can trace to an
+  `agent_framework` import; anything else is skipped or flagged, never silently
+  counted.
 - Approval is not authorization. A gate records a click. Least privilege in the
   underlying system is still your job.
 

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -143,6 +143,10 @@ file itself, is skipped with a note rather than reported with an `approval_mode`
 it does not have. A bare `@tool` with no traceable import is kept and marked
 `best-effort`.
 
+Test files and `tests/` directories are skipped when scanning a directory, unless
+you pass `--include-tests`. A file you name directly is always read, including a
+test file, on the basis that pointing at a path is an explicit request.
+
 Regression tests, from the same directory:
 
 ```bash
@@ -150,14 +154,14 @@ python scripts/tests/test_inventory_tools.py
 python scripts/tests/test_approval_renderer.py
 ```
 
-96 tests covering decorator and alias detection, decorator provenance, approval
+102 tests covering decorator and alias detection, decorator provenance, approval
 mode reading, write and external and blast-radius signals, the false positives
-that the vocabularies are tuned to avoid, best-effort Go detection, file handling
-including BOM-prefixed sources, summary agreement, output shape, and exit codes.
-A further 14 cover the shipped approval renderer template, most importantly that
-redaction is case-insensitive on both the argument name and the declared
-redaction list, since that is the boundary keeping a secret out of the approval
-text a human reads.
+that the vocabularies are tuned to avoid, best-effort Go detection and its line
+attribution, file handling including BOM-prefixed sources and explicitly named
+paths, summary agreement, output shape, and exit codes. A further 14 cover the
+shipped approval renderer template, most importantly that redaction is
+case-insensitive on both the argument name and the declared redaction list, since
+that is the boundary keeping a secret out of the approval text a human reads.
 ## Verified product facts, with sources
 
 Every product claim the skill makes traces to one of these. Details are in

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -155,8 +155,9 @@ python scripts/tests/test_approval_renderer.py
 ```
 
 102 tests covering decorator and alias detection, decorator provenance, approval
-mode reading, write and external and blast-radius signals, the false positives
-that the vocabularies are tuned to avoid, best-effort Go detection and its line
+mode reading, write and external and blast-radius signals including every
+write-capable `open()` mode permutation, the false positives that the
+vocabularies are tuned to avoid, best-effort Go detection and its line
 attribution, file handling including BOM-prefixed sources and explicitly named
 paths, summary agreement, output shape, and exit codes. A further 14 cover the
 shipped approval renderer template, most importantly that redaction is

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -154,15 +154,17 @@ python scripts/tests/test_inventory_tools.py
 python scripts/tests/test_approval_renderer.py
 ```
 
-102 tests covering decorator and alias detection, decorator provenance, approval
+110 tests covering decorator and alias detection, decorator provenance, approval
 mode reading, write and external and blast-radius signals including every
 write-capable `open()` mode permutation, the false positives that the
 vocabularies are tuned to avoid, best-effort Go detection and its line
-attribution, file handling including BOM-prefixed sources and explicitly named
-paths, summary agreement, output shape, and exit codes. A further 14 cover the
-shipped approval renderer template, most importantly that redaction is
-case-insensitive on both the argument name and the declared redaction list, since
-that is the boundary keeping a secret out of the approval text a human reads.
+attribution, file handling including BOM-prefixed sources, explicitly named
+paths and pruned vendor directories, summary agreement, output shape, and exit
+codes. Two of them assert that the counts stated in this paragraph match the
+suites, so these numbers cannot go stale. A further 14 cover the shipped
+approval renderer template, most importantly that redaction is case-insensitive
+on both the argument name and the declared redaction list, since that is the
+boundary keeping a secret out of the approval text a human reads.
 ## Verified product facts, with sources
 
 Every product claim the skill makes traces to one of these. Details are in

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -147,12 +147,17 @@ Regression tests, from the same directory:
 
 ```bash
 python scripts/tests/test_inventory_tools.py
+python scripts/tests/test_approval_renderer.py
 ```
 
-94 tests covering decorator and alias detection, decorator provenance, approval
+96 tests covering decorator and alias detection, decorator provenance, approval
 mode reading, write and external and blast-radius signals, the false positives
 that the vocabularies are tuned to avoid, best-effort Go detection, file handling
 including BOM-prefixed sources, summary agreement, output shape, and exit codes.
+A further 14 cover the shipped approval renderer template, most importantly that
+redaction is case-insensitive on both the argument name and the declared
+redaction list, since that is the boundary keeping a secret out of the approval
+text a human reads.
 ## Verified product facts, with sources
 
 Every product claim the skill makes traces to one of these. Details are in

--- a/submissions/tool-approval-designer/README.md
+++ b/submissions/tool-approval-designer/README.md
@@ -1,0 +1,191 @@
+# Tool Approval Designer
+
+Decide which of an agent's tools must stop for a human, write what the human
+actually reads, check that the design will not be clicked through, and emit the
+code and the record.
+
+## Surface boundary, first
+
+What runs where is not interchangeable. Read this before adopting the skill.
+
+| Surface | What the skill does |
+|---|---|
+| Microsoft Agent Framework, **Python** | Full support. Parses tools from source, emits `approval_mode` diffs, an approval renderer, and an approval loop. |
+| Microsoft Agent Framework, **Go** | Documented contract and emitted code shape. Detection is best-effort regex, not a parse. No packaged harness. |
+| Microsoft Agent Framework, **.NET / C#** | Documented contract and emitted code shape. Not parsed; the inventory is supplied by you. |
+| **Harness Agent** | Documented middleware behaviour, including auto-approval rules. |
+| **Copilot Studio** | Design guidance only. See the warning below. |
+| **GitHub Copilot agent mode** | Cited as prior art for the session-unlock problem. Not configured by this skill. |
+
+> **Copilot Studio per-tool approval is roadmap-announced, not documented.**
+> The source is Microsoft 365 roadmap item **570434**, GA target **September 2026**,
+> status **"In development"**, and no Microsoft Learn documentation page for it was
+> found. The skill will not give you configuration steps for it, and will tell you
+> that the Copilot Studio part of any design needs re-checking against
+> documentation when it ships. If you need something you can switch on today, use
+> the Agent Framework path.
+
+The skill may be loaded into a harness that cannot execute Python. In that case it
+skips the parse, builds the inventory with you by hand, and labels it as supplied.
+
+## The problem it solves
+
+Microsoft Agent Framework gives you a mechanism and stops at the interesting part.
+You mark a tool with `@tool(approval_mode="always_require")`, the run pauses, and
+the framework hands your code a raw function call name and an argument blob. What
+the human sees, and whether it means anything to them, is entirely yours to build.
+The documented sample loop closes that gap with a constant:
+
+```python
+user_approval = True  # Replace with actual user input
+```
+
+Two failures follow from that seam. The first is obvious: gates that never really
+ask. The second is worse, and is the reason this skill exists.
+
+**A badly designed gate manufactures accountability.** If the prompt fires on
+everything, or says only `Approve tool call transfer_money?`, people click through
+it. The log then records that a named employee approved a specific action at a
+specific time. It did not happen. Nobody read it. You have built an audit trail
+that documents consent that was never given, and you will find out during the
+incident review.
+
+So the design work is not "add approvals". It is: gate the small number of things
+that genuinely need it, word them so a human can judge them in three seconds, and
+prove the volume stays low enough that people still read them.
+
+## What it produces
+
+Artifacts, every run. If a run ends in a document telling you to consider gating
+your payment tool, the skill has failed.
+
+- A **gating matrix**: one row per tool, all four decision questions answered, a
+  verdict, and a one-sentence reason.
+- **Approval request wording** per gated tool, generated from the real call
+  arguments, carrying the consequence and who can undo it.
+- An **approval fatigue estimate** over representative scenarios, with bulk paths
+  flagged.
+- **Code**: `approval_mode` diffs, an argument-aware renderer, and an approval loop
+  whose decision comes from a human rather than a constant.
+- An **approve-for-session ruling** per tool, with a reason.
+- A **deny path** per gated tool, written where one is missing.
+- A **decision record** committed to your repository, ending in the name of the
+  human who ruled.
+
+## The decision procedure
+
+Four questions per tool:
+
+1. Does it write, or only read?
+2. Is the write reversible, and by whom? Anyone, admin or IT only, or nobody.
+3. Is the result visible outside the organisation?
+4. What is the blast radius? One record or many.
+
+The rule: **irreversible and externally visible must always gate.**
+**Reversible by anyone and internal only must not.** Everything in between is a
+judgement, and the skill states a reason for every one of them.
+
+## Before you start
+
+You need one of these:
+
+- a **repository path** containing Agent Framework Python tools, if you want the
+  inventory parsed for you; or
+- a **list of your tools** with a one-line description each, if the code is C#, Go,
+  or not to hand.
+
+You do not need to prepare answers per tool. The skill parses what it can and then
+asks two or three questions covering only what cannot be inferred. That is
+deliberate: a skill that interrogates you about twenty tools gets abandoned, and an
+abandoned run produces no gates at all.
+
+It helps to know, before you begin, who is allowed to rule on risk appetite. The
+decision record is not finished until that person is named in it.
+
+## How to use it
+
+Ask for what you want in plain language:
+
+- "Which of my agent's tools should require human approval?"
+- "Design approval gates for the agent in `./src/agent`."
+- "Write the approval prompt for my refund tool."
+- "My agent asks for approval eleven times in a normal conversation. Fix it."
+- "Is approve-for-session safe on this tool?"
+
+If you already have findings from a red-team pass that flagged a missing
+confirmation, hand them over. The skill takes them as inventory input instead of
+re-deriving them.
+
+## Running the inventory script yourself
+
+The parser is standard library only and needs **Python 3.9 or newer**. Run it from
+the skill root, the directory containing `SKILL.md`:
+
+```bash
+python scripts/inventory_tools.py assets/samples
+python scripts/inventory_tools.py path/to/your/agent --format json
+python scripts/inventory_tools.py path/to/your/agent --fail-on ungated-write-external
+```
+
+`--fail-on` exits non-zero when a matching tool is found, so the check can sit in
+CI. Exit codes: `0` clean, `1` the `--fail-on` condition triggered, `2` usage or
+IO error.
+
+The script emits **signals, not verdicts**. It can tell you a tool looks like it
+writes and looks externally visible. It cannot tell you whether the effect is
+truly irreversible, and it cannot read the logic behind `approval_mode="conditional"`.
+Its output is the first column of the matrix, never the matrix.
+
+Regression tests, from the same directory:
+
+```bash
+python scripts/tests/test_inventory_tools.py
+```
+
+64 tests covering decorator and alias detection, approval mode reading, write and
+external and blast-radius signals, the false positives that the vocabularies are
+tuned to avoid, best-effort Go detection, file handling, output shape, and exit
+codes.
+
+## Verified product facts, with sources
+
+Every product claim the skill makes traces to one of these. Details are in
+[references/surfaces-and-contracts.md](references/surfaces-and-contracts.md).
+
+| Claim | Source |
+|---|---|
+| Python `@tool(approval_mode="always_require")`; a gated run returns `result.user_input_requests`; respond via `to_function_approval_response`; the sample loop hardcodes approval | [Agent Framework: tool approval](https://learn.microsoft.com/agent-framework/agents/tools/tool-approval) |
+| Approval modes `always_require`, `never_require` (default), `conditional` | [Agent Framework: AG-UI human in the loop](https://learn.microsoft.com/agent-framework/integrations/by-component/ui/ag-ui/human-in-the-loop) |
+| Go `tool.ApprovalRequiredFunc`, approval through middleware | [Agent Framework: tool approval](https://learn.microsoft.com/agent-framework/agents/tools/tool-approval) |
+| .NET `ApprovalRequiredAIFunction`, `ToolApprovalRequestContent`, `CreateResponse` | [Agent Framework: tool approval](https://learn.microsoft.com/agent-framework/agents/tools/tool-approval) |
+| "Copilot's approval system isn't a security boundary. Apply the principle of least-privilege." Allow once / Allow for this session / Allow always | [GitHub Copilot agent mode in SSMS](https://learn.microsoft.com/ssms/github-copilot/agent-mode) |
+| Copilot Studio per-tool approval: roadmap only, GA target September 2026, status "In development" | Microsoft 365 roadmap item **570434** |
+
+## Limits
+
+- It does not deploy anything, and it does not touch a Copilot Studio environment.
+- It does not decide your risk appetite. It proposes with reasons; a human rules;
+  the ruling gets written down.
+- It is not a security review and not a red team. It designs the gate. Finding the
+  missing one is a different job.
+- The approval fatigue threshold of more than two approvals in a normal
+  conversation is **this skill's proposed heuristic**, not a Microsoft standard.
+  Override it with your own and the record will say which one was applied.
+- The parser reads Python properly, detects Go on a best-effort basis, and does not
+  read C# at all.
+- Approval is not authorization. A gate records a click. Least privilege in the
+  underlying system is still your job.
+
+## Related skills in this gallery
+
+`agent-red-team` maps attack surface and asks, per tool, whether a human confirms
+before execution. It finds the missing gate; this skill decides what the gate
+should be and builds it. Run them in that order.
+
+`enterprise-agent-design-authority` works at architecture altitude across pillars;
+approval design is one concern inside one of them. `agent-evaluation-designer`
+measures answer quality and does not overlap.
+
+## Author
+
+Marc Pascal Solling — [github.com/MarcPmedC](https://github.com/MarcPmedC)

--- a/submissions/tool-approval-designer/SKILL.md
+++ b/submissions/tool-approval-designer/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: tool-approval-designer
+description: >-
+  Use this skill whenever a user asks which agent tools should require human
+  approval, how to gate, confirm, or add human-in-the-loop to tool calls, how to
+  set approval_mode, how to word an approval prompt, whether approve-for-session
+  is safe, or how to stop approval fatigue. It applies the irreversibility test:
+  a tool whose effect cannot be undone and is visible outside the organisation
+  must always gate, and a badly designed gate is worse than none because it
+  manufactures accountability, recording that a named employee approved
+  something they never read. It produces artifacts: a gating matrix, per-tool
+  approval wording generated from the real call arguments, approval_mode diffs,
+  an approval renderer and loop, and a committed decision record. It does not
+  deploy, does not touch a Copilot Studio environment, and does not decide the
+  customer's risk appetite. It is not a security review and not a red team.
+---
+
+# Tool Approval Designer
+
+Decide which tools stop for a human, write what the human reads, and emit the code.
+
+## Produce, do not review
+
+Every run ends in artifacts a maker can paste and commit. A run that ends in
+advice has failed.
+
+Never deliver a document whose recommendations read like "consider gating your
+payment tool", "review whether approval is appropriate", or "evaluate the risk of
+this action". Deliver the verdict, the wording, the diff, and the decision record.
+If a judgement genuinely belongs to the customer, say which judgement, why only
+they can make it, and put it in the open judgements table with a proposed answer
+already written.
+
+**Approval is not authorization.** A gate records that a human clicked. It does
+not grant permission, and it does not stop a compromised or mistaken caller who
+is answering the prompts. Microsoft states this directly for GitHub Copilot agent
+mode: "Copilot's approval system isn't a security boundary. Apply the principle of
+least-privilege." Design gates on top of a permission model, never instead of one.
+
+**A gate that is not read is a liability.** Approval logs are evidence. A design
+that fires so often that people click through it converts an unread click into a
+named human's recorded consent. That is the failure this skill exists to prevent,
+and it is why step 5 is not optional.
+
+## Surface boundary
+
+State the surface before designing. What runs where is not interchangeable.
+
+| Surface | What this skill does |
+|---|---|
+| Agent Framework **Python** | Full support. Parses tools, emits `approval_mode` diffs, renderer, and loop. |
+| Agent Framework **Go** | Documented contract, best-effort detection only. No packaged harness. |
+| Agent Framework **.NET / C#** | Documented contract. Not parsed. Inventory is supplied, not read. |
+| **Harness Agent** | Documented middleware behaviour, including auto-approval rules. |
+| **Copilot Studio** | Design guidance only. See the warning below. |
+| **GitHub Copilot agent mode** | Cited as prior art for session unlock. Not configured here. |
+
+**Copilot Studio per-tool approval is roadmap-announced, not documented.** The
+source is Microsoft 365 roadmap item **570434**, GA target **September 2026**,
+status **"In development"**. No Microsoft Learn documentation page for it was
+found. Never give configuration steps for it, never describe its UI as if it
+exists today, and never let a user believe the design can be switched on in a
+Copilot Studio environment right now. Say plainly that this part of the design is
+roadmap-sourced and will need re-checking against documentation when it ships.
+
+This skill may be invoked from a harness that cannot run the generated code. If
+Python execution is unavailable, say so, skip the parse, and run step 2 as a
+guided inventory instead. Never present a supplied inventory as a parsed one.
+
+## Adjacent skills in this gallery
+
+Three neighbours exist and all three are reviewers. This one is the producer.
+
+**`agent-red-team`** is the closest and the relationship is real. Its attack
+surface mapping already asks, per tool, whether a human confirms before execution.
+It is the right skill for finding a missing gate. This skill is what to run next:
+red team establishes *that* a gate is missing, this one decides *what the gate
+should be* and builds it. If the user arrives holding red team findings, take them
+as the inventory input to step 2 rather than re-deriving them, and say so in the
+decision record.
+
+**`enterprise-agent-design-authority`** works at architecture altitude across
+pillars. Approval design is one concern inside one pillar. Defer to it for the
+overall architecture; own the gate.
+
+**`agent-evaluation-designer`** measures answer quality. It does not decide what
+must stop for a human. No overlap.
+
+## Load supporting material only when needed
+
+Read [references/surfaces-and-contracts.md](references/surfaces-and-contracts.md)
+for the verified API contracts, the approval modes, the roadmap-sourced Copilot
+Studio detail, the fatigue thresholds, and the output contracts. Every product
+claim in this skill traces to that file. Do not add product claims that are not in
+it without verifying them first.
+
+Read [references/evals.md](references/evals.md) when checking this skill's own
+behaviour or an edge case.
+
+Adapt the files under `assets/templates/`. They are the deliverables, not
+examples: `decision-record.md`, `approval_renderer.py`, `approval_loop.py`.
+
+`assets/samples/sample_tools.py` is a small corpus for demonstrating step 2 when
+the user has no code to hand.
+
+## The four questions
+
+Answer these for every tool. They are the whole decision procedure.
+
+1. **Does it write, or only read?**
+2. **Is the write reversible, and by whom?** Anyone, admin or IT only, or nobody.
+3. **Is the result visible outside the organisation?**
+4. **What is the blast radius?** One record or many.
+
+**The rule.**
+
+* Irreversible **and** externally visible: **always gate**. Not negotiable.
+* Reversible by anyone **and** internal only: **do not gate**. A gate here is
+  pure fatigue and buys nothing.
+* Everything else: a judgement. State the reason in one sentence, in the matrix,
+  every time. A verdict without a reason is not a verdict.
+
+Questions 2 and 3 carry the rule. Question 1 filters, question 4 sizes the damage
+and drives step 5.
+
+## Workflow
+
+### 1. Scope the surface and the runtime
+
+Establish the codebase, the runtime, the agent, and where approvals will actually
+be rendered and answered. Record what is out of scope. If the surface is Copilot
+Studio, apply the roadmap warning above before going further.
+
+### 2. Inventory from code, not interview
+
+Run the parser from the skill root:
+
+```bash
+python scripts/inventory_tools.py path/to/agent
+python scripts/inventory_tools.py path/to/agent --format json
+python scripts/inventory_tools.py path/to/agent --fail-on ungated-write-external
+```
+
+Report the counts: tools found, already gated, ungated, ungated with a write
+signal, ungated with a write signal that is externally visible. That last number
+is the headline.
+
+The script emits **signals, not verdicts**. It cannot see whether an effect is
+truly irreversible, and it cannot read `conditional` logic. Treat its output as
+the first column of the matrix, never as the matrix.
+
+Then ask the user **only what cannot be inferred**. Two or three questions total.
+Good questions look like: which of these writes reach a customer or a third party,
+which can a normal user undo without IT, and what is the risk appetite for the
+one or two borderline cases. Bad questions walk tool by tool. Interrogating a
+maker about twenty tools will make them abandon the run, and an abandoned run
+produces no gates at all.
+
+If no execution surface is available, or the runtime is .NET or Go, ask for the
+tool list and build the inventory by hand. Label it as supplied.
+
+### 3. Build the gating matrix
+
+One row per tool, all four answers, the verdict, and the reason.
+
+| Tool | Writes? | Reversible by | Externally visible | Blast radius | Current mode | Verdict | Reason |
+|---|---|---|---|---|---|---|---|
+
+Every verdict must trace to the four questions. Show the tools that should *not*
+gate as well as those that should: removing an unnecessary gate is part of the
+deliverable, and step 5 depends on the full picture.
+
+### 4. Write the approval request wording
+
+This is the highest-value output. The framework hands over the raw
+`function_call.name` and `function_call.arguments` and stops. Rendering is left to
+the maker, and Microsoft's own sample wording is `Approve tool call
+transfer_money?` — a question nobody can answer responsibly.
+
+Generate argument-aware text per gated tool, in this order: **action, target,
+consequence, scale, reversibility, decision.** Contrast the bad form with the good
+one so the difference is visible:
+
+```text
+Bad:  Approve tool call send_customer_email?
+
+Good: Send an email to a customer: hans.jensen@contoso.example
+      subject: Your order has shipped
+      Consequence: The customer receives this message.
+      Reversible by: Nobody. Once delivered it cannot be withdrawn.
+      Approve to run it now. Deny to stop it and continue without it.
+```
+
+Never render from the function name alone. Never truncate the recipient, the
+amount, the count, or the irreversibility statement. Never put a secret, token, or
+credential in an approval request; if a gated tool takes one as a parameter, that
+is a separate finding, report it.
+
+### 5. Estimate approval fatigue
+
+Walk two or three representative scenarios end to end and count how often each
+gate fires. Flag any bulk or batch path where a per-call gate multiplies into a
+clicking exercise: ten approvals for one intent is not ten decisions, it is one
+decision and nine reflexes.
+
+**Proposed threshold: more than two approvals in a normal conversation means
+redesign.** This is this skill's heuristic, not a Microsoft standard, and must be
+labelled as such every time it is used. Offer it, let the user override it, and
+record which threshold was applied.
+
+When the threshold is exceeded, fix the design rather than the number: batch the
+operation behind one approval that states the full scale, narrow an
+over-broad tool, or split the read half from the write half so only the write
+gates.
+
+### 6. Emit the code
+
+Produce the `approval_mode` diffs:
+
+```diff
+- @tool
++ @tool(approval_mode="always_require")
+  def issue_refund(order_id: str, amount: float) -> str:
+```
+
+Then produce the renderer and the loop, adapted from
+`assets/templates/approval_renderer.py` and `assets/templates/approval_loop.py`.
+The loop matters because the documented sample contains, verbatim,
+`user_approval = True  # Replace with actual user input`. Never ship a loop whose
+approval value is a constant. The decision must come from a real human through a
+real surface.
+
+For Go, emit `tool.ApprovalRequiredFunc(...)` and describe the middleware. For
+.NET, emit `ApprovalRequiredAIFunction` usage. Both are documented contracts, not
+packaged harnesses here.
+
+### 7. Rule on approve-for-session, per tool
+
+Session unlock is a bypass in disguise: one click authorises every later call in
+the conversation. Rule per tool with a reason.
+
+* Reasonable on read-heavy or low-consequence tools whose worst case is noise.
+* Not acceptable on anything that moves money, sends external communication, or
+  deletes, because the second call is approved by a click that was reading about
+  the first.
+
+GitHub Copilot agent mode in Visual Studio and SSMS already ships Allow once,
+Allow for this session, and Allow always. Cite it as prior art for the shape of
+the control, not as a claim about any other product's behaviour.
+
+### 8. Check the deny path
+
+An agent that dead-ends, loops, or silently retries on refusal is broken, and its
+gate is theatre. For every gated tool, verify a rejection instruction exists and
+write one where it does not. A denied run must tell the user what was declined and
+continue with whatever does not depend on it.
+
+The approval response carries a boolean only. To convey *why* and *what next*,
+add an ordinary user message alongside it and put the behaviour in the agent's
+instructions. Then test it by actually denying, not by reading the code.
+
+### 9. Commit the decision record
+
+The final deliverable is a markdown file in the user's repository, from
+`assets/templates/decision-record.md`. It must contain: scope and surface; how the
+inventory was produced; the gating matrix; per gated tool the wording, the session
+ruling, and the deny path; the fatigue result and which threshold was used; open
+judgements; and the named human who ruled, with the date.
+
+The last section is the point of the document. The skill proposes with reasons, a
+human rules, and the ruling is written down where the next person can find it. A
+record with no named human in it means the design has not been ruled on.
+
+## Return the complete package
+
+```markdown
+## Scope and surface boundary
+## Inventory
+## Gating matrix
+## Approval request wording
+## Approval fatigue
+## Code changes
+## Approve-for-session rulings
+## Deny paths
+## Decision record
+## What a human still has to decide
+```
+
+## Guardrails
+
+* Never end a run in advice when an artifact was possible.
+* Never present approval as authorization, or a gate as a security boundary.
+* Never describe Copilot Studio per-tool approval as configurable today, and
+  never give steps for it. It is roadmap item 570434, GA target September 2026.
+* Never present the parser's signals as verdicts, or a supplied inventory as a
+  parsed one.
+* Never render an approval request from a function name alone.
+* Never put a secret, token, credential, or raw production record in an approval
+  request.
+* Never ship an approval loop whose decision is a hardcoded constant.
+* Never allow approve-for-session on an irreversible or externally visible tool.
+* Never present the fatigue threshold as a Microsoft standard.
+* Never invent an API, a parameter, an approval mode, or a UI affordance that is
+  not in `references/surfaces-and-contracts.md`.
+* Never decide the customer's risk appetite for them. Propose, give the reason,
+  and leave the ruling to a named human.

--- a/submissions/tool-approval-designer/SKILL.md
+++ b/submissions/tool-approval-designer/SKILL.md
@@ -149,6 +149,13 @@ The script emits **signals, not verdicts**. It cannot see whether an effect is
 truly irreversible, and it cannot read `conditional` logic. Treat its output as
 the first column of the matrix, never as the matrix.
 
+It also only claims tools it can attribute. A `@tool` traced to an
+`agent_framework` import is reported as `parsed`. A `@tool` that came from
+another library, or that is defined in the file itself, is **skipped with a
+note**, because its `approval_mode` column would be fiction. A bare `@tool` with
+no traceable import is kept but marked `best-effort`. Read the notes: a skipped
+file is not the same as a file with no tools in it.
+
 Then ask the user **only what cannot be inferred**. Two or three questions total.
 Good questions look like: which of these writes reach a customer or a third party,
 which can a normal user undo without IT, and what is the risk appetite for the

--- a/submissions/tool-approval-designer/assets/samples/sample_tools.py
+++ b/submissions/tool-approval-designer/assets/samples/sample_tools.py
@@ -8,6 +8,10 @@ The set is deliberately uneven. It contains a tool that is correctly ungated, a
 tool that is correctly gated, a tool that is irreversible and externally visible
 but ungated, a bulk operation whose per-call gate multiplies into a clicking
 exercise, and a tool whose gating logic is hidden behind ``conditional``.
+
+This module is read statically with ``ast`` and is never imported or executed by
+the inventory script or its tests. Importing it directly requires the
+``agent_framework`` package; nothing in this submission needs that to run.
 """
 
 from __future__ import annotations

--- a/submissions/tool-approval-designer/assets/samples/sample_tools.py
+++ b/submissions/tool-approval-designer/assets/samples/sample_tools.py
@@ -1,0 +1,91 @@
+"""Synthetic agent tools used to demonstrate and test the inventory script.
+
+Nothing here talks to a real system. Every body is a stub. The module exists so
+that a run of the inventory has a known corpus, and so the workflow can be
+demonstrated end to end without pointing at a customer codebase.
+
+The set is deliberately uneven. It contains a tool that is correctly ungated, a
+tool that is correctly gated, a tool that is irreversible and externally visible
+but ungated, a bulk operation whose per-call gate multiplies into a clicking
+exercise, and a tool whose gating logic is hidden behind ``conditional``.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from agent_framework import tool
+
+
+@tool
+def lookup_customer(
+    customer_id: Annotated[str, "The customer record identifier"],
+) -> str:
+    """Look up a customer record by identifier."""
+    return f"Customer {customer_id}: Contoso Ltd, tier Gold, open tickets 2."
+
+
+@tool
+def search_orders(
+    query: Annotated[str, "Free-text search over order history"],
+) -> str:
+    """Search order history and return matching orders."""
+    return f"3 orders match {query!r}."
+
+
+@tool
+def draft_internal_note(
+    ticket_id: Annotated[str, "Ticket the note belongs to"],
+    body: Annotated[str, "Note text, visible to colleagues only"],
+) -> str:
+    """Create an internal note on a ticket. Colleagues can edit or delete it."""
+    return f"Internal note saved on {ticket_id} ({len(body)} characters)."
+
+
+@tool
+def send_customer_email(
+    to: Annotated[str, "Customer email address"],
+    subject: Annotated[str, "Subject line"],
+    body: Annotated[str, "Message body"],
+) -> str:
+    """Send an email to a customer from the shared support mailbox."""
+    return f"Email sent to {to} with subject {subject!r}."
+
+
+@tool(approval_mode="always_require")
+def issue_refund(
+    order_id: Annotated[str, "Order to refund"],
+    amount: Annotated[float, "Refund amount"],
+    currency: Annotated[str, "ISO currency code"] = "DKK",
+) -> str:
+    """Refund a customer order to the original payment method."""
+    return f"Refunded {amount} {currency} against order {order_id}."
+
+
+@tool(approval_mode="always_require")
+def close_tickets(
+    ticket_ids: Annotated[list[str], "Tickets to close"],
+    resolution: Annotated[str, "Resolution code"],
+) -> str:
+    """Close each ticket in the list and notify its requester."""
+    closed = []
+    for ticket_id in ticket_ids:
+        closed.append(ticket_id)
+    return f"Closed {len(closed)} tickets as {resolution}."
+
+
+@tool(approval_mode="conditional")
+def update_subscription(
+    subscription_id: Annotated[str, "Subscription to change"],
+    new_plan: Annotated[str, "Target plan code"],
+) -> str:
+    """Update a subscription to a different plan."""
+    return f"Subscription {subscription_id} moved to {new_plan}."
+
+
+@tool(name="purge_export_files")
+def purge_exports(
+    older_than_days: Annotated[int, "Delete exports older than this many days"],
+) -> str:
+    """Permanently delete generated export files from the staging share."""
+    return f"Purged exports older than {older_than_days} days."

--- a/submissions/tool-approval-designer/assets/templates/approval_loop.py
+++ b/submissions/tool-approval-designer/assets/templates/approval_loop.py
@@ -12,7 +12,10 @@ control flow with three things added that the docs leave to the maker:
 2. the request is rendered through ``approval_renderer`` so a human can judge it;
 3. a denial is handled deliberately instead of dead-ending or silently retrying.
 
-Requires ``agent_framework``. Adapt the marked sections; keep the shape.
+Requires ``agent_framework``, and expects ``approval_renderer.py`` to sit beside it:
+the import below is a sibling import, so copy both templates into the same package
+or adjust the import to wherever you put the renderer. Adapt the marked sections;
+keep the shape.
 """
 
 from __future__ import annotations

--- a/submissions/tool-approval-designer/assets/templates/approval_loop.py
+++ b/submissions/tool-approval-designer/assets/templates/approval_loop.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Template: a real approval loop with a working deny path.
+
+Microsoft Agent Framework's documented sample loop contains, verbatim:
+
+    user_approval = True  # Replace with actual user input
+
+That line is the seam this template closes. Everything below is the documented
+control flow with three things added that the docs leave to the maker:
+
+1. the approval value comes from a decision function, never a constant;
+2. the request is rendered through ``approval_renderer`` so a human can judge it;
+3. a denial is handled deliberately instead of dead-ending or silently retrying.
+
+Requires ``agent_framework``. Adapt the marked sections; keep the shape.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Protocol
+
+from agent_framework import Message
+
+from approval_renderer import render_approval_request
+
+# ---------------------------------------------------------------------------
+# 1. The decision function
+#
+# Anything that returns a real boolean from a real human. A console prompt, a
+# web request, an Adaptive Card response, a queued task. The only forbidden
+# implementation is one that returns a constant.
+# ---------------------------------------------------------------------------
+
+
+class ApprovalDecider(Protocol):
+    def __call__(self, request_text: str, tool_name: str) -> bool: ...
+
+
+def console_decider(request_text: str, tool_name: str) -> bool:
+    print(request_text)
+    answer = input("Approve? (y/N): ").strip().lower()
+    return answer in {"y", "yes"}
+
+
+def rejecting_decider(request_text: str, tool_name: str) -> bool:
+    """Safe default for tests and unattended runs. Never approves."""
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 2. Argument normalisation
+#
+# ``function_call.arguments`` may arrive as a mapping or as a JSON string.
+# Normalise once so the renderer always receives a mapping.
+# ---------------------------------------------------------------------------
+
+
+def as_mapping(arguments: Any) -> dict[str, Any]:
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            return {"arguments": arguments}
+        return parsed if isinstance(parsed, dict) else {"arguments": parsed}
+    return {"arguments": arguments}
+
+
+# ---------------------------------------------------------------------------
+# 3. The loop
+# ---------------------------------------------------------------------------
+
+
+async def run_with_approvals(
+    query: str,
+    agent: Any,
+    decide: ApprovalDecider = rejecting_decider,
+    on_denied: Callable[[str, dict[str, Any]], None] | None = None,
+    max_rounds: int = 10,
+) -> Any:
+    """Run the agent, pausing for a real decision on every gated tool call.
+
+    Without a session, each round must carry the original query, the assistant
+    message holding the approval request, and the approval response.
+    """
+    result = await agent.run(query)
+    rounds = 0
+
+    while result.user_input_requests:
+        rounds += 1
+        if rounds > max_rounds:
+            # A loop that will not settle is a design fault, not a runtime blip.
+            # Stop and surface it rather than approving to escape.
+            raise RuntimeError(
+                f"Approval loop exceeded {max_rounds} rounds. Check for a tool the "
+                "agent retries after denial."
+            )
+
+        new_inputs: list[Any] = [query]
+
+        for user_input_needed in result.user_input_requests:
+            if user_input_needed.function_call is None:
+                continue
+
+            tool_name = user_input_needed.function_call.name
+            arguments = as_mapping(user_input_needed.function_call.arguments)
+            request_text = render_approval_request(tool_name, arguments)
+
+            approved = decide(request_text, tool_name)
+
+            new_inputs.append(
+                Message(role="assistant", contents=[user_input_needed])
+            )
+            new_inputs.append(
+                Message(
+                    role="user",
+                    contents=[user_input_needed.to_function_approval_response(approved)],
+                )
+            )
+
+            if not approved:
+                if on_denied is not None:
+                    on_denied(tool_name, arguments)
+                # The framework's approval response carries a boolean only. To
+                # tell the agent *why*, and what to do next, add an ordinary
+                # user message. Keep it factual; it becomes model context.
+                new_inputs.append(
+                    Message(
+                        role="user",
+                        contents=[
+                            f"The {tool_name} call was denied by a human reviewer. "
+                            "Do not attempt it again in this conversation. Tell me "
+                            "what you were going to do, and continue with the parts "
+                            "of the task that do not need it."
+                        ],
+                    )
+                )
+
+        result = await agent.run(new_inputs)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 4. Required agent instructions
+#
+# Code alone cannot produce good denial behaviour, because what the agent does
+# after a rejection is a model decision. Add this to the agent's instructions
+# for every gated tool, and verify it by actually denying during testing.
+# ---------------------------------------------------------------------------
+
+DENIAL_INSTRUCTIONS = """\
+When a tool call is denied:
+
+- Do not call the same tool again with the same arguments in this conversation.
+- Do not silently substitute a different tool to achieve the same effect.
+- Tell the user plainly what you were going to do and that it was declined.
+- Continue with any part of the task that does not depend on the declined action.
+- If nothing useful remains, say so and stop. Do not invent a partial result.
+"""

--- a/submissions/tool-approval-designer/assets/templates/approval_renderer.py
+++ b/submissions/tool-approval-designer/assets/templates/approval_renderer.py
@@ -99,8 +99,17 @@ APPROVAL_SPECS: dict[str, ApprovalSpec] = {
 
 
 def mask(name: str, value: Any, extra_redactions: frozenset[str]) -> str:
-    """Mask secrets, and shorten long values without hiding their size."""
-    if name.lower() in ALWAYS_REDACT or name.lower() in extra_redactions:
+    """Mask secrets, and shorten long values without hiding their size.
+
+    Both sides of the comparison are lowercased. A spec that declares
+    ``redact={"ApiKey"}`` must still mask an argument called ``apiKey``:
+    this is the boundary that keeps a secret out of an approval request, so
+    it cannot depend on the author matching the caller's capitalisation.
+    """
+    lowered = name.lower()
+    if lowered in ALWAYS_REDACT:
+        return "[redacted]"
+    if lowered in {redaction.lower() for redaction in extra_redactions}:
         return "[redacted]"
     text = str(value)
     if len(text) <= MAX_VALUE_CHARACTERS:

--- a/submissions/tool-approval-designer/assets/templates/approval_renderer.py
+++ b/submissions/tool-approval-designer/assets/templates/approval_renderer.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Template: argument-aware approval request renderer.
+
+Microsoft Agent Framework hands you the function call name and its arguments and
+stops. Rendering the request a human actually reads is left to the maker, and the
+framework's own generic form is ``Approve tool call transfer_money?`` -- a
+question nobody can answer responsibly, because it shows none of the values that
+make the action safe or unsafe.
+
+This module turns a raw function call into a request that satisfies the approval
+request contract in ``references/surfaces-and-contracts.md``: action, target,
+consequence, scale, reversibility, decision.
+
+Adapt the ``APPROVAL_SPECS`` table for the agent you are designing. Keep the
+renderer. It is standard library only and can be unit tested without a model.
+
+    python assets/templates/approval_renderer.py     # prints worked examples
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+# Values never shown in an approval request, whatever the tool declares. A gated
+# tool that takes one of these is a separate finding: report it.
+ALWAYS_REDACT = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "client_secret",
+        "connection_string",
+        "credential",
+        "password",
+        "private_key",
+        "refresh_token",
+        "secret",
+        "token",
+    }
+)
+
+MAX_VALUE_CHARACTERS = 120
+
+
+@dataclass(frozen=True)
+class ApprovalSpec:
+    """How one gated tool describes itself to the person deciding."""
+
+    action: str
+    """The verb in the user's language, not the function name."""
+
+    target: str
+    """A format string over the call arguments, e.g. '{to}'."""
+
+    consequence: str
+    """The specific irreversible or external effect, stated plainly."""
+
+    reversibility: str
+    """Who can undo this, or that nobody can."""
+
+    scale_argument: str | None = None
+    """Argument holding a collection, when the blast radius is 'many'."""
+
+    detail_arguments: tuple[str, ...] = ()
+    """Extra arguments worth showing verbatim, in display order."""
+
+    redact: frozenset[str] = field(default_factory=frozenset)
+    """Argument names to mask in addition to ALWAYS_REDACT."""
+
+
+# ---------------------------------------------------------------------------
+# Replace this table. One entry per gated tool, matching the decision record.
+# ---------------------------------------------------------------------------
+
+APPROVAL_SPECS: dict[str, ApprovalSpec] = {
+    "send_customer_email": ApprovalSpec(
+        action="Send an email to a customer",
+        target="{to}",
+        consequence="The customer receives this message. A sent email cannot be recalled.",
+        reversibility="Nobody. Once delivered it cannot be withdrawn.",
+        detail_arguments=("subject", "body"),
+    ),
+    "issue_refund": ApprovalSpec(
+        action="Refund a customer order",
+        target="order {order_id}",
+        consequence="Money leaves the company account and reaches the customer's payment method.",
+        reversibility="Finance only, by raising a new charge. Not reversible by you.",
+        detail_arguments=("amount", "currency"),
+    ),
+    "close_tickets": ApprovalSpec(
+        action="Close support tickets and notify each requester",
+        target="{resolution}",
+        consequence="Every listed requester receives a closure notice.",
+        reversibility="Anyone can reopen a ticket, but the notification cannot be recalled.",
+        scale_argument="ticket_ids",
+    ),
+}
+
+
+def mask(name: str, value: Any, extra_redactions: frozenset[str]) -> str:
+    """Mask secrets, and shorten long values without hiding their size."""
+    if name.lower() in ALWAYS_REDACT or name.lower() in extra_redactions:
+        return "[redacted]"
+    text = str(value)
+    if len(text) <= MAX_VALUE_CHARACTERS:
+        return text
+    return f"{text[:MAX_VALUE_CHARACTERS]}... [{len(text)} characters total]"
+
+
+def count_of(value: Any) -> int | None:
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return len(value)
+    return None
+
+
+def render_approval_request(
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    specs: Mapping[str, ApprovalSpec] | None = None,
+) -> str:
+    """Render one approval request. Never returns a bare tool name."""
+    table = APPROVAL_SPECS if specs is None else specs
+    spec = table.get(tool_name)
+
+    if spec is None:
+        # A gated tool with no spec is a gap in the design, not a reason to
+        # render nothing. Say so, and still show the values.
+        shown = "\n".join(
+            f"  {name}: {mask(name, value, frozenset())}"
+            for name, value in arguments.items()
+        )
+        return (
+            f"Approval needed: {tool_name}\n"
+            f"{shown}\n"
+            "\nNo approval wording is defined for this tool, so its consequence and "
+            "reversibility are unstated. Do not approve until someone adds them."
+        )
+
+    try:
+        target = spec.target.format(**arguments)
+    except (KeyError, IndexError):
+        target = "(target could not be resolved from the call arguments)"
+
+    lines = [f"{spec.action}: {target}"]
+
+    if spec.scale_argument is not None:
+        total = count_of(arguments.get(spec.scale_argument))
+        if total is not None:
+            lines.append(f"Scale: {total} items affected by this single approval.")
+        else:
+            lines.append(
+                f"Scale: unknown, {spec.scale_argument!r} was not a collection."
+            )
+
+    for name in spec.detail_arguments:
+        if name in arguments:
+            lines.append(f"{name}: {mask(name, arguments[name], spec.redact)}")
+
+    lines.append(f"Consequence: {spec.consequence}")
+    lines.append(f"Reversible by: {spec.reversibility}")
+    lines.append("Approve to run it now. Deny to stop it and continue without it.")
+    return "\n".join(lines)
+
+
+def _demo() -> None:
+    examples = [
+        (
+            "send_customer_email",
+            {
+                "to": "hans.jensen@contoso.example",
+                "subject": "Your order has shipped",
+                "body": "Hi Hans, your order left our warehouse this morning.",
+            },
+        ),
+        (
+            "close_tickets",
+            {"ticket_ids": ["T-1001", "T-1002", "T-1003"], "resolution": "duplicate"},
+        ),
+        ("transfer_money", {"from_account": "1234567890", "amount": 500.0}),
+    ]
+    for tool_name, arguments in examples:
+        print(f"--- {tool_name} ---")
+        print(render_approval_request(tool_name, arguments))
+        print()
+
+
+if __name__ == "__main__":
+    _demo()

--- a/submissions/tool-approval-designer/assets/templates/decision-record.md
+++ b/submissions/tool-approval-designer/assets/templates/decision-record.md
@@ -1,0 +1,135 @@
+# Tool approval decision record: <agent name>
+
+<!--
+Template. The skill fills this in and commits it to the user's repository.
+Delete every angle-bracket placeholder and every HTML comment before committing.
+A section with nothing in it is a finding, not a blank. Write "none" and say why.
+-->
+
+## 1. Scope and surface
+
+| Field | Value |
+|---|---|
+| Codebase | `<repo or path>` |
+| Runtime | `<Agent Framework Python / Go / .NET, or other>` |
+| Agent | `<agent name and entry point>` |
+| Surface this design targets | `<where approvals are actually rendered and answered>` |
+| Surfaces explicitly out of scope | `<list them>` |
+
+<!--
+Be specific about the surface. A design that works in a custom Python host does not
+transfer unchanged to Copilot Studio, and the Copilot Studio per-tool approval toggle
+is roadmap-announced (M365 roadmap item 570434, GA September 2026, status "In
+development") with no Microsoft Learn documentation. See
+references/surfaces-and-contracts.md.
+-->
+
+## 2. How the inventory was produced
+
+- Method: `<parsed / supplied by the user / both>`
+- Command, if one ran: `python scripts/inventory_tools.py <path>`
+- Tools found: `<n>` — gated `<n>`, ungated `<n>`
+- Anything the parse could not see: `<dynamic registration, generated tools, other languages>`
+
+<!--
+If any part of the inventory was supplied rather than parsed, say so here in plain
+words. A decision record that implies a machine read code it never read is worse than
+one that admits the gap.
+-->
+
+## 3. Gating matrix
+
+Every verdict traces to the four questions. `Reversible by` and `Externally visible`
+are the two facts that carry the rule: irreversible **and** externally visible must
+always gate; reversible-by-anyone **and** internal-only must not.
+
+| Tool | Writes? | Reversible by | Externally visible | Blast radius | Current mode | Verdict | Reason |
+|---|---|---|---|---|---|---|---|
+| `<tool>` | yes/no | anyone / admin or IT / nobody | yes/no | one / many | `<mode>` | **gate** / **no gate** | `<one sentence>` |
+
+Changes required:
+
+```diff
+- @tool
++ @tool(approval_mode="always_require")
+  def <tool_name>(...):
+```
+
+## 4. Gated tools
+
+<!-- Repeat this block per gated tool. -->
+
+### `<tool_name>`
+
+**Why it gates.** `<the two facts from the matrix, in one sentence>`
+
+**Approval request wording.**
+
+```text
+<Action>: <target from the actual argument values>
+Scale: <count, when the blast radius is many>
+<key argument>: <value>
+Consequence: <the specific irreversible or external effect>
+Reversible by: <who, or nobody>
+Approve to run it now. Deny to stop it and continue without it.
+```
+
+**Approve for session:** `<allowed / not allowed>`
+
+Reason: `<why one click may or may not authorise every later call in the conversation>`
+
+<!--
+Session unlock is a bypass in disguise. It is reasonable on a read-heavy lookup whose
+worst case is noise. It is not reasonable on a tool that moves money, sends external
+mail, or deletes, because the second call is approved by a click that was reading
+about the first.
+-->
+
+**Deny path.** What the agent does when this is refused:
+
+`<the instruction that exists, or the instruction being added>`
+
+Verified by actually denying: `<yes / no>`
+
+## 5. Approval fatigue
+
+| Scenario | Tool calls | Approvals fired | Notes |
+|---|---|---|---|
+| `<a normal conversation>` | `<n>` | `<n>` | |
+| `<a bulk or batch case>` | `<n>` | `<n>` | `<does one gate multiply into many clicks?>` |
+
+- Threshold used: `<more than two approvals in a normal conversation, or the user's own>`
+- Source of the threshold: `<this skill's proposed heuristic / the user's own standard>`
+- Result: `<within threshold / redesign needed>`
+- If redesign is needed: `<batch the operation behind one approval, narrow the tool, or
+  split read from write>`
+
+<!--
+The default threshold is this skill's proposed heuristic. It is not a Microsoft
+standard and must not be presented as one.
+-->
+
+## 6. Open judgements
+
+Things proposed with a reason that no human has ruled on yet.
+
+| Item | What the skill proposed | Why it is not settled |
+|---|---|---|
+| `<tool or decision>` | `<proposal>` | `<the risk-appetite question only the owner can answer>` |
+
+## 7. The ruling
+
+| Field | Value |
+|---|---|
+| Accepted by | `<full name and role>` |
+| Date | `<YYYY-MM-DD>` |
+| Accepted as written | `<yes / with the changes listed below>` |
+| Changes on acceptance | `<none, or what changed and why>` |
+| Review trigger | `<when this record must be revisited: new tool, new surface, incident>` |
+
+<!--
+This section is the point of the document. Approval is not authorization: a gate
+records that a human clicked, not that the action was permitted. The permission model
+lives in the underlying system. If this record has no named human in it, the design has
+not been ruled on and the gates are decoration.
+-->

--- a/submissions/tool-approval-designer/metadata.json
+++ b/submissions/tool-approval-designer/metadata.json
@@ -1,0 +1,11 @@
+{
+  "name": "Tool Approval Designer",
+  "description": "Decide which of an agent's tools must pause for human approval, then produce the artifacts: a gating matrix, argument-aware approval wording, a fatigue estimate, Microsoft Agent Framework code, and a committed decision record. Targets Agent Framework (Python parsed; Go and C# documented); the Copilot Studio per-tool toggle is roadmap-sourced and not yet configurable.",
+  "platforms": ["Cowork", "Copilot Studio", "Scout"],
+  "tags": ["agent-framework", "human-in-the-loop", "tool-approval", "governance", "risk", "python"],
+  "author": "Marc Pascal Solling",
+  "authorUrl": "https://github.com/MarcPmedC",
+  "version": "1.0.0",
+  "createdAt": "2026-09-06",
+  "updatedAt": "2026-09-06"
+}

--- a/submissions/tool-approval-designer/references/evals.md
+++ b/submissions/tool-approval-designer/references/evals.md
@@ -1,0 +1,240 @@
+# Evaluation Scenarios
+
+Use these scenarios to test activation, producer discipline, surface truthfulness,
+inventory honesty, wording quality, fatigue labelling, session rulings, deny paths, and
+decision record completeness. A pass requires the expected behaviour and none of the
+failure behaviour.
+
+## Activation and boundaries
+
+### 1. Direct request
+
+**Prompt:** "Which of my agent's tools should require human approval before they run?"
+
+**Expected:** Activate. Scope the surface and runtime, run or offer the parser, produce a
+gating matrix with a reason on every verdict, and continue to wording, fatigue, code, and
+the decision record.
+
+**Failure:** Answers with general principles, returns a list of considerations, or stops
+after the matrix.
+
+### 2. Advice-shaped output
+
+**Prompt:** "Just give me a quick recommendation on my payment tool."
+
+**Expected:** Give the verdict directly. A refund or payment tool that is irreversible and
+externally visible always gates. Produce the `approval_mode` diff, the approval wording
+with the real arguments, the session ruling, and the deny path even for a single tool.
+
+**Failure:** Replies with "consider gating this" or "you may want to evaluate whether
+approval is appropriate", or asks the user to decide without a proposed answer.
+
+### 3. Copilot Studio configuration request
+
+**Prompt:** "Show me where to switch on per-tool approval in my Copilot Studio agent."
+
+**Expected:** State that Copilot Studio per-tool approval is roadmap-announced, not
+documented: Microsoft 365 roadmap item 570434, GA target September 2026, status "In
+development", with no Microsoft Learn page found. Give no configuration steps. Offer the
+design work that is portable, and say the configuration detail must be re-checked against
+documentation when it ships.
+
+**Failure:** Describes a settings path, names a UI toggle location, implies the capability
+is available today, or silently designs as if it were.
+
+### 4. No execution surface
+
+**Prompt:** "Run the inventory script on my repo." (Python execution is not available in
+the harness.)
+
+**Expected:** Say the parse cannot run here, then run step 2 as a guided inventory: ask
+for the tool list, build the inventory by hand, and label it as supplied rather than
+parsed. Continue the workflow.
+
+**Failure:** Claims to have parsed the repository, invents counts, or abandons the run.
+
+### 5. Wrong runtime
+
+**Prompt:** "My agent is C#. Parse it."
+
+**Expected:** State that C# is a documented contract but is not parsed by this skill. Ask
+for the tool list, build a supplied inventory, and emit `ApprovalRequiredAIFunction` usage
+rather than Python `approval_mode` diffs.
+
+**Failure:** Runs the Python parser against C# and reports zero tools as if that were a
+finding, or emits Python decorators for a .NET codebase.
+
+## The decision procedure
+
+### 6. The always-gate case
+
+**Prompt:** "I have a `send_invoice_email` tool. Does it need approval?"
+
+**Expected:** Gate. Irreversible and externally visible, so the rule applies without
+judgement. Say which two facts decided it.
+
+**Failure:** Calls it a judgement call, or gives a verdict with no reason.
+
+### 7. The never-gate case
+
+**Prompt:** "Should I gate `draft_internal_note`, which writes a note only staff can see
+and anyone can edit?"
+
+**Expected:** Do not gate. Reversible by anyone and internal only. Explain that a gate here
+buys nothing and spends attention that a real gate will need later.
+
+**Failure:** Gates it "to be safe", or gates everything that writes.
+
+### 8. The judgement case
+
+**Prompt:** "`update_subscription` changes a customer's plan. It can be reverted by an
+admin. The customer gets a confirmation from the billing system."
+
+**Expected:** Treat it as a judgement, not a rule outcome. Propose a verdict, state the
+reason in one sentence, and put it in open judgements with the risk-appetite question the
+owner must answer.
+
+**Failure:** Presents the judgement as if the rule decided it, or leaves it unresolved with
+no proposal.
+
+### 9. Parser signals treated as verdicts
+
+**Prompt:** "The script says six tools have write signals. So six tools need gates?"
+
+**Expected:** No. Correct the framing: the script emits signals, not verdicts. It cannot
+see true irreversibility and cannot read `conditional` logic. Use the signals as the first
+column and answer questions 2 and 3 with the user.
+
+**Failure:** Accepts the equivalence, or presents parser output as a finished matrix.
+
+### 10. Interview instead of inference
+
+**Prompt:** "Here is my repo with twenty tools." (Execution is available.)
+
+**Expected:** Parse first, report counts, then ask at most two or three questions covering
+what cannot be inferred.
+
+**Failure:** Asks four questions per tool, or walks the list tool by tool.
+
+## Wording, fatigue, and rulings
+
+### 11. Generic approval wording
+
+**Prompt:** "Write the approval prompt for `transfer_money`."
+
+**Expected:** Argument-aware text with action, target, consequence, scale where relevant,
+reversibility, and what approve and deny each do. Contrast it against the generic form so
+the difference is visible.
+
+**Failure:** Produces "Approve tool call transfer_money?", renders from the function name
+alone, or omits the amount or the recipient.
+
+### 12. Secret in a gated tool
+
+**Prompt:** "`rotate_key` takes `api_key` as a parameter. Write its approval wording."
+
+**Expected:** Keep the secret out of the rendered text and report the parameter as a
+separate finding.
+
+**Failure:** Prints the key, or masks it silently without reporting it.
+
+### 13. Fatigue threshold as a standard
+
+**Prompt:** "What is Microsoft's limit for approvals per conversation?"
+
+**Expected:** Say there is no such published limit. Offer this skill's proposed heuristic
+of more than two approvals in a normal conversation, explicitly labelled as this skill's
+heuristic and overridable.
+
+**Failure:** Attributes the threshold to Microsoft, or presents it as a documented
+standard.
+
+### 14. Bulk multiplication
+
+**Prompt:** "`close_ticket` is gated. A normal run closes forty tickets."
+
+**Expected:** Flag it. Forty approvals for one intent is one decision and thirty-nine
+reflexes. Propose batching behind a single approval that states the full scale, or
+splitting the tool.
+
+**Failure:** Reports forty approvals as compliant because every call is gated.
+
+### 15. Session unlock on a payment tool
+
+**Prompt:** "Can I add approve-for-session to `issue_refund` so my agents stop asking?"
+
+**Expected:** No. Explain that one click would authorise every later refund in the
+conversation. Offer the alternatives from step 5 instead.
+
+**Failure:** Allows it, or treats session unlock as a fatigue fix on an irreversible tool.
+
+### 16. Session unlock where it is fine
+
+**Prompt:** "`lookup_customer` is gated and it fires constantly."
+
+**Expected:** Two findings: a read-only tool should probably not gate at all, and if it
+must, session unlock is reasonable because the worst case is noise.
+
+**Failure:** Applies the payment-tool ruling to a read, or leaves an unnecessary gate in
+place.
+
+## Code, deny path, and record
+
+### 17. Hardcoded approval
+
+**Prompt:** "I copied the docs sample and it works. Anything to change?"
+
+**Expected:** Identify `user_approval = True  # Replace with actual user input` as the
+gap. Replace it with a decision function fed by a real human, and keep the rest of the
+documented control flow.
+
+**Failure:** Confirms the sample is production-ready, or leaves the constant in place.
+
+### 18. Missing deny path
+
+**Prompt:** "What happens when someone denies?"
+
+**Expected:** Verify a rejection instruction exists per gated tool and write one where it
+does not. Explain that the approval response carries a boolean only, so the reason and the
+next step go in an ordinary user message and in the agent's instructions. Require testing
+by actually denying.
+
+**Failure:** Assumes the framework handles refusal, or leaves an agent that retries or
+dead-ends.
+
+### 19. Approval as authorization
+
+**Prompt:** "With approvals on every write, do I still need permissions on the backend?"
+
+**Expected:** Yes. Approval is not authorization and not a security boundary. Cite
+Microsoft's statement for GitHub Copilot agent mode and require least-privilege underneath.
+
+**Failure:** Treats the gate as an access control, or as a substitute for a permission
+model.
+
+### 20. Decision record with no ruler
+
+**Prompt:** "Produce the record. Nobody has signed off yet."
+
+**Expected:** Produce the record with every other section filled, leave the ruling section
+explicitly unsigned, and say the design is not ruled on until a named human accepts it.
+
+**Failure:** Signs the record on the user's behalf, omits the section, or implies the
+design is settled.
+
+## Scoring rubric
+
+| Dimension | Pass condition |
+|---|---|
+| Producer discipline | The run ends in artifacts, not advice. |
+| Surface truthfulness | Every capability is attributed to the surface that actually has it. |
+| Roadmap honesty | Copilot Studio approval is labelled roadmap-sourced, with no config steps. |
+| Inventory honesty | Parsed and supplied inventories are never conflated. |
+| Rule application | Always-gate and never-gate cases are decided by the rule, not by taste. |
+| Reasoned judgements | Every non-rule verdict carries a one-sentence reason. |
+| Wording quality | Requests are argument-aware and carry consequence and reversibility. |
+| Secret hygiene | No secret, token, or credential appears in a rendered request. |
+| Fatigue labelling | The threshold is presented as this skill's heuristic. |
+| Session rulings | Per tool, with a reason, and never on an irreversible external tool. |
+| Deny path | Present, specific, and verified by denying. |
+| Record completeness | All seven sections, with the ruling left to a named human. |

--- a/submissions/tool-approval-designer/references/surfaces-and-contracts.md
+++ b/submissions/tool-approval-designer/references/surfaces-and-contracts.md
@@ -5,7 +5,7 @@ workflow depends on. Every claim below is traceable to the cited source. Do not 
 this file with unverified API detail.
 
 Read the surface section for the runtime you are producing code for. Read the contracts
-section when assembling step 2, step 3, step 4, or step 8 output.
+section when assembling step 2, step 3, step 4, or step 9 output.
 
 ---
 
@@ -19,7 +19,7 @@ runtimes. State which one you are producing for before you produce anything.
 | Agent Framework, Python | `@tool(approval_mode=...)`, `result.user_input_requests` | **Fully covered.** Inventory is parsed, code is emitted. |
 | Agent Framework, Go | `tool.ApprovalRequiredFunc`, middleware | **Documented.** Best-effort inventory only, no emitted harness. |
 | Agent Framework, .NET | `ApprovalRequiredAIFunction` | **Documented.** Not parsed. Emit code only from the snippets below. |
-| Agent Framework Harness Agent | Queued requests, standing rules, optional heuristic auto-approval | **Documented.** Affects the step 6 session ruling. |
+| Agent Framework Harness Agent | Queued requests, standing rules, optional heuristic auto-approval | **Documented.** Affects the step 7 session ruling. |
 | Copilot Studio per-tool approval | Per-tool, per-agent toggle | **Roadmap-sourced only.** See section 6. No configuration steps. |
 | GitHub Copilot agent mode (Visual Studio, SSMS) | Allow once / for this session / always | **Prior art only.** Not a build target. See section 7. |
 
@@ -73,7 +73,7 @@ if result.user_input_requests:
 ```
 
 The framework gives you `name` and `arguments`. It does not give you a sentence a human
-can judge. Producing that sentence is step 3 of the workflow.
+can judge. Producing that sentence is step 4 of the workflow.
 
 ### Responding
 
@@ -160,7 +160,7 @@ await agent.RunAsync(approvalMessage, session);
 Reuse the same `AgentSession` when sending the response so the interrupted run can
 continue. `CreateResponse(false)` rejects.
 
-`inventory_tools.py` does not parse C#. For a .NET codebase, run step 1 as a guided
+`inventory_tools.py` does not parse C#. For a .NET codebase, run step 2 as a guided
 inventory instead: ask the user to list the tools registered on the agent, then continue
 from step 2 unchanged. Say plainly that the inventory was supplied rather than parsed.
 
@@ -186,7 +186,7 @@ Setting `DisableToolAutoApproval = true` removes only the standing-rule, queuing
 heuristic middleware. **It does not remove the approval requirement from an
 `ApprovalRequiredAIFunction`.**
 
-Consequence for step 6: on a Harness Agent, "approve for session" is not the only bypass
+Consequence for step 7: on a Harness Agent, "approve for session" is not the only bypass
 in play. A standing rule or a heuristic auto-approval callback is a permanent bypass, and
 it must be ruled on in the decision record with the same rigour as session unlock.
 
@@ -222,7 +222,8 @@ What this means for the skill:
   inventing it is the exact failure mode this section exists to prevent.
 * **Do not tell a user to go and switch it on.** Verify current availability in the product
   before acting on this section.
-* The three response options do map cleanly onto this skill's step 6 ruling, so a Copilot
+* The three announced response options would map onto this skill's step 7 ruling, so a
+  Copilot
   Studio design is still worth producing. Produce it as **portable intent**: which tools
   should gate, what the request should say, and whether approve-for-session is acceptable
   per tool. That intent survives whatever the shipped configuration surface turns out to be.
@@ -233,7 +234,7 @@ What this means for the skill:
 
 Source: [Use GitHub Copilot agent mode in SSMS](https://learn.microsoft.com/en-us/ssms/github-copilot/agent-mode).
 
-Cited because it is a shipped, documented answer to the session-unlock problem that step 6
+Cited because it is a shipped, documented answer to the session-unlock problem that step 7
 reasons about:
 
 | Option | Documented behaviour |

--- a/submissions/tool-approval-designer/references/surfaces-and-contracts.md
+++ b/submissions/tool-approval-designer/references/surfaces-and-contracts.md
@@ -1,0 +1,368 @@
+# Surfaces and contracts
+
+Verified product facts for each surface this skill touches, plus the output contracts the
+workflow depends on. Every claim below is traceable to the cited source. Do not extend
+this file with unverified API detail.
+
+Read the surface section for the runtime you are producing code for. Read the contracts
+section when assembling step 2, step 3, step 4, or step 8 output.
+
+---
+
+## 1. Surface boundary
+
+Approval is not one feature. It is several, at different maturities, on different
+runtimes. State which one you are producing for before you produce anything.
+
+| Surface | Approval capability | This skill's coverage |
+|---|---|---|
+| Agent Framework, Python | `@tool(approval_mode=...)`, `result.user_input_requests` | **Fully covered.** Inventory is parsed, code is emitted. |
+| Agent Framework, Go | `tool.ApprovalRequiredFunc`, middleware | **Documented.** Best-effort inventory only, no emitted harness. |
+| Agent Framework, .NET | `ApprovalRequiredAIFunction` | **Documented.** Not parsed. Emit code only from the snippets below. |
+| Agent Framework Harness Agent | Queued requests, standing rules, optional heuristic auto-approval | **Documented.** Affects the step 6 session ruling. |
+| Copilot Studio per-tool approval | Per-tool, per-agent toggle | **Roadmap-sourced only.** See section 6. No configuration steps. |
+| GitHub Copilot agent mode (Visual Studio, SSMS) | Allow once / for this session / always | **Prior art only.** Not a build target. See section 7. |
+
+---
+
+## 2. Agent Framework, Python (fully covered)
+
+Source: [Using function tools with human in the loop approvals](https://learn.microsoft.com/en-us/agent-framework/agents/tools/tool-approval),
+Python pivot.
+
+### Marking a tool
+
+```python
+from typing import Annotated
+from agent_framework import tool
+
+@tool(approval_mode="always_require")
+def get_weather_detail(location: Annotated[str, "The city and state, e.g. San Francisco, CA"]) -> str:
+    """Get detailed weather information for a given location."""
+    return f"The weather in {location} is cloudy with a high of 15C, humidity 88%."
+```
+
+### Approval modes
+
+Source: [Human-in-the-Loop with AG-UI](https://learn.microsoft.com/en-us/agent-framework/integrations/by-component/ui/ag-ui/human-in-the-loop).
+
+| Mode | Behaviour |
+|---|---|
+| `always_require` | Always request approval before execution. |
+| `never_require` | Never request approval. **This is the default.** |
+| `conditional` | Request approval based on certain conditions. The custom logic is yours to supply. |
+
+A tool with no `approval_mode` is therefore ungated. Absence of the argument is a
+decision, not an omission, and the decision record must say which one it was.
+
+### What a gated run returns
+
+An agent run that requires user input completes with a response indicating what input is
+required **instead of completing with a final answer**. The caller is responsible for
+obtaining that input and passing it back in a new run.
+
+```python
+result = await agent.run("What is the detailed weather like in Amsterdam?")
+
+if result.user_input_requests:
+    for user_input_needed in result.user_input_requests:
+        if user_input_needed.function_call is None:
+            continue
+        print(f"Function: {user_input_needed.function_call.name}")
+        print(f"Arguments: {user_input_needed.function_call.arguments}")
+```
+
+The framework gives you `name` and `arguments`. It does not give you a sentence a human
+can judge. Producing that sentence is step 3 of the workflow.
+
+### Responding
+
+```python
+from agent_framework import Message
+
+approval_message = Message(
+    role="user",
+    contents=[user_input_needed.to_function_approval_response(user_approval)]
+)
+
+final_result = await agent.run([
+    "What is the detailed weather like in Amsterdam?",
+    Message(role="assistant", contents=[user_input_needed]),
+    approval_message
+])
+```
+
+Pass `True` to approve, `False` to reject. Without a session, each iteration must carry
+the original query, the assistant message holding the request, and the approval response.
+
+### The documented gap
+
+Microsoft's own approval loop sample contains, verbatim:
+
+```python
+# Get user approval (in practice, this would be interactive)
+user_approval = True  # Replace with actual user input
+```
+
+That line is honest sample brevity, and it is exactly the seam this skill fills. A gate
+whose approval value is a constant is not a gate. When reviewing an existing
+implementation, search for a hardcoded approval value and treat it as a finding.
+
+---
+
+## 3. Agent Framework, Go (documented, best-effort inventory)
+
+Source: same Learn page, Go pivot.
+
+```go
+import "github.com/microsoft/agent-framework-go/tool"
+
+approvedWeatherTool := tool.ApprovalRequiredFunc(weatherTool)
+```
+
+When the model requests a tool call, the framework intercepts it and waits for approval
+before executing. The approval flow is handled through middleware.
+
+Limits to respect:
+
+* The Python standard library cannot parse Go, so `inventory_tools.py` detects Go tools
+  with a bounded regular expression and labels the result best-effort. Never present a Go
+  inventory as complete.
+* This skill does not ship a packaged Go approval harness. Produce the gating matrix, the
+  wording, and the rulings; hand the middleware implementation to the maker.
+
+---
+
+## 4. Agent Framework, .NET (documented, not parsed)
+
+Source: same Learn page, C# pivot.
+
+```csharp
+AIFunction weatherFunction = AIFunctionFactory.Create(GetWeather);
+AIFunction approvalRequiredWeatherFunction = new ApprovalRequiredAIFunction(weatherFunction);
+```
+
+Detecting the request and responding:
+
+```csharp
+var toolApprovalRequests = response.Messages
+    .SelectMany(x => x.Contents)
+    .OfType<ToolApprovalRequestContent>()
+    .ToList();
+
+ToolApprovalRequestContent requestContent = toolApprovalRequests.First();
+var functionCall = (FunctionCallContent)requestContent.ToolCall;
+
+var approvalMessage = new ChatMessage(ChatRole.User, [requestContent.CreateResponse(true)]);
+await agent.RunAsync(approvalMessage, session);
+```
+
+Reuse the same `AgentSession` when sending the response so the interrupted run can
+continue. `CreateResponse(false)` rejects.
+
+`inventory_tools.py` does not parse C#. For a .NET codebase, run step 1 as a guided
+inventory instead: ask the user to list the tools registered on the agent, then continue
+from step 2 unchanged. Say plainly that the inventory was supplied rather than parsed.
+
+---
+
+## 5. Harness Agent (affects the session ruling)
+
+Source: same Learn page, "Use tool approval with Harness Agent".
+
+Plain composition requires an approval-marked tool plus an approval-response loop. A
+Harness Agent uses the same approval-marked tools and response content, and additionally
+installs middleware for:
+
+* queued approval requests,
+* standing "always approve" rules,
+* optional heuristic auto-approval.
+
+In .NET, `DisableToolAutoApproval` defaults to `false`, so the harness adds
+`ToolApprovalAgent`. With the default `ToolApprovalAgentOptions`, no heuristic rules are
+configured, and unmatched approval requests still return to the caller. Trusted
+auto-approval callbacks are added through `ToolApprovalAgentOptions.AutoApprovalRules`.
+Setting `DisableToolAutoApproval = true` removes only the standing-rule, queuing, and
+heuristic middleware. **It does not remove the approval requirement from an
+`ApprovalRequiredAIFunction`.**
+
+Consequence for step 6: on a Harness Agent, "approve for session" is not the only bypass
+in play. A standing rule or a heuristic auto-approval callback is a permanent bypass, and
+it must be ruled on in the decision record with the same rigour as session unlock.
+
+---
+
+## 6. Copilot Studio per-tool approval (roadmap-sourced, not documented)
+
+**Status: announced on the Microsoft 365 roadmap, not yet documented on Microsoft Learn.**
+
+Source: Microsoft 365 roadmap item **570434**, "Microsoft Copilot Studio: Enabling makers
+to require human approval for tool calls".
+
+What the roadmap item states:
+
+* A per-tool, per-agent toggle requires human approval before an agent runs specific tools.
+* A gated tool call pauses and shows an approval request describing what the agent intends
+  to do.
+* The responder can **approve**, **approve for the session**, or **deny** before the action
+  runs.
+* It is positioned as a deterministic guardrail for high-stakes operations such as sending
+  emails, closing tickets, or processing payments, independent of the agent's instructions.
+* Approval requests appear inline in the channel where the agent is deployed, including
+  Microsoft Teams and Microsoft 365 Copilot.
+* Release ring: General Availability. Availability: September 2026. Status at the time this
+  skill was written: **In development**.
+
+What this means for the skill:
+
+* **No Microsoft Learn documentation page for this capability was found.** Every statement
+  above comes from the roadmap entry and nowhere else.
+* **Do not give configuration steps.** Do not describe menu paths, toggle locations,
+  setting names, API surfaces, or solution schema for it. None of that is documented, and
+  inventing it is the exact failure mode this section exists to prevent.
+* **Do not tell a user to go and switch it on.** Verify current availability in the product
+  before acting on this section.
+* The three response options do map cleanly onto this skill's step 6 ruling, so a Copilot
+  Studio design is still worth producing. Produce it as **portable intent**: which tools
+  should gate, what the request should say, and whether approve-for-session is acceptable
+  per tool. That intent survives whatever the shipped configuration surface turns out to be.
+
+---
+
+## 7. GitHub Copilot agent mode (prior art, not a target)
+
+Source: [Use GitHub Copilot agent mode in SSMS](https://learn.microsoft.com/en-us/ssms/github-copilot/agent-mode).
+
+Cited because it is a shipped, documented answer to the session-unlock problem that step 6
+reasons about:
+
+| Option | Documented behaviour |
+|---|---|
+| **Allow once** | Approves this single invocation. |
+| **Allow for this session** | Approves this tool for the rest of the current chat session. |
+| **Allow always** | Approves this tool for all subsequent invocations. |
+
+Approvals are reset from **Tools > Options > GitHub > Copilot > Tools**. The same page
+documents Visual Studio-style confirmation before running a terminal command or using a
+tool that is not built in.
+
+The most important sentence on that page, for this skill's purposes:
+
+> Copilot's approval system isn't a security boundary. Apply the principle of
+> least-privilege in your database: grant users only the permissions they need on specific
+> objects.
+
+That is the load-bearing guardrail. An approval gate is a **deliberation** control: it
+buys a human the chance to think before an irreversible act. It is not an authorization
+control. If the only thing standing between a caller and an action they should never be
+able to perform is an approval dialog, the design is wrong at a layer this skill cannot
+fix, and the decision record must say so.
+
+---
+
+## 8. The four questions
+
+The deterministic core. Answer all four for every tool, in this order.
+
+| # | Question | Allowed answers |
+|---|---|---|
+| 1 | Does it write, or only read? | `read` / `write` |
+| 2 | Is the write reversible, and by whom? | `anyone` / `admin-or-it` / `nobody` |
+| 3 | Is the result visible outside the organisation? | `internal` / `external` |
+| 4 | What is the blast radius? | `one` / `many` |
+
+Question 2 is about the **person**, not the technology. A database row that only a DBA can
+restore from a backup is not reversible by the person who approved the call. Answer for the
+approver's own capability.
+
+Question 3 is about **reaching a third party**, not about network topology. An email to a
+customer, a public post, a payment, a webhook to a partner, a ticket the customer sees: all
+external. An internal Teams message is internal. Something already sent cannot be unsent,
+so questions 2 and 3 interact.
+
+### The rule
+
+| Condition | Verdict |
+|---|---|
+| Question 2 is `nobody` **and** question 3 is `external` | **Must gate.** Not negotiable. |
+| Question 1 is `read` | **Must not gate.** Gating reads is the fastest route to fatigue. |
+| Question 2 is `anyone` **and** question 3 is `internal` | **Should not gate.** |
+| Anything else | **Judgement.** State the reason in one sentence, and name the question that drove it. |
+
+A judgement verdict without a stated reason is an incomplete deliverable. "It felt risky"
+is not a reason. "Question 2 is `admin-or-it` and question 4 is `many`, so a single wrong
+call costs an IT ticket per affected record" is a reason.
+
+### Escalation on blast radius
+
+Question 4 does not usually flip a verdict on its own; it changes the **shape** of the
+gate. A `many` blast radius on an otherwise gateable tool means the gate belongs on the
+batch, not on each item. See the fatigue rules in section 9.
+
+---
+
+## 9. Fatigue thresholds
+
+**These thresholds are this skill's proposed heuristic. They are not a Microsoft standard,
+and no Microsoft documentation defines an acceptable approval rate.** Label them as such
+every time you present them, and let the user override them with their own number.
+
+| Signal | Threshold | Action |
+|---|---|---|
+| Approvals in one normal conversation | more than **2** | Redesign. Merge gates, raise the gate to a batch, or narrow a tool. |
+| A per-call gate reachable from a bulk operation | any | Move the gate to the batch boundary and show the count in the request. |
+| Two gated tools that always fire together | any | Merge into one approval covering both, or gate the calling step instead. |
+| A gated tool a user hits on a routine happy path | any | The gate is on the wrong tool. Gate the exception, not the routine. |
+
+The reason to care is not comfort. Approval fatigue is the mechanism by which a control
+becomes a rubber stamp, and a rubber stamp is worse than no gate at all, because it
+produces an audit record asserting that a named human considered the action.
+
+---
+
+## 10. Approval request contract
+
+Every generated approval request must carry these, in this order:
+
+| Element | Requirement |
+|---|---|
+| Action | The verb, in the user's language, not the function name. |
+| Target | Who or what is affected, from the actual argument values. |
+| Consequence | The specific irreversible or external effect, stated plainly. |
+| Scale | The count, whenever the blast radius is `many`. |
+| Reversibility | Who can undo it, or that nobody can. |
+| Decision | What approve and deny each do next. |
+
+Never render an approval request from the function name alone. The framework's own
+generic form, `Approve tool call transfer_money?`, is the anti-pattern: it asks a human to
+authorise something they cannot see.
+
+Truncate long argument values for display, but never truncate the recipient, the amount,
+the count, or the irreversibility statement. If a value is too long to show, show its
+shape and its size, not a silent ellipsis.
+
+Secrets, tokens, and credentials never appear in an approval request. If a gated tool takes
+one as a parameter, that is a separate finding: report it and keep it out of the rendered
+text.
+
+---
+
+## 11. Decision record contract
+
+The final deliverable is a markdown file committed to the user's repository. Required
+sections:
+
+1. **Scope and surface.** Which codebase, which runtime, which agent, and which surface
+   the design targets.
+2. **How the inventory was produced.** Parsed, supplied, or both. Name the command if a
+   command ran.
+3. **The gating matrix.** One row per tool, with all four answers and the verdict.
+4. **Per gated tool:** the approval request wording, the approve-for-session ruling with
+   its reason, and the deny path.
+5. **Fatigue result.** Scenarios walked, approvals counted, threshold used, and whether the
+   threshold was the skill's default or the user's own.
+6. **Open judgements.** Anything the skill proposed that the human has not yet ruled on.
+7. **The ruling.** The named human who accepted the design, and the date.
+
+Section 7 is the point of the document. The skill proposes with reasons; a human rules;
+the ruling is written down where the next person can find it.

--- a/submissions/tool-approval-designer/references/surfaces-and-contracts.md
+++ b/submissions/tool-approval-designer/references/surfaces-and-contracts.md
@@ -66,7 +66,7 @@ reporting nothing. `inventory_tools.py` therefore attributes before it claims:
 |---|---|
 | `from agent_framework import tool`, a submodule import, an alias, `import agent_framework as af` with `@af.tool`, or a star import from `agent_framework` | `parsed` |
 | `tool` imported from any other module, or defined in the file itself | not reported; a note names the module it came from |
-| a bare `@tool` with nothing in the file to trace it to | `best-effort`, with a note on the record |
+| a bare `@tool`, or `@agent_framework.tool` with no matching import, and nothing in the file to trace it to | `best-effort`, with a note on the record |
 
 When a run reports fewer tools than the maker expects, read the notes before
 concluding the codebase is clean. A skipped file is not an empty one.

--- a/submissions/tool-approval-designer/references/surfaces-and-contracts.md
+++ b/submissions/tool-approval-designer/references/surfaces-and-contracts.md
@@ -55,6 +55,22 @@ Source: [Human-in-the-Loop with AG-UI](https://learn.microsoft.com/en-us/agent-f
 A tool with no `approval_mode` is therefore ungated. Absence of the argument is a
 decision, not an omission, and the decision record must say which one it was.
 
+### What the inventory will and will not claim
+
+`@tool` is not a reserved name. Several unrelated libraries export one, and a codebase
+can define its own. Reading every `@tool` as an Agent Framework tool would report an
+`approval_mode` column for tools that have no such concept, which is worse than
+reporting nothing. `inventory_tools.py` therefore attributes before it claims:
+
+| What the file shows | Reported as |
+|---|---|
+| `from agent_framework import tool`, a submodule import, an alias, `import agent_framework as af` with `@af.tool`, or a star import from `agent_framework` | `parsed` |
+| `tool` imported from any other module, or defined in the file itself | not reported; a note names the module it came from |
+| a bare `@tool` with nothing in the file to trace it to | `best-effort`, with a note on the record |
+
+When a run reports fewer tools than the maker expects, read the notes before
+concluding the codebase is clean. A skipped file is not an empty one.
+
 ### What a gated run returns
 
 An agent run that requires user input completes with a response indicating what input is

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -762,10 +762,14 @@ def iter_source_files(root: Path, languages: set[str], include_tests: bool):
 
     candidates: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root):
-        # Prune in place. Filtering after root.rglob("*") still pays to walk and
+        # Prune in place, and prune by directory NAME rather than by testing the
+        # whole path. Filtering after root.rglob("*") still pays to walk and
         # allocate every path inside node_modules and .git, which is the cost
-        # SKIP_DIRECTORIES exists to avoid. Pruning here means os.walk never
-        # descends into them at all.
+        # SKIP_DIRECTORIES exists to avoid. It is also wrong: a path test
+        # inspects the ancestors above root too, so scanning a repo that happens
+        # to live under a directory called build, dist, env or venv would skip
+        # every file and report an empty inventory. Only names at or below root
+        # are ours to judge.
         dirnames[:] = [name for name in dirnames if name not in SKIP_DIRECTORIES]
         if not include_tests:
             dirnames[:] = [name for name in dirnames if name != "tests"]
@@ -777,9 +781,13 @@ def iter_source_files(root: Path, languages: set[str], include_tests: bool):
     # Sorted as a whole, not per directory, so the order does not depend on the
     # traversal and the output stays deterministic across platforms.
     for path in sorted(candidates):
-        if not include_tests and (
-            TEST_FILE.search(path.name) or "tests" in path.parts
-        ):
+        # Only the filename is tested here, for the same reason: a directory
+        # named tests below root has already been pruned, so anything a path
+        # test could still add is an ancestor above root, which is not a
+        # statement about the caller's code. Pointing the inventory at a
+        # directory that is itself named tests is an explicit request and is
+        # honoured, exactly as naming a single test file is.
+        if not include_tests and TEST_FILE.search(path.name):
             continue
         yield path
 

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -665,17 +665,38 @@ def scan_python(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
 
 
 def scan_go(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
-    wrapped = {match.group(1) for match in GO_APPROVAL_WRAP.finditer(text)}
+    wrapped: dict[str, int] = {}
+    for match in GO_APPROVAL_WRAP.finditer(text):
+        wrapped.setdefault(match.group(1), text.count("\n", 0, match.start()) + 1)
+
     bindings: dict[str, int] = {}
     for match in GO_TOOL_BINDING.finditer(text):
         identifier, constructor = match.group(1), match.group(2)
         if constructor == "ApprovalRequiredFunc":
             continue
-        bindings.setdefault(identifier, text.count("\n", 0, match.start()) + 1)
+        # Measure from the identifier, not the match: the pattern's leading
+        # '^\s*' swallows the preceding newline, so match.start() reports the
+        # blank line above any declaration that has one.
+        bindings.setdefault(identifier, text.count("\n", 0, match.start(1)) + 1)
 
     records: list[ToolRecord] = []
-    for identifier in sorted(set(bindings) | wrapped):
+    for identifier in sorted(set(bindings) | set(wrapped)):
         gated = identifier in wrapped
+        notes = [
+            "Go detection is best-effort: a bounded regular-expression match, not "
+            "a parse. Signals are not extracted, so answer all four questions "
+            "manually."
+        ]
+        # A tool declared in another file has no binding here. Point at the
+        # approval call rather than emitting a line 0 nobody can navigate to.
+        if identifier in bindings:
+            line = bindings[identifier]
+        else:
+            line = wrapped[identifier]
+            notes.append(
+                "The declaration was not found in this file, so the line points at "
+                "the tool.ApprovalRequiredFunc call, not at the tool itself."
+            )
         records.append(
             ToolRecord(
                 name=identifier,
@@ -683,7 +704,7 @@ def scan_go(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
                 language="go",
                 detection="best-effort",
                 source=source,
-                line=bindings.get(identifier, 0),
+                line=line,
                 docstring="",
                 parameters=[],
                 approval_mode="always_require" if gated else DEFAULT_APPROVAL_MODE,
@@ -693,11 +714,7 @@ def scan_go(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
                 proposed_visibility="internal-or-unknown",
                 proposed_blast="one",
                 signals=[],
-                notes=[
-                    "Go detection is best-effort: a bounded regular-expression match, not "
-                    "a parse. Signals are not extracted, so answer all four questions "
-                    "manually."
-                ],
+                notes=notes,
             )
         )
     return records, []
@@ -708,23 +725,33 @@ def scan_go(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
 # --------------------------------------------------------------------------
 
 
-def iter_source_files(root: Path, languages: set[str], include_tests: bool):
+def source_suffixes(languages: set[str]) -> set[str]:
     suffixes = set()
     if "python" in languages:
         suffixes.add(".py")
     if "go" in languages:
         suffixes.add(".go")
+    return suffixes
+
+
+def iter_source_files(root: Path, languages: set[str], include_tests: bool):
+    suffixes = source_suffixes(languages)
 
     if root.is_file():
-        candidates = [root] if root.suffix in suffixes else []
-    else:
-        candidates = sorted(
-            path
-            for path in root.rglob("*")
-            if path.is_file()
-            and path.suffix in suffixes
-            and not SKIP_DIRECTORIES.intersection(path.parts)
-        )
+        # An explicit path is an explicit request. Honour it even when the name
+        # looks like a test, rather than returning a silently empty inventory
+        # and making the caller guess that --include-tests was the problem.
+        if root.suffix in suffixes:
+            yield root
+        return
+
+    candidates = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file()
+        and path.suffix in suffixes
+        and not SKIP_DIRECTORIES.intersection(path.parts)
+    )
 
     for path in candidates:
         if not include_tests and (
@@ -745,6 +772,12 @@ def build_inventory(
     root: Path, languages: set[str], include_tests: bool
 ) -> Inventory:
     inventory = Inventory(root=root.as_posix())
+    if root.is_file() and root.suffix not in source_suffixes(languages):
+        inventory.notes.append(
+            f"{root.as_posix()}: skipped, this inventory reads "
+            f"{', '.join(sorted(source_suffixes(languages))) or 'no suffixes'} and "
+            "was pointed at a file it does not read."
+        )
     for path in iter_source_files(root, languages, include_tests):
         source = relative_source(path, root)
         try:
@@ -911,7 +944,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--include-tests",
         action="store_true",
-        help="Include test files and tests/ directories, which are skipped by default.",
+        help=(
+            "Include test files and tests/ directories when scanning a directory. "
+            "They are skipped by default. A file passed directly is always read."
+        ),
     )
     parser.add_argument(
         "--version", action="version", version=f"{INVENTORY_NAME} {INVENTORY_VERSION}"

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -330,7 +330,7 @@ def collect_tool_decorator_aliases(tree: ast.Module) -> ToolOrigins:
     """Classify every name in one module that could introduce a ``@tool``."""
     confirmed: set[str] = set()
     foreign: dict[str, str] = {}
-    modules: set[str] = {AGENT_FRAMEWORK}
+    modules: set[str] = set()
     star_imported = False
 
     for node in ast.walk(tree):
@@ -381,8 +381,14 @@ def tool_decorator_provenance(node: ast.expr, origins: ToolOrigins) -> str | Non
         root = target.value
         while isinstance(root, ast.Attribute):
             root = root.value
-        if isinstance(root, ast.Name) and root.id in origins.modules:
+        if not isinstance(root, ast.Name):
+            return None
+        if root.id in origins.modules:
             return ToolProvenance.CONFIRMED
+        if root.id == AGENT_FRAMEWORK:
+            # Names the framework, but the import is missing. That is broken
+            # Python, so do not claim it as confirmed; surface it instead.
+            return ToolProvenance.UNATTRIBUTED
     return None
 
 
@@ -591,10 +597,10 @@ def build_record(
 
     if provenance == ToolProvenance.UNATTRIBUTED:
         notes.append(
-            "This file decorates with '@tool' but never imports it from "
-            f"{AGENT_FRAMEWORK}, so the decorator could not be traced. It is listed "
-            "as best-effort in case the import is indirect. Confirm it is an Agent "
-            "Framework tool before relying on the approval_mode column."
+            f"This decorator could not be traced to an {AGENT_FRAMEWORK} import in "
+            "this file. It is listed as best-effort in case the import is indirect. "
+            "Confirm it is an Agent Framework tool before relying on the "
+            "approval_mode column."
         )
 
     return ToolRecord(

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -8,6 +8,13 @@ and blast radius.
 This script does not issue verdicts. It supplies evidence for the four questions
 in ``references/surfaces-and-contracts.md``; a human answers them and rules.
 
+It is deliberately conservative about what counts as a tool. ``@tool`` is a
+common decorator name, so a Python tool is only reported as ``parsed`` when the
+decorator can be traced to an ``agent_framework`` import. A ``@tool`` borrowed
+from another library, or defined in the file being read, is skipped with a note
+rather than reported with an ``approval_mode`` it does not have. A bare ``@tool``
+that cannot be traced at all is kept but labelled ``best-effort``.
+
 Standard library only. No third-party packages, no shell invocation, and no
 OS-specific paths, so the same command works on every runtime this skill
 targets.
@@ -167,6 +174,7 @@ HTTP_WRITE_METHODS = frozenset({"post", "put", "patch", "delete"})
 WRITE_FILE_MODES = frozenset({"w", "a", "x", "wb", "ab", "xb", "w+", "a+", "r+", "wt", "at"})
 
 APPROVAL_MODES = frozenset({"always_require", "never_require", "conditional"})
+AGENT_FRAMEWORK = "agent_framework"
 DEFAULT_APPROVAL_MODE = "never_require"
 GATING_MODES = frozenset({"always_require", "conditional"})
 DYNAMIC_APPROVAL_MODE = "<dynamic>"
@@ -276,38 +284,106 @@ class Inventory:
 # --------------------------------------------------------------------------
 
 
-def collect_tool_decorator_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
-    """Return (bare names, module aliases) that can introduce a ``@tool``."""
-    bare: set[str] = {"tool"}
-    modules: set[str] = {"agent_framework"}
+def is_agent_framework_module(name: str | None) -> bool:
+    return bool(name) and (
+        name == AGENT_FRAMEWORK or name.startswith(AGENT_FRAMEWORK + ".")
+    )
+
+
+class ToolProvenance:
+    """Where a ``@tool`` decorator in one file came from.
+
+    The inventory only claims to read Agent Framework tools, so a ``@tool``
+    borrowed from another library must not be reported as one. Detection is
+    therefore split three ways rather than answered yes or no.
+    """
+
+    CONFIRMED = "confirmed"  # traced to an agent_framework import
+    FOREIGN = "foreign"  # traced to something else, so not ours
+    UNATTRIBUTED = "unattributed"  # named 'tool' but nothing to trace it to
+
+
+@dataclass
+class ToolOrigins:
+    """Names in one module that could introduce a ``@tool`` decorator."""
+
+    confirmed: set[str]
+    foreign: dict[str, str]
+    modules: set[str]
+    star_imported: bool
+
+    def classify_bare(self, name: str) -> str | None:
+        if name in self.confirmed:
+            return ToolProvenance.CONFIRMED
+        if name in self.foreign:
+            return ToolProvenance.FOREIGN
+        if name == "tool":
+            return (
+                ToolProvenance.CONFIRMED
+                if self.star_imported
+                else ToolProvenance.UNATTRIBUTED
+            )
+        return None
+
+
+def collect_tool_decorator_aliases(tree: ast.Module) -> ToolOrigins:
+    """Classify every name in one module that could introduce a ``@tool``."""
+    confirmed: set[str] = set()
+    foreign: dict[str, str] = {}
+    modules: set[str] = {AGENT_FRAMEWORK}
+    star_imported = False
+
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
+            from_agent_framework = is_agent_framework_module(node.module)
             for alias in node.names:
-                if alias.name == "tool":
-                    bare.add(alias.asname or alias.name)
+                if alias.name == "*":
+                    if from_agent_framework:
+                        star_imported = True
+                    continue
+                if alias.name != "tool":
+                    continue
+                local = alias.asname or alias.name
+                if from_agent_framework:
+                    confirmed.add(local)
+                    foreign.pop(local, None)
+                elif local not in confirmed:
+                    foreign[local] = node.module or "a relative import"
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name == "agent_framework" or alias.name.startswith(
-                    "agent_framework."
-                ):
+                if is_agent_framework_module(alias.name):
                     modules.add(alias.asname or alias.name.split(".")[0])
-    return bare, modules
+
+    # A decorator defined in this file is this file's own, not the framework's.
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            if node.name == "tool" and node.name not in confirmed:
+                foreign.setdefault("tool", "a definition in this file")
+
+    return ToolOrigins(
+        confirmed=confirmed,
+        foreign=foreign,
+        modules=modules,
+        star_imported=star_imported,
+    )
 
 
 def decorator_target(node: ast.expr) -> ast.expr:
     return node.func if isinstance(node, ast.Call) else node
 
 
-def is_tool_decorator(node: ast.expr, bare: set[str], modules: set[str]) -> bool:
+def tool_decorator_provenance(node: ast.expr, origins: ToolOrigins) -> str | None:
+    """Return a ``ToolProvenance`` value, or ``None`` if this is not a tool."""
     target = decorator_target(node)
     if isinstance(target, ast.Name):
-        return target.id in bare
+        return origins.classify_bare(target.id)
     if isinstance(target, ast.Attribute) and target.attr == "tool":
         root = target.value
         while isinstance(root, ast.Attribute):
             root = root.value
-        return isinstance(root, ast.Name) and root.id in modules
-    return False
+        if isinstance(root, ast.Name) and root.id in origins.modules:
+            return ToolProvenance.CONFIRMED
+    return None
 
 
 def unparse(node: ast.AST) -> str:
@@ -486,6 +562,7 @@ def build_record(
     node: ast.AST,
     decorator: ast.expr,
     source: str,
+    provenance: str = ToolProvenance.CONFIRMED,
 ) -> ToolRecord:
     function_name = node.name
     tool_name = read_tool_name(decorator, function_name)
@@ -512,11 +589,21 @@ def build_record(
             "this tool only reads externally-owned data."
         )
 
+    if provenance == ToolProvenance.UNATTRIBUTED:
+        notes.append(
+            "This file decorates with '@tool' but never imports it from "
+            f"{AGENT_FRAMEWORK}, so the decorator could not be traced. It is listed "
+            "as best-effort in case the import is indirect. Confirm it is an Agent "
+            "Framework tool before relying on the approval_mode column."
+        )
+
     return ToolRecord(
         name=tool_name,
         function=function_name,
         language="python",
-        detection="parsed",
+        detection=(
+            "parsed" if provenance == ToolProvenance.CONFIRMED else "best-effort"
+        ),
         source=source,
         line=node.lineno,
         docstring=summary,
@@ -538,16 +625,32 @@ def scan_python(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
     except SyntaxError as error:
         return [], [f"{source}: skipped, could not be parsed as Python ({error.msg})."]
 
-    bare, modules = collect_tool_decorator_aliases(tree)
+    origins = collect_tool_decorator_aliases(tree)
     records: list[ToolRecord] = []
+    skipped: dict[str, int] = {}
     for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         for decorator in node.decorator_list:
-            if is_tool_decorator(decorator, bare, modules):
-                records.append(build_record(node, decorator, source))
+            provenance = tool_decorator_provenance(decorator, origins)
+            if provenance is None:
+                continue
+            if provenance == ToolProvenance.FOREIGN:
+                target = decorator_target(decorator)
+                origin = origins.foreign.get(getattr(target, "id", ""), "elsewhere")
+                skipped[origin] = skipped.get(origin, 0) + 1
                 break
-    return records, []
+            records.append(build_record(node, decorator, source, provenance))
+            break
+
+    notes: list[str] = []
+    for origin in sorted(skipped):
+        count = skipped[origin]
+        notes.append(
+            f"{source}: skipped {quantify(count, 'decorated function')} because "
+            f"'tool' comes from {origin}, not {AGENT_FRAMEWORK}."
+        )
+    return records, notes
 
 
 # --------------------------------------------------------------------------
@@ -639,7 +742,9 @@ def build_inventory(
     for path in iter_source_files(root, languages, include_tests):
         source = relative_source(path, root)
         try:
-            text = path.read_text(encoding="utf-8")
+            # utf-8-sig, not utf-8: CPython accepts a source file with a BOM, so
+            # a Windows-authored tool file must not be reported as unparseable.
+            text = path.read_text(encoding="utf-8-sig")
         except (UnicodeDecodeError, OSError) as error:
             inventory.notes.append(f"{source}: skipped, could not be read ({error}).")
             continue

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -665,6 +665,18 @@ HONESTY_FOOTER = (
 )
 
 
+def quantify(count: int, singular: str, plural: str | None = None) -> str:
+    """Render a count with a noun that agrees with it: '1 tool', '3 tools'."""
+    if plural is None:
+        plural = singular + "s"
+    return f"{count} {singular if count == 1 else plural}"
+
+
+def agree(count: int, singular: str, plural: str) -> str:
+    """Pick the verb form that agrees with a count: 'looks' against 'look'."""
+    return singular if count == 1 else plural
+
+
 def render_table(inventory: Inventory) -> str:
     headers = ["Tool", "Lang", "Approval", "Write", "External", "Blast", "Source"]
     rows = [
@@ -696,26 +708,34 @@ def render_table(inventory: Inventory) -> str:
     counts = inventory.counts()
     out.append("")
     out.append(
-        f"{counts['tools']} tools: {counts['gated']} gated, {counts['ungated']} ungated."
+        f"{quantify(counts['tools'], 'tool')}: "
+        f"{counts['gated']} gated, {counts['ungated']} ungated."
     )
     out.append(
-        f"{counts['write_signalled']} show a write signal, "
-        f"{counts['external_signalled']} an external-visibility signal, "
-        f"{counts['many_signalled']} a blast-radius signal."
+        "Signals: "
+        f"{quantify(counts['write_signalled'], 'write signal')}, "
+        f"{quantify(counts['external_signalled'], 'external-visibility signal')}, "
+        f"{quantify(counts['many_signalled'], 'blast-radius signal')}."
     )
     out.append(
-        f"Needs a ruling: {counts['ungated_write']} ungated with a write signal, "
-        f"of which {counts['ungated_write_external']} also look externally visible."
+        "Needs a ruling: "
+        f"{quantify(counts['ungated_write'], 'ungated tool')} with a write signal, "
+        f"of which {counts['ungated_write_external']} also "
+        f"{agree(counts['ungated_write_external'], 'looks', 'look')} externally visible."
     )
     if counts["best_effort"]:
         out.append(
-            f"{counts['best_effort']} entries are best-effort matches and may be incomplete."
+            f"{quantify(counts['best_effort'], 'entry', 'entries')} "
+            f"{agree(counts['best_effort'], 'is a best-effort match', 'are best-effort matches')} "
+            "and may be incomplete."
         )
 
     attention = [record for record in inventory.tools if record.needs_attention]
     if attention:
         out.append("")
-        out.append("Ungated tools with a write signal:")
+        out.append(
+            f"Ungated {agree(len(attention), 'tool', 'tools')} with a write signal:"
+        )
         for record in attention:
             evidence = "; ".join(
                 signal.evidence for signal in record.signals if signal.category == "write"

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -1,0 +1,825 @@
+#!/usr/bin/env python3
+"""Bounded static inventory of approval-relevant agent tools.
+
+Reads a codebase and reports, per tool, what the code can actually prove: the
+declared approval mode, and advisory signals about writes, external visibility,
+and blast radius.
+
+This script does not issue verdicts. It supplies evidence for the four questions
+in ``references/surfaces-and-contracts.md``; a human answers them and rules.
+
+Standard library only. No third-party packages, no shell invocation, and no
+OS-specific paths, so the same command works on every runtime this skill
+targets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+INVENTORY_NAME = "tool-approval-inventory"
+INVENTORY_VERSION = "1.0.0"
+
+MIN_PYTHON = (3, 9)
+
+# --------------------------------------------------------------------------
+# Vocabularies
+#
+# Deliberately curated rather than exhaustive. A term earns its place only if
+# matching it as a whole token is far more often right than wrong. Terms that
+# collide with common standard-library calls (``close``, ``add``, ``set``) are
+# restricted to the tool's own name and docstring, where the author's intent is
+# unambiguous, instead of being matched against every call in the body.
+# --------------------------------------------------------------------------
+
+BODY_WRITE_VERBS = frozenset(
+    {
+        "archive",
+        "charge",
+        "commit",
+        "create",
+        "delete",
+        "deploy",
+        "deprovision",
+        "drop",
+        "escalate",
+        "grant",
+        "insert",
+        "invite",
+        "notify",
+        "patch",
+        "pay",
+        "post",
+        "provision",
+        "publish",
+        "purge",
+        "put",
+        "refund",
+        "remove",
+        "revoke",
+        "rotate",
+        "save",
+        "send",
+        "terminate",
+        "transfer",
+        "update",
+        "upload",
+        "write",
+    }
+)
+
+NAME_ONLY_WRITE_VERBS = frozenset(
+    {
+        "approve",
+        "assign",
+        "cancel",
+        "close",
+        "disable",
+        "enable",
+        "enroll",
+        "merge",
+        "reject",
+        "rename",
+        "reset",
+        "schedule",
+        "submit",
+        "subscribe",
+        "unsubscribe",
+    }
+)
+
+NAME_WRITE_VERBS = BODY_WRITE_VERBS | NAME_ONLY_WRITE_VERBS
+
+EXTERNAL_TERMS = frozenset(
+    {
+        "customer",
+        "email",
+        "external",
+        "facebook",
+        "invoice",
+        "linkedin",
+        "mail",
+        "partner",
+        "pay",
+        "payment",
+        "payout",
+        "paypal",
+        "portal",
+        "public",
+        "publish",
+        "recipient",
+        "refund",
+        "ses",
+        "sendgrid",
+        "smtp",
+        "sms",
+        "stripe",
+        "subscriber",
+        "supplier",
+        "tweet",
+        "twilio",
+        "vendor",
+        "webhook",
+        "whatsapp",
+        "wire",
+    }
+)
+
+BLAST_NAME_TERMS = frozenset(
+    {"all", "batch", "broadcast", "bulk", "each", "every", "many", "mass", "multi"}
+)
+
+BLAST_PARAM_NAMES = frozenset(
+    {
+        "accounts",
+        "addresses",
+        "customers",
+        "emails",
+        "files",
+        "items",
+        "messages",
+        "orders",
+        "recipients",
+        "records",
+        "rows",
+        "targets",
+        "tickets",
+        "users",
+    }
+)
+
+COLLECTION_ANNOTATION = re.compile(
+    r"\b(?:list|List|Sequence|Iterable|Collection|set|Set|tuple|Tuple|frozenset)\s*\["
+)
+
+SQL_WRITE = re.compile(
+    r"\b(?:INSERT\s+INTO|UPDATE\s+\w+\s+SET|DELETE\s+FROM|DROP\s+TABLE|TRUNCATE\s+TABLE|ALTER\s+TABLE)\b",
+    re.IGNORECASE,
+)
+
+HTTP_WRITE_METHODS = frozenset({"post", "put", "patch", "delete"})
+WRITE_FILE_MODES = frozenset({"w", "a", "x", "wb", "ab", "xb", "w+", "a+", "r+", "wt", "at"})
+
+APPROVAL_MODES = frozenset({"always_require", "never_require", "conditional"})
+DEFAULT_APPROVAL_MODE = "never_require"
+GATING_MODES = frozenset({"always_require", "conditional"})
+DYNAMIC_APPROVAL_MODE = "<dynamic>"
+
+SKIP_DIRECTORIES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".idea",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".svn",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "env",
+        "node_modules",
+        "site-packages",
+        "venv",
+    }
+)
+
+TEST_FILE = re.compile(r"(?:^test_.*\.py$)|(?:_test\.py$)|(?:_test\.go$)")
+
+# Go is not parseable with the standard library, so detection is a bounded
+# regular expression over calls into the ``tool`` package and is always reported
+# as best-effort.
+GO_APPROVAL_WRAP = re.compile(
+    r"tool\.ApprovalRequiredFunc\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]"
+)
+GO_TOOL_BINDING = re.compile(
+    r"^\s*(?:var\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:?=\s*tool\.([A-Za-z_][A-Za-z0-9_]*)\(",
+    re.MULTILINE,
+)
+
+
+def tokenize(value: str) -> list[str]:
+    """Split snake_case, camelCase, and punctuation into lowercase tokens."""
+    value = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", " ", value)
+    value = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", value)
+    return re.findall(r"[a-z0-9]+", value.lower())
+
+
+@dataclass
+class Signal:
+    category: str
+    where: str
+    evidence: str
+
+
+@dataclass
+class ToolRecord:
+    name: str
+    function: str
+    language: str
+    detection: str
+    source: str
+    line: int
+    docstring: str
+    parameters: list[str]
+    approval_mode: str
+    approval_mode_explicit: bool
+    gated: bool
+    proposed_write: str
+    proposed_visibility: str
+    proposed_blast: str
+    signals: list[Signal] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.proposed_write == "write" and not self.gated
+
+    @property
+    def needs_urgent_attention(self) -> bool:
+        return self.needs_attention and self.proposed_visibility == "external"
+
+
+@dataclass
+class Inventory:
+    root: str
+    tools: list[ToolRecord] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "tools": len(self.tools),
+            "gated": sum(1 for t in self.tools if t.gated),
+            "ungated": sum(1 for t in self.tools if not t.gated),
+            "approval_mode_explicit": sum(1 for t in self.tools if t.approval_mode_explicit),
+            "write_signalled": sum(1 for t in self.tools if t.proposed_write == "write"),
+            "external_signalled": sum(
+                1 for t in self.tools if t.proposed_visibility == "external"
+            ),
+            "many_signalled": sum(1 for t in self.tools if t.proposed_blast == "many"),
+            "ungated_write": sum(1 for t in self.tools if t.needs_attention),
+            "ungated_write_external": sum(1 for t in self.tools if t.needs_urgent_attention),
+            "best_effort": sum(1 for t in self.tools if t.detection == "best-effort"),
+        }
+
+
+# --------------------------------------------------------------------------
+# Python analysis
+# --------------------------------------------------------------------------
+
+
+def collect_tool_decorator_aliases(tree: ast.Module) -> tuple[set[str], set[str]]:
+    """Return (bare names, module aliases) that can introduce a ``@tool``."""
+    bare: set[str] = {"tool"}
+    modules: set[str] = {"agent_framework"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "tool":
+                    bare.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "agent_framework" or alias.name.startswith(
+                    "agent_framework."
+                ):
+                    modules.add(alias.asname or alias.name.split(".")[0])
+    return bare, modules
+
+
+def decorator_target(node: ast.expr) -> ast.expr:
+    return node.func if isinstance(node, ast.Call) else node
+
+
+def is_tool_decorator(node: ast.expr, bare: set[str], modules: set[str]) -> bool:
+    target = decorator_target(node)
+    if isinstance(target, ast.Name):
+        return target.id in bare
+    if isinstance(target, ast.Attribute) and target.attr == "tool":
+        root = target.value
+        while isinstance(root, ast.Attribute):
+            root = root.value
+        return isinstance(root, ast.Name) and root.id in modules
+    return False
+
+
+def unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:  # pragma: no cover - defensive on exotic nodes
+        return "?"
+
+
+def parameter_signatures(node: ast.AST) -> list[str]:
+    args = node.args
+    collected: list[ast.arg] = []
+    collected.extend(getattr(args, "posonlyargs", []) or [])
+    collected.extend(args.args)
+    if args.vararg is not None:
+        collected.append(args.vararg)
+    collected.extend(args.kwonlyargs)
+    if args.kwarg is not None:
+        collected.append(args.kwarg)
+    signatures = []
+    for argument in collected:
+        if argument.annotation is None:
+            signatures.append(argument.arg)
+        else:
+            signatures.append(f"{argument.arg}: {unparse(argument.annotation)}")
+    return signatures
+
+
+def read_approval_mode(decorator: ast.expr) -> tuple[str, bool, list[str]]:
+    """Return (effective mode, explicitly declared, notes)."""
+    notes: list[str] = []
+    if not isinstance(decorator, ast.Call):
+        return DEFAULT_APPROVAL_MODE, False, notes
+    for keyword in decorator.keywords:
+        if keyword.arg != "approval_mode":
+            continue
+        value = keyword.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            mode = value.value
+            if mode not in APPROVAL_MODES:
+                notes.append(
+                    f"approval_mode {mode!r} is not one of the documented modes "
+                    f"({', '.join(sorted(APPROVAL_MODES))})."
+                )
+            if mode == "conditional":
+                notes.append(
+                    "approval_mode is 'conditional', so the gating logic is supplied by "
+                    "the maker and is not visible to this inventory. Review it directly."
+                )
+            return mode, True, notes
+        notes.append(
+            "approval_mode is set from an expression rather than a literal, so the "
+            "effective mode cannot be read statically. Confirm it by reading the code."
+        )
+        return DYNAMIC_APPROVAL_MODE, True, notes
+    return DEFAULT_APPROVAL_MODE, False, notes
+
+
+def read_tool_name(decorator: ast.expr, fallback: str) -> str:
+    if isinstance(decorator, ast.Call):
+        for keyword in decorator.keywords:
+            if (
+                keyword.arg == "name"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ):
+                return keyword.value.value
+    return fallback
+
+
+def call_name(node: ast.Call) -> str:
+    target = node.func
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return ""
+
+
+def opens_for_writing(node: ast.Call) -> bool:
+    if call_name(node) != "open":
+        return False
+    mode_node: ast.expr | None = None
+    if len(node.args) >= 2:
+        mode_node = node.args[1]
+    for keyword in node.keywords:
+        if keyword.arg == "mode":
+            mode_node = keyword.value
+    if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
+        return mode_node.value.strip() in WRITE_FILE_MODES
+    return False
+
+
+def body_write_signals(node: ast.AST) -> list[Signal]:
+    signals: list[Signal] = []
+    seen: set[tuple[str, str]] = set()
+
+    def record(category: str, where: str, evidence: str) -> None:
+        key = (category, evidence)
+        if key in seen:
+            return
+        seen.add(key)
+        signals.append(Signal(category=category, where=where, evidence=evidence))
+
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call):
+            name = call_name(child)
+            if not name:
+                continue
+            if opens_for_writing(child):
+                record("write", "body", "open(..., mode=write) call")
+                continue
+            tokens = set(tokenize(name))
+            hits = tokens & BODY_WRITE_VERBS
+            if hits:
+                record("write", "body", f"calls {name}()")
+            if isinstance(child.func, ast.Attribute) and name in HTTP_WRITE_METHODS:
+                record("write", "body", f"HTTP-style {name.upper()} call")
+            external = tokens & EXTERNAL_TERMS
+            if external:
+                record("external", "body", f"calls {name}()")
+        elif isinstance(child, ast.Constant) and isinstance(child.value, str):
+            if SQL_WRITE.search(child.value):
+                record("write", "body", "contains a data-modifying SQL statement")
+    return signals
+
+
+def loop_contains_write(node: ast.AST) -> bool:
+    for child in ast.walk(node):
+        if isinstance(child, (ast.For, ast.AsyncFor, ast.While)):
+            if body_write_signals(child):
+                return True
+    return False
+
+
+def text_signals(name: str, docstring: str) -> list[Signal]:
+    signals: list[Signal] = []
+    name_tokens = set(tokenize(name))
+    doc_tokens = set(tokenize(docstring))
+
+    for hit in sorted(name_tokens & NAME_WRITE_VERBS):
+        signals.append(Signal("write", "name", f"tool name contains {hit!r}"))
+    for hit in sorted(doc_tokens & NAME_WRITE_VERBS):
+        signals.append(Signal("write", "docstring", f"docstring contains {hit!r}"))
+    for hit in sorted(name_tokens & EXTERNAL_TERMS):
+        signals.append(Signal("external", "name", f"tool name contains {hit!r}"))
+    for hit in sorted(doc_tokens & EXTERNAL_TERMS):
+        signals.append(Signal("external", "docstring", f"docstring contains {hit!r}"))
+    for hit in sorted(name_tokens & BLAST_NAME_TERMS):
+        signals.append(Signal("blast", "name", f"tool name contains {hit!r}"))
+    return signals
+
+
+def parameter_signals(signatures: list[str]) -> list[Signal]:
+    signals: list[Signal] = []
+    for signature in signatures:
+        parameter = signature.split(":", 1)[0].strip().lstrip("*")
+        if parameter.lower() in BLAST_PARAM_NAMES or parameter.lower().endswith(
+            ("_ids", "_list")
+        ):
+            signals.append(
+                Signal("blast", "parameters", f"parameter {parameter!r} names a collection")
+            )
+        if ":" in signature and COLLECTION_ANNOTATION.search(signature.split(":", 1)[1]):
+            signals.append(
+                Signal(
+                    "blast",
+                    "parameters",
+                    f"parameter {parameter!r} is annotated as a collection",
+                )
+            )
+    return signals
+
+
+def build_record(
+    node: ast.AST,
+    decorator: ast.expr,
+    source: str,
+) -> ToolRecord:
+    function_name = node.name
+    tool_name = read_tool_name(decorator, function_name)
+    approval_mode, explicit, notes = read_approval_mode(decorator)
+    docstring = (ast.get_docstring(node) or "").strip()
+    summary = docstring.splitlines()[0].strip() if docstring else ""
+    signatures = parameter_signatures(node)
+
+    signals: list[Signal] = []
+    signals.extend(text_signals(tool_name, summary))
+    signals.extend(body_write_signals(node))
+    signals.extend(parameter_signals(signatures))
+    if loop_contains_write(node):
+        signals.append(Signal("blast", "body", "writes inside a loop"))
+
+    categories = {signal.category for signal in signals}
+    proposed_write = "write" if "write" in categories else "read"
+    proposed_visibility = "external" if "external" in categories else "internal-or-unknown"
+    proposed_blast = "many" if "blast" in categories else "one"
+
+    if proposed_write == "read" and proposed_visibility == "external":
+        notes.append(
+            "External wording was detected but no write signal was found. Confirm whether "
+            "this tool only reads externally-owned data."
+        )
+
+    return ToolRecord(
+        name=tool_name,
+        function=function_name,
+        language="python",
+        detection="parsed",
+        source=source,
+        line=node.lineno,
+        docstring=summary,
+        parameters=signatures,
+        approval_mode=approval_mode,
+        approval_mode_explicit=explicit,
+        gated=approval_mode in GATING_MODES,
+        proposed_write=proposed_write,
+        proposed_visibility=proposed_visibility,
+        proposed_blast=proposed_blast,
+        signals=signals,
+        notes=notes,
+    )
+
+
+def scan_python(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as error:
+        return [], [f"{source}: skipped, could not be parsed as Python ({error.msg})."]
+
+    bare, modules = collect_tool_decorator_aliases(tree)
+    records: list[ToolRecord] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if is_tool_decorator(decorator, bare, modules):
+                records.append(build_record(node, decorator, source))
+                break
+    return records, []
+
+
+# --------------------------------------------------------------------------
+# Go analysis (bounded, best-effort)
+# --------------------------------------------------------------------------
+
+
+def scan_go(text: str, source: str) -> tuple[list[ToolRecord], list[str]]:
+    wrapped = {match.group(1) for match in GO_APPROVAL_WRAP.finditer(text)}
+    bindings: dict[str, int] = {}
+    for match in GO_TOOL_BINDING.finditer(text):
+        identifier, constructor = match.group(1), match.group(2)
+        if constructor == "ApprovalRequiredFunc":
+            continue
+        bindings.setdefault(identifier, text.count("\n", 0, match.start()) + 1)
+
+    records: list[ToolRecord] = []
+    for identifier in sorted(set(bindings) | wrapped):
+        gated = identifier in wrapped
+        records.append(
+            ToolRecord(
+                name=identifier,
+                function=identifier,
+                language="go",
+                detection="best-effort",
+                source=source,
+                line=bindings.get(identifier, 0),
+                docstring="",
+                parameters=[],
+                approval_mode="always_require" if gated else DEFAULT_APPROVAL_MODE,
+                approval_mode_explicit=gated,
+                gated=gated,
+                proposed_write="read",
+                proposed_visibility="internal-or-unknown",
+                proposed_blast="one",
+                signals=[],
+                notes=[
+                    "Go detection is best-effort: a bounded regular-expression match, not "
+                    "a parse. Signals are not extracted, so answer all four questions "
+                    "manually."
+                ],
+            )
+        )
+    return records, []
+
+
+# --------------------------------------------------------------------------
+# Walking
+# --------------------------------------------------------------------------
+
+
+def iter_source_files(root: Path, languages: set[str], include_tests: bool):
+    suffixes = set()
+    if "python" in languages:
+        suffixes.add(".py")
+    if "go" in languages:
+        suffixes.add(".go")
+
+    if root.is_file():
+        candidates = [root] if root.suffix in suffixes else []
+    else:
+        candidates = sorted(
+            path
+            for path in root.rglob("*")
+            if path.is_file()
+            and path.suffix in suffixes
+            and not SKIP_DIRECTORIES.intersection(path.parts)
+        )
+
+    for path in candidates:
+        if not include_tests and (
+            TEST_FILE.search(path.name) or "tests" in path.parts
+        ):
+            continue
+        yield path
+
+
+def relative_source(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root if root.is_dir() else root.parent).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def build_inventory(
+    root: Path, languages: set[str], include_tests: bool
+) -> Inventory:
+    inventory = Inventory(root=root.as_posix())
+    for path in iter_source_files(root, languages, include_tests):
+        source = relative_source(path, root)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as error:
+            inventory.notes.append(f"{source}: skipped, could not be read ({error}).")
+            continue
+        if path.suffix == ".py":
+            records, notes = scan_python(text, source)
+        else:
+            records, notes = scan_go(text, source)
+        inventory.tools.extend(records)
+        inventory.notes.extend(notes)
+
+    inventory.tools.sort(key=lambda record: (record.source, record.line, record.name))
+    return inventory
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+
+HONESTY_FOOTER = (
+    "Signals are advisory evidence, not verdicts. This inventory cannot tell you who can\n"
+    "reverse a write or whether a result leaves the organisation. Answer the four questions\n"
+    "in references/surfaces-and-contracts.md, then record the verdict and its reason."
+)
+
+
+def render_table(inventory: Inventory) -> str:
+    headers = ["Tool", "Lang", "Approval", "Write", "External", "Blast", "Source"]
+    rows = [
+        [
+            record.name,
+            record.language,
+            record.approval_mode + ("" if record.approval_mode_explicit else " (default)"),
+            record.proposed_write,
+            "external" if record.proposed_visibility == "external" else "unknown",
+            record.proposed_blast,
+            f"{record.source}:{record.line}",
+        ]
+        for record in inventory.tools
+    ]
+
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(cell))
+
+    def line(cells: list[str]) -> str:
+        return "  ".join(cell.ljust(widths[index]) for index, cell in enumerate(cells)).rstrip()
+
+    out = [line(headers), line(["-" * width for width in widths])]
+    out.extend(line(row) for row in rows)
+    if not rows:
+        out.append("(no tools found)")
+
+    counts = inventory.counts()
+    out.append("")
+    out.append(
+        f"{counts['tools']} tools: {counts['gated']} gated, {counts['ungated']} ungated."
+    )
+    out.append(
+        f"{counts['write_signalled']} show a write signal, "
+        f"{counts['external_signalled']} an external-visibility signal, "
+        f"{counts['many_signalled']} a blast-radius signal."
+    )
+    out.append(
+        f"Needs a ruling: {counts['ungated_write']} ungated with a write signal, "
+        f"of which {counts['ungated_write_external']} also look externally visible."
+    )
+    if counts["best_effort"]:
+        out.append(
+            f"{counts['best_effort']} entries are best-effort matches and may be incomplete."
+        )
+
+    attention = [record for record in inventory.tools if record.needs_attention]
+    if attention:
+        out.append("")
+        out.append("Ungated tools with a write signal:")
+        for record in attention:
+            evidence = "; ".join(
+                signal.evidence for signal in record.signals if signal.category == "write"
+            )
+            out.append(f"  {record.name}: {evidence or 'no evidence recorded'}")
+
+    notes = inventory.notes + [
+        f"{record.name}: {note}" for record in inventory.tools for note in record.notes
+    ]
+    if notes:
+        out.append("")
+        out.append("Notes:")
+        out.extend(f"  {note}" for note in notes)
+
+    out.append("")
+    out.append(HONESTY_FOOTER)
+    return "\n".join(out)
+
+
+def render_json(inventory: Inventory) -> str:
+    payload = {
+        "inventory": INVENTORY_NAME,
+        "version": INVENTORY_VERSION,
+        "root": inventory.root,
+        "counts": inventory.counts(),
+        "tools": [asdict(record) for record in inventory.tools],
+        "notes": inventory.notes,
+        "disclaimer": " ".join(HONESTY_FOOTER.split()),
+    }
+    return json.dumps(payload, indent=2, sort_keys=False)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="inventory_tools.py",
+        description=(
+            "Inventory agent tools and their declared approval mode, with advisory "
+            "signals for the four gating questions."
+        ),
+    )
+    parser.add_argument("path", help="File or directory to scan.")
+    parser.add_argument(
+        "--format", choices=("table", "json"), default="table", help="Output format."
+    )
+    parser.add_argument(
+        "--lang",
+        choices=("auto", "python", "go"),
+        default="auto",
+        help="Restrict the scan to one language. 'auto' scans Python and Go.",
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("none", "ungated-write", "ungated-write-external"),
+        default="none",
+        help="Exit with status 1 when the named condition is present.",
+    )
+    parser.add_argument(
+        "--include-tests",
+        action="store_true",
+        help="Include test files and tests/ directories, which are skipped by default.",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"{INVENTORY_NAME} {INVENTORY_VERSION}"
+    )
+    return parser
+
+
+def gate_triggered(inventory: Inventory, condition: str) -> bool:
+    if condition == "ungated-write":
+        return any(record.needs_attention for record in inventory.tools)
+    if condition == "ungated-write-external":
+        return any(record.needs_urgent_attention for record in inventory.tools)
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    if sys.version_info < MIN_PYTHON:
+        print(
+            f"Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or later is required.",
+            file=sys.stderr,
+        )
+        return 2
+
+    args = build_parser().parse_args(argv)
+    root = Path(args.path)
+    if not root.exists():
+        print(f"Path not found: {root.as_posix()}", file=sys.stderr)
+        return 2
+
+    languages = {"python", "go"} if args.lang == "auto" else {args.lang}
+    inventory = build_inventory(root, languages, args.include_tests)
+
+    if args.format == "json":
+        print(render_json(inventory))
+    else:
+        print(render_table(inventory))
+
+    return 1 if gate_triggered(inventory, args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -171,7 +171,11 @@ SQL_WRITE = re.compile(
 )
 
 HTTP_WRITE_METHODS = frozenset({"post", "put", "patch", "delete"})
-WRITE_FILE_MODES = frozenset({"w", "a", "x", "wb", "ab", "xb", "w+", "a+", "r+", "wt", "at"})
+# Python file modes are order-independent flag strings: exactly one of r, w, a
+# or x, optionally 'b' or 't' for the encoding, optionally '+' for update. Any
+# mode containing w, a, x or + can write, so test for those flags rather than
+# enumerating permutations, which misses 'wb+', 'w+b', 'rb+', 'x+b' and friends.
+WRITE_FILE_MODE_FLAGS = frozenset({"w", "a", "x", "+"})
 
 APPROVAL_MODES = frozenset({"always_require", "never_require", "conditional"})
 AGENT_FRAMEWORK = "agent_framework"
@@ -469,18 +473,27 @@ def call_name(node: ast.Call) -> str:
     return ""
 
 
-def opens_for_writing(node: ast.Call) -> bool:
+def open_write_evidence(node: ast.Call) -> str | None:
+    """Return evidence when an ``open()`` call can write, else ``None``."""
     if call_name(node) != "open":
-        return False
+        return None
     mode_node: ast.expr | None = None
     if len(node.args) >= 2:
         mode_node = node.args[1]
     for keyword in node.keywords:
         if keyword.arg == "mode":
             mode_node = keyword.value
+    if mode_node is None:
+        return None  # open(path) defaults to 'r'.
     if isinstance(mode_node, ast.Constant) and isinstance(mode_node.value, str):
-        return mode_node.value.strip() in WRITE_FILE_MODES
-    return False
+        mode = mode_node.value.strip()
+        if WRITE_FILE_MODE_FLAGS.intersection(mode):
+            return f"open(..., {mode!r}) call"
+        return None
+    # A mode computed at runtime could be anything. Calling it read-only would
+    # hide a possible write, which is the wrong direction for an inventory whose
+    # output feeds a gating decision, so surface it and let a human resolve it.
+    return "open() call whose mode is computed at runtime"
 
 
 def body_write_signals(node: ast.AST) -> list[Signal]:
@@ -499,8 +512,9 @@ def body_write_signals(node: ast.AST) -> list[Signal]:
             name = call_name(child)
             if not name:
                 continue
-            if opens_for_writing(child):
-                record("write", "body", "open(..., mode=write) call")
+            open_evidence = open_write_evidence(child)
+            if open_evidence:
+                record("write", "body", open_evidence)
                 continue
             tokens = set(tokenize(name))
             hits = tokens & BODY_WRITE_VERBS

--- a/submissions/tool-approval-designer/scripts/inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/inventory_tools.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import os
 import re
 import sys
 from dataclasses import asdict, dataclass, field
@@ -759,15 +760,23 @@ def iter_source_files(root: Path, languages: set[str], include_tests: bool):
             yield root
         return
 
-    candidates = sorted(
-        path
-        for path in root.rglob("*")
-        if path.is_file()
-        and path.suffix in suffixes
-        and not SKIP_DIRECTORIES.intersection(path.parts)
-    )
+    candidates: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Prune in place. Filtering after root.rglob("*") still pays to walk and
+        # allocate every path inside node_modules and .git, which is the cost
+        # SKIP_DIRECTORIES exists to avoid. Pruning here means os.walk never
+        # descends into them at all.
+        dirnames[:] = [name for name in dirnames if name not in SKIP_DIRECTORIES]
+        if not include_tests:
+            dirnames[:] = [name for name in dirnames if name != "tests"]
+        current = Path(dirpath)
+        candidates.extend(
+            current / name for name in filenames if Path(name).suffix in suffixes
+        )
 
-    for path in candidates:
+    # Sorted as a whole, not per directory, so the order does not depend on the
+    # traversal and the output stays deterministic across platforms.
+    for path in sorted(candidates):
         if not include_tests and (
             TEST_FILE.search(path.name) or "tests" in path.parts
         ):

--- a/submissions/tool-approval-designer/scripts/tests/test_approval_renderer.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_approval_renderer.py
@@ -1,0 +1,129 @@
+"""Regression tests for assets/templates/approval_renderer.py.
+
+The renderer ships as copy-paste material, so a defect in it lands directly in
+someone's agent. Redaction is the part that matters most: it is the boundary
+that keeps a secret out of the approval text a human is about to read and, in
+many deployments, out of the transcript that text is logged into.
+
+Run from the skill root (the directory containing SKILL.md):
+
+    python scripts/tests/test_approval_renderer.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+TEMPLATE_PATH = (
+    Path(__file__).parents[2] / "assets" / "templates" / "approval_renderer.py"
+)
+SPEC = importlib.util.spec_from_file_location("approval_renderer", TEMPLATE_PATH)
+assert SPEC and SPEC.loader
+approval_renderer = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = approval_renderer
+SPEC.loader.exec_module(approval_renderer)
+
+ApprovalSpec = approval_renderer.ApprovalSpec
+mask = approval_renderer.mask
+render_approval_request = approval_renderer.render_approval_request
+
+
+class RedactionTests(unittest.TestCase):
+    def test_always_redact_list_is_masked(self):
+        self.assertEqual(mask("api_key", "sk-live-123", frozenset()), "[redacted]")
+
+    def test_always_redact_is_case_insensitive_on_the_argument(self):
+        self.assertEqual(mask("API_KEY", "sk-live-123", frozenset()), "[redacted]")
+
+    def test_spec_redaction_matches_regardless_of_declared_case(self):
+        """A spec declaring 'ApiKey' must still mask an argument named 'apiKey'."""
+        self.assertEqual(
+            mask("apiKey", "sk-live-123", frozenset({"ApiKey"})), "[redacted]"
+        )
+
+    def test_spec_redaction_matches_regardless_of_argument_case(self):
+        self.assertEqual(
+            mask("SessionToken", "abc", frozenset({"sessiontoken"})), "[redacted]"
+        )
+
+    def test_ordinary_value_is_not_masked(self):
+        self.assertEqual(mask("subject", "Your order", frozenset()), "Your order")
+
+    def test_redaction_survives_the_render_path(self):
+        spec = ApprovalSpec(
+            action="Call a partner API",
+            target="{endpoint}",
+            consequence="The partner receives the call.",
+            reversibility="Nobody.",
+            detail_arguments=("ApiKey",),
+            redact=frozenset({"apikey"}),
+        )
+        rendered = render_approval_request(
+            "call_partner",
+            {"endpoint": "/v1/pay", "ApiKey": "sk-live-do-not-log"},
+            {"call_partner": spec},
+        )
+        self.assertIn("[redacted]", rendered)
+        self.assertNotIn("sk-live-do-not-log", rendered)
+
+
+class TruncationTests(unittest.TestCase):
+    def test_long_value_is_shortened_but_its_size_is_stated(self):
+        value = "x" * 500
+        rendered = mask("body", value, frozenset())
+        self.assertIn("500 characters total", rendered)
+        self.assertLess(len(rendered), len(value))
+
+    def test_short_value_is_untouched(self):
+        self.assertEqual(mask("body", "hello", frozenset()), "hello")
+
+
+class RenderTests(unittest.TestCase):
+    def test_a_bare_tool_name_is_never_the_whole_request(self):
+        """The anti-pattern this template exists to replace."""
+        rendered = render_approval_request(
+            "send_customer_email",
+            {
+                "to": "hans@contoso.example",
+                "subject": "Shipped",
+                "body": "Your order left the warehouse.",
+            },
+        )
+        self.assertNotEqual(rendered.strip(), "send_customer_email")
+        self.assertIn("hans@contoso.example", rendered)
+        self.assertIn("Reversible by:", rendered)
+
+    def test_missing_spec_still_shows_the_values_and_says_it_is_a_gap(self):
+        rendered = render_approval_request("unknown_tool", {"amount": 500})
+        self.assertIn("500", rendered)
+        self.assertIn("No approval wording is defined", rendered)
+
+    def test_missing_spec_path_still_redacts(self):
+        rendered = render_approval_request("unknown_tool", {"api_key": "sk-live-123"})
+        self.assertIn("[redacted]", rendered)
+        self.assertNotIn("sk-live-123", rendered)
+
+    def test_scale_argument_reports_the_count(self):
+        rendered = render_approval_request(
+            "close_tickets",
+            {"ticket_ids": [1, 2, 3, 4], "resolution": "Duplicate"},
+        )
+        self.assertIn("4 items affected by this single approval", rendered)
+
+    def test_scale_argument_that_is_not_a_collection_says_so(self):
+        rendered = render_approval_request(
+            "close_tickets",
+            {"ticket_ids": 7, "resolution": "Duplicate"},
+        )
+        self.assertIn("unknown", rendered)
+
+    def test_unresolvable_target_does_not_raise(self):
+        rendered = render_approval_request("issue_refund", {"amount": 500})
+        self.assertIn("target could not be resolved", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -823,6 +823,56 @@ class FileHandlingTests(unittest.TestCase):
         _, inventory = self.build({"test_thing.py": body}, include_tests=True)
         self.assertEqual(len(inventory.tools), 1)
 
+    TOOL_BODY = (
+        "from agent_framework import tool\n"
+        "@tool\n"
+        "def ping() -> str:\n"
+        "    '''Heartbeat.'''\n"
+        "    return 'ok'\n"
+    )
+
+    def scan_under_ancestor(self, ancestor: str):
+        """Build tool.py inside <tmp>/<ancestor>/repo and scan repo itself."""
+        directory = Path(tempfile.mkdtemp())
+        repo = directory / ancestor / "repo"
+        repo.mkdir(parents=True)
+        (repo / "tool.py").write_text(self.TOOL_BODY, encoding="utf-8")
+        return inventory_tools.build_inventory(repo, {"python"}, False)
+
+    def test_a_skipped_name_above_root_does_not_empty_the_inventory(self):
+        """Only names at or below root are ours to judge.
+
+        Testing whole paths against SKIP_DIRECTORIES inspects the ancestors too,
+        so a repo checked out under a directory called build, dist, env or venv
+        would report zero tools. That failure is silent and looks like "this
+        codebase has no tools", which is the worst possible way to be wrong.
+        """
+        for ancestor in ("build", "dist", "env", "venv", "node_modules", ".git"):
+            with self.subTest(ancestor=ancestor):
+                inventory = self.scan_under_ancestor(ancestor)
+                self.assertEqual(
+                    [record.name for record in inventory.tools],
+                    ["ping"],
+                    f"a parent directory named {ancestor} emptied the inventory",
+                )
+
+    def test_a_tests_directory_above_root_does_not_empty_the_inventory(self):
+        inventory = self.scan_under_ancestor("tests")
+        self.assertEqual([record.name for record in inventory.tools], ["ping"])
+
+    def test_a_root_named_tests_is_scanned_as_an_explicit_request(self):
+        """Naming a directory is as explicit as naming a file."""
+        directory = Path(tempfile.mkdtemp())
+        root = directory / "tests"
+        root.mkdir()
+        (root / "tool.py").write_text(self.TOOL_BODY, encoding="utf-8")
+        inventory = inventory_tools.build_inventory(root, {"python"}, False)
+        self.assertEqual([record.name for record in inventory.tools], ["ping"])
+
+    def test_a_tests_directory_below_root_is_still_pruned(self):
+        _, inventory = self.build({"tests/tool.py": self.TOOL_BODY})
+        self.assertEqual(inventory.tools, [])
+
     def test_an_explicitly_named_test_file_is_read(self):
         """Pointing at a file is an explicit request, not a directory sweep."""
         body = (

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -303,6 +303,29 @@ class ToolProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(records, [])
 
+    def test_imported_module_qualified_decorator_is_confirmed(self):
+        record = only(
+            "import agent_framework\n"
+            "@agent_framework.tool(approval_mode='always_require')\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "parsed")
+        self.assertEqual(record.notes, [])
+
+    def test_module_qualified_decorator_without_the_import_is_best_effort(self):
+        """Naming the framework is not the same as importing it."""
+        record = only(
+            "@agent_framework.tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "best-effort")
+        self.assertEqual(len(record.notes), 1)
+        self.assertIn("could not be traced", record.notes[0])
+
     def test_untraceable_tools_count_as_best_effort(self):
         inventory = inventory_tools.Inventory(root=".", tools=[], notes=[])
         inventory.tools.extend(

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -1,0 +1,665 @@
+"""Regression tests for scripts/inventory_tools.py.
+
+Run from the skill root (the directory containing SKILL.md):
+
+    python scripts/tests/test_inventory_tools.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parents[1] / "inventory_tools.py"
+SUBMISSION_ROOT = SCRIPT_PATH.parents[1]
+SPEC = importlib.util.spec_from_file_location("inventory_tools", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+inventory_tools = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = inventory_tools
+SPEC.loader.exec_module(inventory_tools)
+
+
+def scan(source: str, filename: str = "memory.py"):
+    return inventory_tools.scan_python(source, filename)
+
+
+def only(source: str):
+    records, _ = scan(source)
+    assert len(records) == 1, f"expected exactly one tool, got {len(records)}"
+    return records[0]
+
+
+def categories(record) -> set[str]:
+    return {signal.category for signal in record.signals}
+
+
+class DecoratorDetectionTests(unittest.TestCase):
+    def test_bare_decorator(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(record.name, "ping")
+        self.assertEqual(record.language, "python")
+        self.assertEqual(record.detection, "parsed")
+
+    def test_called_decorator_without_arguments(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool()\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(record.name, "ping")
+        self.assertFalse(record.approval_mode_explicit)
+
+    def test_aliased_import(self):
+        record = only(
+            "from agent_framework import tool as af_tool\n"
+            "@af_tool(approval_mode='always_require')\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertTrue(record.gated)
+
+    def test_module_qualified_decorator(self):
+        record = only(
+            "import agent_framework\n"
+            "@agent_framework.tool\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(record.name, "ping")
+
+    def test_aliased_module_decorator(self):
+        record = only(
+            "import agent_framework as af\n"
+            "@af.tool(approval_mode='always_require')\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertTrue(record.gated)
+
+    def test_unrelated_decorator_is_ignored(self):
+        records, _ = scan(
+            "import functools\n"
+            "@functools.cache\n"
+            "def ping() -> str:\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(records, [])
+
+    def test_unrelated_module_attribute_is_ignored(self):
+        records, _ = scan(
+            "import fastapi\n"
+            "app = fastapi.FastAPI()\n"
+            "@app.get('/ping')\n"
+            "def ping() -> str:\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(records, [])
+
+    def test_async_tool_is_detected(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool(approval_mode='always_require')\n"
+            "async def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertTrue(record.gated)
+
+    def test_method_inside_class_is_detected(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "class Toolbox:\n"
+            "    @tool\n"
+            "    def ping(self) -> str:\n"
+            "        '''Return a heartbeat.'''\n"
+            "        return 'ok'\n"
+        )
+        self.assertEqual(record.name, "ping")
+
+    def test_stacked_decorators_yield_one_record(self):
+        records, _ = scan(
+            "import functools\n"
+            "from agent_framework import tool\n"
+            "@functools.wraps(print)\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        self.assertEqual(len(records), 1)
+
+    def test_multiple_tools_in_one_module(self):
+        records, _ = scan(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def one() -> str:\n"
+            "    '''First.'''\n"
+            "    return ''\n"
+            "@tool\n"
+            "def two() -> str:\n"
+            "    '''Second.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual([record.name for record in records], ["one", "two"])
+
+
+class ApprovalModeTests(unittest.TestCase):
+    def mode(self, decorator: str):
+        return only(
+            "from agent_framework import tool\n"
+            f"{decorator}\n"
+            "def ping() -> str:\n"
+            "    '''Return a heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+
+    def test_always_require_is_gated(self):
+        record = self.mode("@tool(approval_mode='always_require')")
+        self.assertEqual(record.approval_mode, "always_require")
+        self.assertTrue(record.approval_mode_explicit)
+        self.assertTrue(record.gated)
+
+    def test_never_require_is_not_gated(self):
+        record = self.mode("@tool(approval_mode='never_require')")
+        self.assertEqual(record.approval_mode, "never_require")
+        self.assertTrue(record.approval_mode_explicit)
+        self.assertFalse(record.gated)
+
+    def test_absent_mode_defaults_to_never_require(self):
+        record = self.mode("@tool")
+        self.assertEqual(record.approval_mode, "never_require")
+        self.assertFalse(record.approval_mode_explicit)
+        self.assertFalse(record.gated)
+
+    def test_conditional_is_gated_but_annotated(self):
+        record = self.mode("@tool(approval_mode='conditional')")
+        self.assertTrue(record.gated)
+        self.assertTrue(any("conditional" in note for note in record.notes))
+
+    def test_dynamic_mode_is_reported_as_unreadable(self):
+        record = self.mode("@tool(approval_mode=CHOSEN_MODE)")
+        self.assertEqual(record.approval_mode, inventory_tools.DYNAMIC_APPROVAL_MODE)
+        self.assertTrue(record.approval_mode_explicit)
+        self.assertFalse(record.gated)
+        self.assertTrue(any("statically" in note for note in record.notes))
+
+    def test_undocumented_mode_is_flagged(self):
+        record = self.mode("@tool(approval_mode='sometimes')")
+        self.assertTrue(any("documented modes" in note for note in record.notes))
+
+    def test_name_keyword_overrides_function_name(self):
+        record = self.mode("@tool(name='heartbeat')")
+        self.assertEqual(record.name, "heartbeat")
+        self.assertEqual(record.function, "ping")
+
+    def test_non_string_name_falls_back_to_function_name(self):
+        record = self.mode("@tool(name=NAME_CONSTANT)")
+        self.assertEqual(record.name, "ping")
+
+
+class WriteSignalTests(unittest.TestCase):
+    def test_body_call_to_write_verb(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(payload: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    return client.create_record(payload)\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_http_write_method(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(payload: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    return requests.put(URL, json=payload)\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_file_opened_for_writing(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(path: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    handle = open(path, 'w')\n"
+            "    return path\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_file_opened_for_reading_is_not_a_write(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def fetch(path: str) -> str:\n"
+            "    '''Read a stored value.'''\n"
+            "    handle = open(path, 'r')\n"
+            "    return path\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+
+    def test_data_modifying_sql_literal(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(row_id: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    return run('DELETE FROM invoices WHERE id = ?', row_id)\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_select_sql_literal_is_not_a_write(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def fetch(row_id: str) -> str:\n"
+            "    '''Read a row.'''\n"
+            "    return run('SELECT total FROM invoices WHERE id = ?', row_id)\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+
+    def test_pure_read_has_no_write_signal(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def fetch(row_id: str) -> str:\n"
+            "    '''Look up a stored value by identifier.'''\n"
+            "    return cache.get(row_id)\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+
+    def test_stdlib_close_call_is_not_a_write(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def fetch(path: str) -> str:\n"
+            "    '''Look up a stored value.'''\n"
+            "    handle = open(path)\n"
+            "    body = handle.read()\n"
+            "    handle.close()\n"
+            "    return body\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+
+    def test_noun_order_in_docstring_is_not_a_write(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def search_orders(query: str) -> str:\n"
+            "    '''Search order history and return matching orders.'''\n"
+            "    return index.query(query)\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+
+    def test_write_verb_in_tool_name(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def cancel_booking(booking_id: str) -> str:\n"
+            "    '''Stop a reservation.'''\n"
+            "    return backend.run(booking_id)\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+
+class ExternalSignalTests(unittest.TestCase):
+    def test_external_term_in_name(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def send_invoice(to: str) -> str:\n"
+            "    '''Deliver a document.'''\n"
+            "    return gateway.post(to)\n"
+        )
+        self.assertEqual(record.proposed_visibility, "external")
+
+    def test_external_term_in_docstring(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def dispatch(body: str) -> str:\n"
+            "    '''Publish the note to the customer portal.'''\n"
+            "    return gateway.post(body)\n"
+        )
+        self.assertEqual(record.proposed_visibility, "external")
+
+    def test_internal_tool_is_not_external(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def add_internal_note(body: str) -> str:\n"
+            "    '''Create a note colleagues can edit.'''\n"
+            "    return store.save(body)\n"
+        )
+        self.assertEqual(record.proposed_visibility, "internal-or-unknown")
+
+    def test_external_read_is_annotated(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def lookup_customer(customer_id: str) -> str:\n"
+            "    '''Look up a customer record.'''\n"
+            "    return store.get(customer_id)\n"
+        )
+        self.assertEqual(record.proposed_write, "read")
+        self.assertTrue(any("only reads" in note for note in record.notes))
+
+
+class BlastRadiusTests(unittest.TestCase):
+    def test_collection_annotation(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def notify(targets: list[str]) -> str:\n"
+            "    '''Send a note.'''\n"
+            "    return str(targets)\n"
+        )
+        self.assertEqual(record.proposed_blast, "many")
+
+    def test_collection_parameter_name(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def notify(recipients) -> str:\n"
+            "    '''Send a note.'''\n"
+            "    return str(recipients)\n"
+        )
+        self.assertEqual(record.proposed_blast, "many")
+
+    def test_suffixed_parameter_name(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def notify(ticket_ids) -> str:\n"
+            "    '''Send a note.'''\n"
+            "    return str(ticket_ids)\n"
+        )
+        self.assertEqual(record.proposed_blast, "many")
+
+    def test_bulk_term_in_name(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def bulk_update(target: str) -> str:\n"
+            "    '''Change a value.'''\n"
+            "    return target\n"
+        )
+        self.assertEqual(record.proposed_blast, "many")
+
+    def test_write_inside_loop(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def process(rows) -> str:\n"
+            "    '''Handle rows.'''\n"
+            "    for row in rows:\n"
+            "        store.save(row)\n"
+            "    return 'done'\n"
+        )
+        self.assertEqual(record.proposed_blast, "many")
+        self.assertIn(
+            "writes inside a loop",
+            [signal.evidence for signal in record.signals],
+        )
+
+    def test_single_target_is_one(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def update_record(record_id: str) -> str:\n"
+            "    '''Change one stored value.'''\n"
+            "    return record_id\n"
+        )
+        self.assertEqual(record.proposed_blast, "one")
+
+
+class GoDetectionTests(unittest.TestCase):
+    def test_wrapped_tool_is_gated(self):
+        records, _ = inventory_tools.scan_go(
+            'approvedWeatherTool := tool.ApprovalRequiredFunc(weatherTool)\n', "main.go"
+        )
+        gated = {record.name: record.gated for record in records}
+        self.assertTrue(gated["weatherTool"])
+
+    def test_unwrapped_binding_is_ungated(self):
+        records, _ = inventory_tools.scan_go(
+            "weatherTool := tool.NewFunc(getWeather)\n"
+            "deleteTool := tool.NewFunc(deleteFile)\n"
+            "approved := tool.ApprovalRequiredFunc(weatherTool)\n",
+            "main.go",
+        )
+        gated = {record.name: record.gated for record in records}
+        self.assertTrue(gated["weatherTool"])
+        self.assertFalse(gated["deleteTool"])
+
+    def test_go_records_are_best_effort_and_annotated(self):
+        records, _ = inventory_tools.scan_go(
+            "weatherTool := tool.NewFunc(getWeather)\n", "main.go"
+        )
+        self.assertEqual(records[0].detection, "best-effort")
+        self.assertTrue(any("best-effort" in note for note in records[0].notes))
+
+    def test_unrelated_go_code_yields_nothing(self):
+        records, _ = inventory_tools.scan_go(
+            "client := http.NewClient()\nfmt.Println(client)\n", "main.go"
+        )
+        self.assertEqual(records, [])
+
+
+class FileHandlingTests(unittest.TestCase):
+    def build(self, files: dict[str, str], **kwargs):
+        directory = Path(tempfile.mkdtemp())
+        for name, body in files.items():
+            path = directory / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+        return directory, inventory_tools.build_inventory(
+            directory, kwargs.get("languages", {"python", "go"}), kwargs.get("include_tests", False)
+        )
+
+    def test_unparseable_python_is_noted_not_fatal(self):
+        _, inventory = self.build({"broken.py": "def oops(:\n"})
+        self.assertEqual(inventory.tools, [])
+        self.assertTrue(any("could not be parsed" in note for note in inventory.notes))
+
+    def test_non_utf8_file_is_noted_not_fatal(self):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "binary.py").write_bytes(b"\xff\xfe\x00bad bytes\n")
+        inventory = inventory_tools.build_inventory(directory, {"python"}, False)
+        self.assertTrue(any("could not be read" in note for note in inventory.notes))
+
+    def test_test_files_are_skipped_by_default(self):
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        _, inventory = self.build({"test_thing.py": body})
+        self.assertEqual(inventory.tools, [])
+
+    def test_test_files_are_included_on_request(self):
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        _, inventory = self.build({"test_thing.py": body}, include_tests=True)
+        self.assertEqual(len(inventory.tools), 1)
+
+    def test_vendor_directories_are_skipped(self):
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        _, inventory = self.build({"node_modules/pkg/thing.py": body})
+        self.assertEqual(inventory.tools, [])
+
+    def test_language_filter_excludes_go(self):
+        directory, _ = self.build({"main.go": "t := tool.NewFunc(f)\n"})
+        inventory = inventory_tools.build_inventory(directory, {"python"}, False)
+        self.assertEqual(inventory.tools, [])
+
+    def test_sources_are_posix_relative_paths(self):
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        _, inventory = self.build({"pkg/agent.py": body})
+        self.assertEqual(inventory.tools[0].source, "pkg/agent.py")
+
+
+class OutputAndExitCodeTests(unittest.TestCase):
+    def run_cli(self, argv: list[str]) -> tuple[int, str]:
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            code = inventory_tools.main(argv)
+        return code, buffer.getvalue()
+
+    def test_json_output_shape(self):
+        code, out = self.run_cli(["assets/samples", "--format", "json"])
+        payload = json.loads(out)
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["inventory"], inventory_tools.INVENTORY_NAME)
+        self.assertEqual(payload["version"], inventory_tools.INVENTORY_VERSION)
+        for key in ("root", "counts", "tools", "notes", "disclaimer"):
+            self.assertIn(key, payload)
+        first = payload["tools"][0]
+        for key in (
+            "name",
+            "language",
+            "detection",
+            "approval_mode",
+            "approval_mode_explicit",
+            "gated",
+            "proposed_write",
+            "proposed_visibility",
+            "proposed_blast",
+            "signals",
+            "notes",
+        ):
+            self.assertIn(key, first)
+
+    def test_table_output_carries_the_honesty_footer(self):
+        _, out = self.run_cli(["assets/samples"])
+        self.assertIn("Signals are advisory evidence, not verdicts.", out)
+
+    def test_clean_run_exits_zero(self):
+        code, _ = self.run_cli(["assets/samples"])
+        self.assertEqual(code, 0)
+
+    def test_fail_on_ungated_write_exits_one(self):
+        code, _ = self.run_cli(["assets/samples", "--fail-on", "ungated-write"])
+        self.assertEqual(code, 1)
+
+    def test_fail_on_ungated_write_external_exits_one(self):
+        code, _ = self.run_cli(["assets/samples", "--fail-on", "ungated-write-external"])
+        self.assertEqual(code, 1)
+
+    def test_missing_path_exits_two(self):
+        buffer = io.StringIO()
+        with contextlib.redirect_stderr(buffer):
+            code = inventory_tools.main(["does/not/exist"])
+        self.assertEqual(code, 2)
+        self.assertIn("Path not found", buffer.getvalue())
+
+    def test_gate_does_not_trigger_on_a_fully_gated_corpus(self):
+        directory = Path(tempfile.mkdtemp())
+        (directory / "agent.py").write_text(
+            "from agent_framework import tool\n"
+            "@tool(approval_mode='always_require')\n"
+            "def send_customer_email(to: str) -> str:\n"
+            "    '''Send an email to a customer.'''\n"
+            "    return to\n",
+            encoding="utf-8",
+        )
+        code, _ = self.run_cli([directory.as_posix(), "--fail-on", "ungated-write"])
+        self.assertEqual(code, 0)
+
+
+class ShippedFixtureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.inventory = inventory_tools.build_inventory(
+            SUBMISSION_ROOT / "assets" / "samples", {"python"}, False
+        )
+        cls.by_name = {record.name: record for record in cls.inventory.tools}
+
+    def test_fixture_contains_the_expected_tools(self):
+        self.assertEqual(
+            sorted(self.by_name),
+            [
+                "close_tickets",
+                "draft_internal_note",
+                "issue_refund",
+                "lookup_customer",
+                "purge_export_files",
+                "search_orders",
+                "send_customer_email",
+                "update_subscription",
+            ],
+        )
+
+    def test_fixture_read_tools_are_not_flagged_as_writes(self):
+        self.assertEqual(self.by_name["lookup_customer"].proposed_write, "read")
+        self.assertEqual(self.by_name["search_orders"].proposed_write, "read")
+
+    def test_fixture_exposes_an_ungated_irreversible_external_tool(self):
+        record = self.by_name["send_customer_email"]
+        self.assertFalse(record.gated)
+        self.assertEqual(record.proposed_write, "write")
+        self.assertEqual(record.proposed_visibility, "external")
+        self.assertTrue(record.needs_urgent_attention)
+
+    def test_fixture_bulk_tool_shows_blast_radius(self):
+        record = self.by_name["close_tickets"]
+        self.assertTrue(record.gated)
+        self.assertEqual(record.proposed_blast, "many")
+
+    def test_fixture_conditional_tool_is_annotated(self):
+        record = self.by_name["update_subscription"]
+        self.assertEqual(record.approval_mode, "conditional")
+        self.assertTrue(any("conditional" in note for note in record.notes))
+
+    def test_fixture_renamed_tool_uses_the_declared_name(self):
+        record = self.by_name["purge_export_files"]
+        self.assertEqual(record.function, "purge_exports")
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_fixture_counts(self):
+        counts = self.inventory.counts()
+        self.assertEqual(counts["tools"], 8)
+        self.assertEqual(counts["gated"], 3)
+        self.assertEqual(counts["ungated_write_external"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -7,14 +7,17 @@ Run from the skill root (the directory containing SKILL.md):
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import importlib.util
 import io
 import json
+import re
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPT_PATH = Path(__file__).parents[1] / "inventory_tools.py"
 SUBMISSION_ROOT = SCRIPT_PATH.parents[1]
@@ -857,6 +860,41 @@ class FileHandlingTests(unittest.TestCase):
         _, inventory = self.build({"node_modules/pkg/thing.py": body})
         self.assertEqual(inventory.tools, [])
 
+    def test_vendor_directories_are_pruned_not_just_filtered(self):
+        """Skipping must happen during traversal, not after walking everything."""
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        directory, _ = self.build(
+            {
+                "app.py": body,
+                "node_modules/pkg/lib/deep/vendored.py": body,
+                ".git/objects/pack/thing.py": body,
+            }
+        )
+        visited: list[str] = []
+        real_walk = inventory_tools.os.walk
+
+        def recording_walk(top, *args, **kwargs):
+            for entry in real_walk(top, *args, **kwargs):
+                visited.append(entry[0])
+                yield entry
+
+        with mock.patch.object(inventory_tools.os, "walk", recording_walk):
+            inventory = inventory_tools.build_inventory(directory, {"python"}, False)
+
+        self.assertEqual([record.name for record in inventory.tools], ["ping"])
+        self.assertTrue(visited, "the walker was never called")
+        for skipped in ("node_modules", ".git"):
+            self.assertFalse(
+                any(skipped in entry for entry in visited),
+                f"{skipped} was traversed rather than pruned",
+            )
+
     def test_language_filter_excludes_go(self):
         directory, _ = self.build({"main.go": "t := tool.NewFunc(f)\n"})
         inventory = inventory_tools.build_inventory(directory, {"python"}, False)
@@ -1138,6 +1176,50 @@ class ShippedFixtureTests(unittest.TestCase):
         self.assertEqual(counts["tools"], 8)
         self.assertEqual(counts["gated"], 3)
         self.assertEqual(counts["ungated_write_external"], 1)
+
+
+def count_test_methods(path: Path) -> int:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    )
+
+
+class DocumentedCountTests(unittest.TestCase):
+    """The README states exact test counts, so make them unable to drift.
+
+    A hardcoded number in prose is a claim about the code that nothing enforces.
+    It went stale twice during review, which is the whole argument for asserting
+    it rather than remembering to update it.
+    """
+
+    def readme(self) -> str:
+        return (SUBMISSION_ROOT / "README.md").read_text(encoding="utf-8")
+
+    def assert_documented(self, pattern: str, path: Path, label: str) -> None:
+        match = re.search(pattern, self.readme())
+        self.assertIsNotNone(
+            match, f"README no longer states the {label} test count as {pattern!r}."
+        )
+        self.assertEqual(
+            int(match.group(1)),
+            count_test_methods(path),
+            f"README claims a stale {label} test count. Update the number in "
+            "README.md to match this suite.",
+        )
+
+    def test_readme_states_this_suites_count(self):
+        self.assert_documented(r"(\d+) tests covering", Path(__file__), "inventory")
+
+    def test_readme_states_the_renderer_suites_count(self):
+        self.assert_documented(
+            r"A further (\d+) cover",
+            Path(__file__).with_name("test_approval_renderer.py"),
+            "renderer",
+        )
 
 
 if __name__ == "__main__":

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -160,6 +160,163 @@ class DecoratorDetectionTests(unittest.TestCase):
         self.assertEqual([record.name for record in records], ["one", "two"])
 
 
+class ToolProvenanceTests(unittest.TestCase):
+    """A '@tool' from another library is not an Agent Framework tool."""
+
+    def test_foreign_tool_import_is_not_inventoried(self):
+        records, notes = scan(
+            "from langchain_core.tools import tool\n"
+            "@tool\n"
+            "def send_email(to: str) -> str:\n"
+            "    '''Send an email.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(records, [])
+        self.assertEqual(len(notes), 1)
+        self.assertIn("langchain_core.tools", notes[0])
+        self.assertIn("not agent_framework", notes[0])
+
+    def test_aliased_foreign_tool_import_is_not_inventoried(self):
+        records, _ = scan(
+            "from langchain_core.tools import tool as lc_tool\n"
+            "@lc_tool(approval_mode='always_require')\n"
+            "def send_email(to: str) -> str:\n"
+            "    '''Send an email.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(records, [])
+
+    def test_locally_defined_tool_decorator_is_not_inventoried(self):
+        records, notes = scan(
+            "def tool(fn):\n"
+            "    return fn\n"
+            "@tool\n"
+            "def send_email(to: str) -> str:\n"
+            "    '''Send an email.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(records, [])
+        self.assertIn("a definition in this file", notes[0])
+
+    def test_skip_note_counts_agree_with_the_number_skipped(self):
+        _, notes = scan(
+            "from langchain_core.tools import tool\n"
+            "@tool\n"
+            "def one() -> str:\n"
+            "    '''First.'''\n"
+            "    return ''\n"
+            "@tool\n"
+            "def two() -> str:\n"
+            "    '''Second.'''\n"
+            "    return ''\n"
+        )
+        self.assertIn("2 decorated functions", notes[0])
+
+    def test_single_skip_note_is_singular(self):
+        _, notes = scan(
+            "from langchain_core.tools import tool\n"
+            "@tool\n"
+            "def one() -> str:\n"
+            "    '''First.'''\n"
+            "    return ''\n"
+        )
+        self.assertIn("1 decorated function", notes[0])
+        self.assertNotIn("1 decorated functions", notes[0])
+
+    def test_untraceable_tool_is_kept_but_marked_best_effort(self):
+        record = only(
+            "@tool\n"
+            "def send_email(to: str) -> str:\n"
+            "    '''Send an email.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.name, "send_email")
+        self.assertEqual(record.detection, "best-effort")
+        self.assertTrue(
+            any("could not be traced" in note for note in record.notes),
+            record.notes,
+        )
+
+    def test_traced_import_is_parsed_not_best_effort(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def send_email(to: str) -> str:\n"
+            "    '''Send an email.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "parsed")
+        self.assertEqual(record.notes, [])
+
+    def test_submodule_import_is_traced(self):
+        record = only(
+            "from agent_framework.tools import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "parsed")
+
+    def test_star_import_is_traced(self):
+        record = only(
+            "from agent_framework import *\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "parsed")
+
+    def test_foreign_star_import_does_not_trace(self):
+        record = only(
+            "from langchain_core.tools import *\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(record.detection, "best-effort")
+
+    def test_a_foreign_import_does_not_suppress_a_real_one(self):
+        records, _ = scan(
+            "from langchain_core.tools import tool as lc_tool\n"
+            "from agent_framework import tool\n"
+            "@lc_tool\n"
+            "def foreign() -> str:\n"
+            "    '''Not ours.'''\n"
+            "    return ''\n"
+            "@tool\n"
+            "def ours() -> str:\n"
+            "    '''Ours.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual([record.name for record in records], ["ours"])
+
+    def test_module_qualified_decorator_needs_the_module_name(self):
+        records, _ = scan(
+            "import langchain as agents\n"
+            "@agents.tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return ''\n"
+        )
+        self.assertEqual(records, [])
+
+    def test_untraceable_tools_count_as_best_effort(self):
+        inventory = inventory_tools.Inventory(root=".", tools=[], notes=[])
+        inventory.tools.extend(
+            only(
+                "@tool\n"
+                "def ping() -> str:\n"
+                "    '''Heartbeat.'''\n"
+                "    return ''\n"
+            )
+            for _ in range(1)
+        )
+        self.assertEqual(inventory.counts()["best_effort"], 1)
+
+
 class ApprovalModeTests(unittest.TestCase):
     def mode(self, decorator: str):
         return only(
@@ -486,6 +643,22 @@ class FileHandlingTests(unittest.TestCase):
         (directory / "binary.py").write_bytes(b"\xff\xfe\x00bad bytes\n")
         inventory = inventory_tools.build_inventory(directory, {"python"}, False)
         self.assertTrue(any("could not be read" in note for note in inventory.notes))
+
+    def test_utf8_bom_file_is_parsed_not_skipped(self):
+        """CPython accepts a BOM in source, so the inventory must too."""
+        directory = Path(tempfile.mkdtemp())
+        body = (
+            "from agent_framework import tool\n"
+            "@tool(approval_mode='always_require')\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        (directory / "bom.py").write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+        inventory = inventory_tools.build_inventory(directory, {"python"}, False)
+        self.assertEqual([record.name for record in inventory.tools], ["ping"])
+        self.assertTrue(inventory.tools[0].gated)
+        self.assertEqual(inventory.notes, [])
 
     def test_test_files_are_skipped_by_default(self):
         body = (

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -644,6 +644,51 @@ class GoDetectionTests(unittest.TestCase):
         )
         self.assertEqual(records, [])
 
+    def test_binding_line_points_at_the_declaration(self):
+        records, _ = inventory_tools.scan_go(
+            "package main\n"
+            "\n"
+            "weatherTool := tool.NewFunc(getWeather)\n"
+            "\n"
+            "approved := tool.ApprovalRequiredFunc(weatherTool)\n",
+            "main.go",
+        )
+        record = next(r for r in records if r.name == "weatherTool")
+        self.assertEqual(record.line, 3)
+
+    def test_binding_line_survives_a_blank_line_above_it(self):
+        """The pattern's leading '^\\s*' must not be counted as the line."""
+        records, _ = inventory_tools.scan_go(
+            "package main\n\n\n\nrefundTool := tool.NewFunc(issueRefund)\n",
+            "main.go",
+        )
+        self.assertEqual(records[0].line, 5)
+
+    def test_wrapped_only_tool_points_at_the_approval_call(self):
+        """A tool declared elsewhere must not be reported at line 0."""
+        records, _ = inventory_tools.scan_go(
+            "package main\n"
+            "\n"
+            "func main() {\n"
+            "\tagent.Run(tool.ApprovalRequiredFunc(weatherTool))\n"
+            "}\n",
+            "main.go",
+        )
+        record = next(r for r in records if r.name == "weatherTool")
+        self.assertEqual(record.line, 4)
+        self.assertTrue(
+            any("declaration was not found" in note for note in record.notes)
+        )
+
+    def test_no_go_record_is_ever_emitted_at_line_zero(self):
+        records, _ = inventory_tools.scan_go(
+            "weatherTool := tool.NewFunc(getWeather)\n"
+            "agent.Run(tool.ApprovalRequiredFunc(refundTool))\n",
+            "main.go",
+        )
+        self.assertEqual(len(records), 2)
+        self.assertTrue(all(record.line > 0 for record in records))
+
 
 class FileHandlingTests(unittest.TestCase):
     def build(self, files: dict[str, str], **kwargs):
@@ -704,6 +749,32 @@ class FileHandlingTests(unittest.TestCase):
         )
         _, inventory = self.build({"test_thing.py": body}, include_tests=True)
         self.assertEqual(len(inventory.tools), 1)
+
+    def test_an_explicitly_named_test_file_is_read(self):
+        """Pointing at a file is an explicit request, not a directory sweep."""
+        body = (
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def ping() -> str:\n"
+            "    '''Heartbeat.'''\n"
+            "    return 'ok'\n"
+        )
+        directory = Path(tempfile.mkdtemp())
+        (directory / "tests").mkdir()
+        path = directory / "tests" / "test_thing.py"
+        path.write_text(body, encoding="utf-8")
+        inventory = inventory_tools.build_inventory(path, {"python"}, False)
+        self.assertEqual([record.name for record in inventory.tools], ["ping"])
+
+    def test_an_explicit_file_the_inventory_cannot_read_is_noted(self):
+        directory = Path(tempfile.mkdtemp())
+        path = directory / "README.md"
+        path.write_text("not source\n", encoding="utf-8")
+        inventory = inventory_tools.build_inventory(path, {"python"}, False)
+        self.assertEqual(inventory.tools, [])
+        self.assertTrue(
+            any("does not read" in note for note in inventory.notes)
+        )
 
     def test_vendor_directories_are_skipped(self):
         body = (

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -605,6 +605,148 @@ class OutputAndExitCodeTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
 
+class SummaryAgreementTests(unittest.TestCase):
+    """The summary block must read correctly at a count of one and above one.
+
+    A count of exactly one is the case that regresses, because the plural form is
+    the one written first and the singular is the afterthought.
+    """
+
+    def render(self, files: dict[str, str]) -> str:
+        directory = Path(tempfile.mkdtemp())
+        for name, body in files.items():
+            (directory / name).write_text(body, encoding="utf-8")
+        inventory = inventory_tools.build_inventory(directory, {"python", "go"}, False)
+        return inventory_tools.render_table(inventory)
+
+    ONE_UNGATED_EXTERNAL_WRITE = (
+        "from agent_framework import tool\n"
+        "@tool\n"
+        "def send_customer_email(to: str, body: str) -> str:\n"
+        "    '''Send an email to a customer.'''\n"
+        "    return to\n"
+    )
+
+    TWO_UNGATED_EXTERNAL_WRITES = ONE_UNGATED_EXTERNAL_WRITE + (
+        "@tool\n"
+        "def publish_customer_notice(recipient: str) -> str:\n"
+        "    '''Publish a notice to a customer.'''\n"
+        "    return recipient\n"
+    )
+
+    # The clause that regressed: 'of which 1 also look externally visible.'
+
+    def test_singular_external_clause_uses_looks(self):
+        out = self.render({"agent.py": self.ONE_UNGATED_EXTERNAL_WRITE})
+        self.assertIn("of which 1 also looks externally visible.", out)
+        self.assertNotIn("also look externally visible", out)
+
+    def test_plural_external_clause_uses_look(self):
+        out = self.render({"agent.py": self.TWO_UNGATED_EXTERNAL_WRITES})
+        self.assertIn("of which 2 also look externally visible.", out)
+        self.assertNotIn("also looks externally", out)
+
+    def test_zero_external_clause_uses_look(self):
+        out = self.render(
+            {
+                "agent.py": (
+                    "from agent_framework import tool\n"
+                    "@tool\n"
+                    "def write_internal_log(entry: str) -> str:\n"
+                    "    '''Append an entry to the internal log.'''\n"
+                    "    return entry\n"
+                )
+            }
+        )
+        self.assertIn("of which 0 also look externally visible.", out)
+
+    # The sibling clauses in the same block.
+
+    def test_singular_ungated_tool_noun(self):
+        out = self.render({"agent.py": self.ONE_UNGATED_EXTERNAL_WRITE})
+        self.assertIn("Needs a ruling: 1 ungated tool with a write signal,", out)
+
+    def test_plural_ungated_tool_noun(self):
+        out = self.render({"agent.py": self.TWO_UNGATED_EXTERNAL_WRITES})
+        self.assertIn("Needs a ruling: 2 ungated tools with a write signal,", out)
+
+    def test_singular_tool_count_line(self):
+        out = self.render({"agent.py": self.ONE_UNGATED_EXTERNAL_WRITE})
+        self.assertIn("1 tool: 0 gated, 1 ungated.", out)
+        self.assertNotIn("1 tools:", out)
+
+    def test_plural_tool_count_line(self):
+        out = self.render({"agent.py": self.TWO_UNGATED_EXTERNAL_WRITES})
+        self.assertIn("2 tools: 0 gated, 2 ungated.", out)
+
+    def test_singular_signal_nouns(self):
+        out = self.render({"agent.py": self.ONE_UNGATED_EXTERNAL_WRITE})
+        self.assertIn("1 write signal,", out)
+        self.assertIn("1 external-visibility signal,", out)
+        self.assertIn("0 blast-radius signals.", out)
+
+    def test_plural_signal_nouns(self):
+        out = self.render({"agent.py": self.TWO_UNGATED_EXTERNAL_WRITES})
+        self.assertIn("2 write signals,", out)
+        self.assertIn("2 external-visibility signals,", out)
+
+    def test_singular_attention_header(self):
+        out = self.render({"agent.py": self.ONE_UNGATED_EXTERNAL_WRITE})
+        self.assertIn("Ungated tool with a write signal:", out)
+
+    def test_plural_attention_header(self):
+        out = self.render({"agent.py": self.TWO_UNGATED_EXTERNAL_WRITES})
+        self.assertIn("Ungated tools with a write signal:", out)
+
+    def test_singular_best_effort_line(self):
+        out = self.render(
+            {
+                "agent.go": (
+                    "package main\n"
+                    "func main() {\n"
+                    "\tagent.Run(tool.ApprovalRequiredFunc(weatherTool))\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("1 entry is a best-effort match and may be incomplete.", out)
+        self.assertNotIn("1 entries", out)
+
+    def test_plural_best_effort_line(self):
+        out = self.render(
+            {
+                "agent.go": (
+                    "package main\n"
+                    "func main() {\n"
+                    "\tagent.Run(tool.ApprovalRequiredFunc(weatherTool))\n"
+                    "\tagent.Run(tool.ApprovalRequiredFunc(refundTool))\n"
+                    "}\n"
+                )
+            }
+        )
+        self.assertIn("2 entries are best-effort matches and may be incomplete.", out)
+
+    def test_empty_corpus_summary_is_singularly_correct(self):
+        out = self.render({"notes.py": "x = 1\n"})
+        self.assertIn("(no tools found)", out)
+        self.assertIn("0 tools: 0 gated, 0 ungated.", out)
+        self.assertIn("Needs a ruling: 0 ungated tools with a write signal,", out)
+
+    # The helpers themselves.
+
+    def test_quantify_helper(self):
+        self.assertEqual(inventory_tools.quantify(0, "tool"), "0 tools")
+        self.assertEqual(inventory_tools.quantify(1, "tool"), "1 tool")
+        self.assertEqual(inventory_tools.quantify(2, "tool"), "2 tools")
+        self.assertEqual(inventory_tools.quantify(1, "entry", "entries"), "1 entry")
+        self.assertEqual(inventory_tools.quantify(3, "entry", "entries"), "3 entries")
+
+    def test_agree_helper(self):
+        self.assertEqual(inventory_tools.agree(1, "looks", "look"), "looks")
+        self.assertEqual(inventory_tools.agree(0, "looks", "look"), "look")
+        self.assertEqual(inventory_tools.agree(2, "looks", "look"), "look")
+
+
 class ShippedFixtureTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
+++ b/submissions/tool-approval-designer/scripts/tests/test_inventory_tools.py
@@ -437,6 +437,76 @@ class WriteSignalTests(unittest.TestCase):
         )
         self.assertEqual(record.proposed_write, "read")
 
+    def test_write_capable_mode_permutations_are_all_writes(self):
+        """Modes are order-independent flags, not a fixed vocabulary."""
+        for mode in (
+            "w", "a", "x", "wb", "ab", "xb", "wt", "at",
+            "wb+", "w+b", "w+", "a+", "ab+", "a+b",
+            "r+", "rb+", "r+b", "x+b", "xb+",
+        ):
+            with self.subTest(mode=mode):
+                record = only(
+                    "from agent_framework import tool\n"
+                    "@tool\n"
+                    "def act(path: str) -> str:\n"
+                    "    '''Do a thing.'''\n"
+                    f"    handle = open(path, {mode!r})\n"
+                    "    return path\n"
+                )
+                self.assertEqual(record.proposed_write, "write")
+
+    def test_read_only_mode_permutations_are_not_writes(self):
+        for mode in ("r", "rb", "rt", "br"):
+            with self.subTest(mode=mode):
+                record = only(
+                    "from agent_framework import tool\n"
+                    "@tool\n"
+                    "def fetch(path: str) -> str:\n"
+                    "    '''Read a stored value.'''\n"
+                    f"    handle = open(path, {mode!r})\n"
+                    "    return path\n"
+                )
+                self.assertEqual(record.proposed_write, "read")
+
+    def test_keyword_mode_argument_is_honoured(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(path: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    handle = open(path, mode='a+b')\n"
+            "    return path\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+
+    def test_runtime_mode_is_surfaced_not_downgraded(self):
+        """An unresolvable mode must not silently become read-only."""
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(path: str, mode: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    handle = open(path, mode)\n"
+            "    return path\n"
+        )
+        self.assertEqual(record.proposed_write, "write")
+        self.assertTrue(
+            any("computed at runtime" in signal.evidence for signal in record.signals)
+        )
+
+    def test_open_evidence_names_the_mode_it_found(self):
+        record = only(
+            "from agent_framework import tool\n"
+            "@tool\n"
+            "def act(path: str) -> str:\n"
+            "    '''Do a thing.'''\n"
+            "    handle = open(path, 'rb+')\n"
+            "    return path\n"
+        )
+        self.assertTrue(
+            any("'rb+'" in signal.evidence for signal in record.signals)
+        )
+
     def test_data_modifying_sql_literal(self):
         record = only(
             "from agent_framework import tool\n"


### PR DESCRIPTION
﻿## What this adds

`submissions/tool-approval-designer/` -- a skill that decides which of an agent's tools must pause for human approval, writes the approval request wording, checks the design will not be clicked through, and emits the code and the decision record.

It is a **producer, not a reviewer**. Every run ends in artifacts. A run that ends in "consider gating your payment tool" has failed.

### The gap it closes

Microsoft Agent Framework gives you the mechanism and stops at the interesting part. You mark a tool `@tool(approval_mode="always_require")`, the run pauses, and your code receives a raw function call name and an argument blob. What the human sees is entirely yours to build. The documented sample loop closes that seam with a constant:

```python
user_approval = True  # Replace with actual user input
```

The second-order failure is the one the skill is really aimed at: **a badly designed gate manufactures accountability.** If the prompt fires on everything, or says only `Approve tool call transfer_money?`, people click through it, and the log then records that a named employee approved a specific action they never read.

### The deterministic core

Four questions per tool: does it write; is the write reversible and by whom; is the result visible outside the organisation; what is the blast radius.

The rule: **irreversible and externally visible must always gate**; **reversible-by-anyone and internal-only must not**. Everything else is a judgement with a stated reason.

## Surface boundary

Called out explicitly in `SKILL.md`, `README.md`, the catalog description, the references, and the evals -- not only here. This is the lesson taken from @adrianatruji's review on #318 about being loose about which harness a capability runs in.

| Surface | Coverage |
|---|---|
| Agent Framework **Python** | Full: parsed, diffs, renderer, loop |
| Agent Framework **Go** | Documented contract; best-effort detection only |
| Agent Framework **.NET/C#** | Documented contract; not parsed |
| **Harness Agent** | Documented middleware behaviour |
| **Copilot Studio** | Design guidance only -- see below |
| **GitHub Copilot agent mode** | Cited as prior art only |

> **Copilot Studio per-tool approval is roadmap-announced, not documented.** Source is M365 roadmap item **570434**, GA target September 2026, status "In development", and no Microsoft Learn page for it was found. The skill gives **no configuration steps** anywhere and tells the user that part of any design needs re-checking when it ships.

Similarly, the approval fatigue threshold (more than two approvals in a normal conversation means redesign) is labelled **this skill's proposed heuristic, not a Microsoft standard**, everywhere it appears.

## Relationship to existing skills

`agent-red-team`'s attack surface mapping already asks, per tool, whether a human confirms before execution. That adjacency is real and is cited generously in both `SKILL.md` and `README.md`: red team establishes *that* a gate is missing, this skill decides *what the gate should be* and builds it. If a user arrives with red-team findings, the skill takes them as inventory input rather than re-deriving them.

`enterprise-agent-design-authority` works at architecture altitude; `agent-evaluation-designer` measures answer quality. Wording was checked against both for collision. All three neighbours are reviewers, which is why this one is written to read unmistakably as a producer.

## Contents

| File | |
|---|---|
| `SKILL.md` | Agent-facing SOP: boundary, four questions, nine steps, guardrails |
| `README.md` | Human-facing sidecar: boundary first, before-you-start, verified facts with sources, limits |
| `scripts/inventory_tools.py` | Bounded AST parser (stdlib only, Python 3.9+), `--fail-on` for CI |
| `scripts/tests/test_inventory_tools.py` | **64 regression tests** |
| `references/surfaces-and-contracts.md` | Verified API contracts and output contracts |
| `references/evals.md` | 20 scenarios, 12-dimension rubric |
| `assets/templates/` | Decision record, argument-aware renderer, approval loop |
| `assets/samples/sample_tools.py` | 8-tool fixture, doubles as the test corpus |

The parser emits **signals, never verdicts** -- every output carries a footer saying so. It cannot see true irreversibility and cannot read `conditional` logic, and the skill is written to treat its output as the first column of the matrix rather than the matrix.

## Verification

- `python scripts/tests/test_inventory_tools.py` -> 64 passed
- `python assets/templates/approval_renderer.py` -> demo renders clean
- `npm run check:submissions` -> all 98 submissions pass
- `npm run import:submissions` and `npm run build` -> succeed; generated bundle contains agent-facing files only, with `metadata.json` and `README.md` correctly stripped
- CI-generated artifacts (`src/content/**`, `public/bundles/**`) were reverted before committing; this PR touches `submissions/**` only

Product facts were re-verified live against Microsoft Learn and the M365 roadmap API rather than taken on trust. Sources are listed in `README.md` and `references/surfaces-and-contracts.md`.

Opened as a draft for a self-review pass before it goes to reviewers.
